### PR TITLE
Add escapeMessage option for PostMessage and UpdateMessage

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -182,14 +182,11 @@ func (api *Slack) PostMessage(channelId string, text string, params PostMessageP
 }
 
 // UpdateMessage updates a message in a channel
-func (api *Slack) UpdateMessage(channelId, timestamp, text string, escape bool) (string, string, string, error) {
-	if escape {
-		text = escapeMessage(text)
-	}
+func (api *Slack) UpdateMessage(channelId, timestamp, text string) (string, string, string, error) {
 	values := url.Values{
 		"token":   {api.config.token},
 		"channel": {channelId},
-		"text":    {text},
+		"text":    {escapeMessage(text)},
 		"ts":      {timestamp},
 	}
 	response, err := chatRequest("chat.update", values, api.debug)


### PR DESCRIPTION
It is not very clear from [the formatting docs](https://api.slack.com/docs/formatting), but bots can add hyperlinks and special commands by sending strings such as `<http://www.foo.com|this is a link>` or `<!channel>`.

However by default, PostMessage and UpdateMessage escape these characters, which makes the bot send literally the characters `<` and `>`.

I added an option to make this escaping optional so that bots can send links and commands again. For PostMessage the escaping is on by default, as previous behavior. For UpdateMessage I had to add a parameter to the function.
