### PR TITLE
Fix JSON Roundtrip Issues

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -40,7 +40,6 @@ type Channel struct {
 	IsArchived         bool           `json:"is_archived"`
 	IsGeneral          bool           `json:"is_general"`
 	IsGroup            bool           `json:"is_group"`
-	IsStarred          bool           `json:"is_starred"`
 	Members            []string       `json:"members"`
 	Topic              ChannelTopic   `json:"topic"`
 	Purpose            ChannelPurpose `json:"purpose"`

--- a/channels.go
+++ b/channels.go
@@ -46,7 +46,7 @@ type Channel struct {
 	Purpose            ChannelPurpose `json:"purpose"`
 	IsMember           bool           `json:"is_member"`
 	LastRead           string         `json:"last_read,omitempty"`
-	Latest             Message        `json:"latest,omitempty"`
+	Latest             *Message       `json:"latest,omitempty"`
 	UnreadCount        int            `json:"unread_count,omitempty"`
 	NumMembers         int            `json:"num_members,omitempty"`
 	UnreadCountDisplay int            `json:"unread_count_display,omitempty"`

--- a/channels.go
+++ b/channels.go
@@ -39,7 +39,6 @@ type Channel struct {
 	Creator            string         `json:"creator"`
 	IsArchived         bool           `json:"is_archived"`
 	IsGeneral          bool           `json:"is_general"`
-	IsGroup            bool           `json:"is_group"`
 	Members            []string       `json:"members"`
 	Topic              ChannelTopic   `json:"topic"`
 	Purpose            ChannelPurpose `json:"purpose"`

--- a/groups.go
+++ b/groups.go
@@ -20,7 +20,7 @@ type Group struct {
 	Topic              ChannelTopic   `json:"topic"`
 	Purpose            ChannelPurpose `json:"purpose"`
 	LastRead           string         `json:"last_read,omitempty"`
-	Latest             Message        `json:"latest,omitempty"`
+	Latest             *Message       `json:"latest,omitempty"`
 	UnreadCount        int            `json:"unread_count,omitempty"`
 	NumMembers         int            `json:"num_members,omitempty"`
 	UnreadCountDisplay int            `json:"unread_count_display,omitempty"`

--- a/groups.go
+++ b/groups.go
@@ -23,9 +23,6 @@ type Group struct {
 	UnreadCount        int            `json:"unread_count,omitempty"`
 	NumMembers         int            `json:"num_members,omitempty"`
 	UnreadCountDisplay int            `json:"unread_count_display,omitempty"`
-
-	// XXX: does this exist for a group too?
-	IsMember bool `json:"is_member"`
 }
 
 type groupResponseFull struct {

--- a/groups.go
+++ b/groups.go
@@ -14,7 +14,6 @@ type Group struct {
 	Created            JSONTime       `json:"created"`
 	Creator            string         `json:"creator"`
 	IsArchived         bool           `json:"is_archived"`
-	IsGeneral          bool           `json:"is_general"`
 	IsOpen             bool           `json:"is_open,omitempty"`
 	Members            []string       `json:"members"`
 	Topic              ChannelTopic   `json:"topic"`

--- a/info.go
+++ b/info.go
@@ -145,14 +145,14 @@ type Bot struct {
 // Info contains various details about Users, Channels, Bots and the authenticated user
 // It is returned by StartRTM
 type Info struct {
-	Url      string      `json:"url,omitempty"`
-	User     UserDetails `json:"self,omitempty"`
-	Team     Team        `json:"team,omitempty"`
-	Users    []User      `json:"users,omitempty"`
-	Channels []Channel   `json:"channels,omitempty"`
-	Groups   []Group     `json:"groups,omitempty"`
-	Bots     []Bot       `json:"bots,omitempty"`
-	IMs      []IM        `json:"ims,omitempty"`
+	Url      string       `json:"url,omitempty"`
+	User     *UserDetails `json:"self,omitempty"`
+	Team     *Team        `json:"team,omitempty"`
+	Users    []User       `json:"users,omitempty"`
+	Channels []Channel    `json:"channels,omitempty"`
+	Groups   []Group      `json:"groups,omitempty"`
+	Bots     []Bot        `json:"bots,omitempty"`
+	IMs      []IM         `json:"ims,omitempty"`
 }
 
 type infoResponseFull struct {

--- a/messages.go
+++ b/messages.go
@@ -10,7 +10,7 @@ type OutgoingMessage struct {
 // Message is an auxiliary type to allow us to have a message containing sub messages
 type Message struct {
 	Msg
-	SubMessage Msg `json:"message,omitempty"`
+	SubMessage *Msg `json:"message,omitempty"`
 }
 
 // Msg contains information about a slack message
@@ -23,7 +23,7 @@ type Msg struct {
 	Timestamp string `json:"ts,omitempty"`
 	Text      string `json:"text,omitempty"`
 	Team      string `json:"team,omitempty"`
-	File      File   `json:"file,omitempty"`
+	File      *File  `json:"file,omitempty"`
 	// Type may come if it's part of a message list
 	// e.g.: channel.history
 	Type      string `json:"type,omitempty"`

--- a/websocket_channels.go
+++ b/websocket_channels.go
@@ -24,10 +24,10 @@ type ChannelInfoEvent struct {
 	// channel_deleted
 	// channel_archive
 	// channel_unarchive
-	Type      string         `json:"type"`
-	ChannelId string         `json:"channel"`
-	UserId    string         `json:"user,omitempty"`
-	Timestamp JSONTimeString `json:"ts,omitempty"`
+	Type      string          `json:"type"`
+	ChannelId string          `json:"channel"`
+	UserId    string          `json:"user,omitempty"`
+	Timestamp *JSONTimeString `json:"ts,omitempty"`
 }
 
 type ChannelRenameEvent struct {

--- a/websocket_teams.go
+++ b/websocket_teams.go
@@ -2,13 +2,13 @@ package slack
 
 type TeamJoinEvent struct {
 	Type string `json:"type"`
-	User User   `json:"user,omitempty"`
+	User *User  `json:"user,omitempty"`
 }
 
 type TeamRenameEvent struct {
-	Type           string         `json:"type"`
-	Name           string         `json:"name,omitempty"`
-	EventTimestamp JSONTimeString `json:"event_ts,omitempty"`
+	Type           string          `json:"type"`
+	Name           string          `json:"name,omitempty"`
+	EventTimestamp *JSONTimeString `json:"event_ts,omitempty"`
 }
 
 type TeamPrefChangeEvent struct {


### PR DESCRIPTION
This fixes a few issues preventing roundtrips (writing JSON back out to disk) from matching the original JSON coming back from `api.slack.com`.
- `omitempty` won't omit fields like `Channel`>`Latest` unless it's a pointer
- `is_starred` isn't present for `channels`
- `is_member` isn't present for `groups`
- `is_general` isn't present for `groups` (only `channels` can be general)
