### PR TITLE
add godoc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-Slack API in Go
+# Slack API in Go
+
+[![GoDoc](https://godoc.org/github.com/nlopes/slack?status.png)](https://godoc.org/github.com/nlopes/slack)
 
 ## Installing
 


### PR DESCRIPTION
This fix is not related to the function, but rather that there was a link to the godoc is I was allowed to modify the README.md Because we think convenient.
