### PR TITLE
Add admin InviteGuest support

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -1,0 +1,52 @@
+package slack
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+type adminResponse struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error"`
+}
+
+func adminRequest(method string, teamName string, values url.Values, debug bool) (*adminResponse, error) {
+	adminResponse := &adminResponse{}
+	err := parseAdminResponse(method, teamName, values, adminResponse, debug)
+	if err != nil {
+		return nil, err
+	}
+
+	if !adminResponse.OK {
+		return nil, errors.New(adminResponse.Error)
+	}
+
+	return adminResponse, nil
+}
+
+func (api *Slack) InviteGuest(
+	teamName string,
+	channelID string,
+	firstName string,
+	lastName string,
+	emailAddress string,
+) error {
+	values := url.Values{
+		"email":            {emailAddress},
+		"channels":         {channelID},
+		"first_name":       {firstName},
+		"last_name":        {lastName},
+		"ultra_restricted": {"1"},
+		"token":            {api.config.token},
+		"set_active":       {"true"},
+		"_attempts":        {"1"},
+	}
+
+	_, err := adminRequest("invite", teamName, values, api.debug)
+	if err != nil {
+		return fmt.Errorf("Failed to invite single-channel guest: %s", err)
+	}
+
+	return nil
+}

--- a/misc.go
+++ b/misc.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -12,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 func fileUploadReq(path, fpath string, values url.Values) (*http.Request, error) {
@@ -86,11 +88,20 @@ func parseResponseMultipart(path string, filepath string, values url.Values, int
 	return parseResponseBody(resp.Body, &intf, debug)
 }
 
-func parseResponse(path string, values url.Values, intf interface{}, debug bool) error {
-	resp, err := http.PostForm(SLACK_API+path, values)
+func postForm(endpoint string, values url.Values, intf interface{}, debug bool) error {
+	resp, err := http.PostForm(endpoint, values)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
 	return parseResponseBody(resp.Body, &intf, debug)
+}
+
+func parseResponse(path string, values url.Values, intf interface{}, debug bool) error {
+	return postForm(SLACK_API+path, values, intf, debug)
+}
+
+func parseAdminResponse(method string, teamName string, values url.Values, intf interface{}, debug bool) error {
+	endpoint := fmt.Sprintf(SLACK_WEB_API_FORMAT, teamName, method, time.Now().Unix())
+	return postForm(endpoint, values, intf, debug)
 }

--- a/slack.go
+++ b/slack.go
@@ -9,6 +9,7 @@ import (
   Added as a var so that we can change this for testing purposes
 */
 var SLACK_API string = "https://slack.com/api/"
+var SLACK_WEB_API_FORMAT string = "https://%s.slack.com/api/users.admin.%s?t=%s"
 
 type SlackResponse struct {
 	Ok    bool   `json:"ok"`


### PR DESCRIPTION
This uses the undocumented users.admin.invite method. This doesn't use
the regular api.slack.com endpoint, but instead uses teamname.slack.com
with the method and an epoch tacked on the end:

https://teamname.slack.com/api/users.admin.invite?t=1416723927

The idea for this came from @levelsio: https://levels.io/slack-typeform-auto-invite-sign-ups/
