### PR TITLE
messages: ReplyTo is a string timestamp, not an int

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -33,7 +33,7 @@ type Msg struct {
 	Hidden           bool         `json:"bool,omitempty"`
 	DeletedTimestamp string       `json:"deleted_ts,omitempty"`
 	Attachments      []Attachment `json:"attachments,omitempty"`
-	ReplyTo          int          `json:"reply_to,omitempty"`
+	ReplyTo          string       `json:"reply_to,omitempty"`
 	Upload           bool         `json:"upload,omitempty"`
 }
 


### PR DESCRIPTION
This is different from the reply_to on websocket ACKs - reply_to in a
message refers to the globally-unique message timestamp of another
message represented as a string.  I don't see this explicit in the
docs, but I get unmarshal errors on a specific object:

{
    "reply_to": "1430355230.67",
    "type": "message",
    "channel": "D04JWB1TW",
    "user": "U03A807KY",
    "text": "...",
    "ts": "1430355230.000009"
}

FWIW this message came from a client using the IRC bridge on a "direct
message" channel - could be why other people don't seem to be
experiencing this.
