### PR TITLE
Add Fields Present In JSON But Missing In User

### DIFF
--- a/users.go
+++ b/users.go
@@ -30,7 +30,7 @@ type User struct {
 	Deleted           bool        `json:"deleted"`
 	Color             string      `json:"color"`
 	RealName          string      `json:"real_name"`
-	TZ                string      `json:"tz"`
+	TZ                string      `json:"tz,omitempty"`
 	TZLabel           string      `json:"tz_label"`
 	TZOffset          int         `json:"tz_offset"`
 	Profile           UserProfile `json:"profile"`

--- a/users.go
+++ b/users.go
@@ -29,6 +29,10 @@ type User struct {
 	Name              string      `json:"name"`
 	Deleted           bool        `json:"deleted"`
 	Color             string      `json:"color"`
+	RealName          string      `json:"real_name"`
+	TZ                string      `json:"tz"`
+	TZLabel           string      `json:"tz_label"`
+	TZOffset          int         `json:"tz_offset"`
 	Profile           UserProfile `json:"profile"`
 	IsBot             bool        `json:"is_bot"`
 	IsAdmin           bool        `json:"is_admin"`


### PR DESCRIPTION
This adds fields to the `User` struct that are present in the JSON response for a user.
