### PR TITLE
BaseChannel: channels, groups and IMs all share common properties

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -30,12 +30,21 @@ type ChannelPurpose struct {
 	LastSet JSONTime `json:"last_set"`
 }
 
+type BaseChannel struct {
+	Id                 string         `json:"id"`
+	Created            JSONTime       `json:"created"`
+	IsOpen             bool           `json:"is_open"`
+	LastRead           string         `json:"last_read,omitempty"`
+	Latest             Message        `json:"latest,omitempty"`
+	UnreadCount        int            `json:"unread_count,omitempty"`
+	UnreadCountDisplay int            `json:"unread_count_display,omitempty"`
+}
+
 // Channel contains information about the channel
 type Channel struct {
-	Id                 string         `json:"id"`
+	BaseChannel
 	Name               string         `json:"name"`
 	IsChannel          bool           `json:"is_channel"`
-	Created            JSONTime       `json:"created"`
 	Creator            string         `json:"creator"`
 	IsArchived         bool           `json:"is_archived"`
 	IsGeneral          bool           `json:"is_general"`
@@ -45,11 +54,7 @@ type Channel struct {
 	Topic              ChannelTopic   `json:"topic"`
 	Purpose            ChannelPurpose `json:"purpose"`
 	IsMember           bool           `json:"is_member"`
-	LastRead           string         `json:"last_read,omitempty"`
-	Latest             Message        `json:"latest,omitempty"`
-	UnreadCount        int            `json:"unread_count,omitempty"`
 	NumMembers         int            `json:"num_members,omitempty"`
-	UnreadCountDisplay int            `json:"unread_count_display,omitempty"`
 }
 
 func channelRequest(path string, values url.Values, debug bool) (*channelResponseFull, error) {

--- a/dm.go
+++ b/dm.go
@@ -22,13 +22,10 @@ type imResponseFull struct {
 
 // IM contains information related to the Direct Message channel
 type IM struct {
-	Id                 string   `json:"id"`
+	BaseChannel
 	IsIM               bool     `json:"is_im"`
 	UserId             string   `json:"user"`
-	Created            JSONTime `json:"created"`
 	IsUserDeleted      bool     `json:"is_user_deleted"`
-	UnreadCount        int      `json:"unread_count,omitempty"`
-	UnreadCountDisplay int      `json:"unread_count_display,omitempty"`
 }
 
 func imRequest(path string, values url.Values, debug bool) (*imResponseFull, error) {

--- a/groups.go
+++ b/groups.go
@@ -8,25 +8,16 @@ import (
 
 // Group contains all the information for a group
 type Group struct {
-	Id                 string         `json:"id"`
+	BaseChannel
 	Name               string         `json:"name"`
 	IsGroup            bool           `json:"is_group"`
-	Created            JSONTime       `json:"created"`
 	Creator            string         `json:"creator"`
 	IsArchived         bool           `json:"is_archived"`
 	IsGeneral          bool           `json:"is_general"`
-	IsOpen             bool           `json:"is_open,omitempty"`
 	Members            []string       `json:"members"`
 	Topic              ChannelTopic   `json:"topic"`
 	Purpose            ChannelPurpose `json:"purpose"`
-	LastRead           string         `json:"last_read,omitempty"`
-	Latest             Message        `json:"latest,omitempty"`
-	UnreadCount        int            `json:"unread_count,omitempty"`
 	NumMembers         int            `json:"num_members,omitempty"`
-	UnreadCountDisplay int            `json:"unread_count_display,omitempty"`
-
-	// XXX: does this exist for a group too?
-	IsMember bool `json:"is_member"`
 }
 
 type groupResponseFull struct {


### PR DESCRIPTION
In seeing I needed to add some fields to IM, it was clear that these 3
types of objects all share common fields.  `BaseChannel` is the part
of the objects common to all.  Open to better a better name - I went
with `BaseChannel` because the IDs of IMs and Groups are both used in
the 'channel' field of messages.
