### PR TITLE
Fix bug in merge #8 from wrong conversion of bool to string

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -132,7 +132,7 @@ func (api *Slack) PostMessage(channelId string, text string, params PostMessageP
 		values.Set("username", string(params.Username))
 	}
 	if params.AsUser != DEFAULT_MESSAGE_ASUSER {
-		values.Set("as_user", string(params.AsUser))
+		values.Set("as_user", "true")
 	}
 	if params.Parse != DEFAULT_MESSAGE_PARSE {
 		values.Set("parse", string(params.Parse))


### PR DESCRIPTION
Actually I messed up, converting a bool to string is not as simple as `string(bool)`. Terribly sorry about that :(

I ended up just copying the way you did it for `UnfurlLinks` and `UnfurlMedia` which is to just hardcode write the opposite bool value of the default.
