### PR TITLE
WIP: Add Missing Fields For Message Subtypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 			return
 		}
 		for _, group := range groups {
-			fmt.Printf("Id: %s, Name: %s\n", group.Id, group.Name)
+			fmt.Printf("ID: %s, Name: %s\n", group.ID, group.Name)
 		}
 	}
 
@@ -48,7 +48,7 @@
 		    fmt.Printf("%s\n", err)
 		    return
 	    }
-	    fmt.Printf("Id: %s, Fullname: %s, Email: %s\n", user.Id, user.Profile.RealName, user.Profile.Email)
+	    fmt.Printf("ID: %s, Fullname: %s, Email: %s\n", user.ID, user.Profile.RealName, user.Profile.Email)
     }
 
 ## Why?

--- a/admin.go
+++ b/admin.go
@@ -96,6 +96,23 @@ func (api *Slack) InviteRestricted(
 	return nil
 }
 
+// SetRegular enables the specified user
+func (api *Slack) SetRegular(teamName string, user string) error {
+	values := url.Values{
+		"user":       {user},
+		"token":      {api.config.token},
+		"set_active": {"true"},
+		"_attempts":  {"1"},
+	}
+
+	_, err := adminRequest("setRegular", teamName, values, api.debug)
+	if err != nil {
+		return fmt.Errorf("Failed to change the user (%s) to a regular user: %s", user, err)
+	}
+
+	return nil
+}
+
 // SendSSOBindingEmail sends an SSO binding email to the specified user
 func (api *Slack) SendSSOBindingEmail(teamName string, user string) error {
 	values := url.Values{

--- a/admin.go
+++ b/admin.go
@@ -25,16 +25,17 @@ func adminRequest(method string, teamName string, values url.Values, debug bool)
 	return adminResponse, nil
 }
 
+// InviteGuest invites a user to Slack as a single-channel guest
 func (api *Slack) InviteGuest(
 	teamName string,
-	channelID string,
+	channel string,
 	firstName string,
 	lastName string,
 	emailAddress string,
 ) error {
 	values := url.Values{
 		"email":            {emailAddress},
-		"channels":         {channelID},
+		"channels":         {channel},
 		"first_name":       {firstName},
 		"last_name":        {lastName},
 		"ultra_restricted": {"1"},
@@ -51,16 +52,17 @@ func (api *Slack) InviteGuest(
 	return nil
 }
 
+// InviteRestricted invites a user to Slack as a restricted account
 func (api *Slack) InviteRestricted(
 	teamName string,
-	channelID string,
+	channel string,
 	firstName string,
 	lastName string,
 	emailAddress string,
 ) error {
 	values := url.Values{
 		"email":      {emailAddress},
-		"channels":   {channelID},
+		"channels":   {channel},
 		"first_name": {firstName},
 		"last_name":  {lastName},
 		"restricted": {"1"},

--- a/admin.go
+++ b/admin.go
@@ -25,6 +25,23 @@ func adminRequest(method string, teamName string, values url.Values, debug bool)
 	return adminResponse, nil
 }
 
+// DisableUser disabled a user account
+func (api *Slack) DisableUser(teamName string, user string) error {
+	values := url.Values{
+		"user":       {user},
+		"token":      {api.config.token},
+		"set_active": {"true"},
+		"_attempts":  {"1"},
+	}
+
+	_, err := adminRequest("setInactive", teamName, values, api.debug)
+	if err != nil {
+		return fmt.Errorf("Failed to disable user (%s): %s", user, err)
+	}
+
+	return nil
+}
+
 // InviteGuest invites a user to Slack as a single-channel guest
 func (api *Slack) InviteGuest(
 	teamName string,
@@ -74,6 +91,23 @@ func (api *Slack) InviteRestricted(
 	_, err := adminRequest("invite", teamName, values, api.debug)
 	if err != nil {
 		return fmt.Errorf("Failed to restricted account: %s", err)
+	}
+
+	return nil
+}
+
+// SendSSOBindingEmail sends an SSO binding email to the specified user
+func (api *Slack) SendSSOBindingEmail(teamName string, user string) error {
+	values := url.Values{
+		"user":       {user},
+		"token":      {api.config.token},
+		"set_active": {"true"},
+		"_attempts":  {"1"},
+	}
+
+	_, err := adminRequest("sendSSOBind", teamName, values, api.debug)
+	if err != nil {
+		return fmt.Errorf("Failed to send SSO binding email for user (%s): %s", user, err)
 	}
 
 	return nil

--- a/attachments.go
+++ b/attachments.go
@@ -1,0 +1,31 @@
+package slack
+
+// AttachmentField contains information for an attachment field
+// An Attachment can contain multiple of these
+type AttachmentField struct {
+	Title string `json:"title"`
+	Value string `json:"value"`
+	Short bool   `json:"short"`
+}
+
+// Attachment contains all the information for an attachment
+type Attachment struct {
+	Color    string `json:"color,omitempty"`
+	Fallback string `json:"fallback"`
+
+	AuthorName    string `json:"author_name,omitempty"`
+	AuthorSubname string `json:"author_subname,omitempty"`
+	AuthorLink    string `json:"author_link,omitempty"`
+	AuthorIcon    string `json:"author_icon,omitempty"`
+
+	Title     string `json:"title,omitempty"`
+	TitleLink string `json:"title_link,omitempty"`
+	Pretext   string `json:"pretext,omitempty"`
+	Text      string `json:"text"`
+
+	ImageURL string `json:"image_url,omitempty"`
+	ThumbURL string `json:"thumb_url,omitempty"`
+
+	Fields     []AttachmentField `json:"fields,omitempty"`
+	MarkdownIn []string          `json:"mrkdwn_in,omitempty"`
+}

--- a/channels.go
+++ b/channels.go
@@ -30,32 +30,32 @@ type ChannelPurpose struct {
 	LastSet JSONTime `json:"last_set"`
 }
 
-type BaseChannel struct {
-	Id                 string         `json:"id"`
-	Created            JSONTime       `json:"created"`
-	IsOpen             bool           `json:"is_open"`
-	LastRead           string         `json:"last_read,omitempty"`
-	Latest             Message        `json:"latest,omitempty"`
-	UnreadCount        int            `json:"unread_count,omitempty"`
-	UnreadCountDisplay int            `json:"unread_count_display,omitempty"`
+type baseChannel struct {
+	ID                 string   `json:"id"`
+	Created            JSONTime `json:"created"`
+	IsOpen             bool     `json:"is_open"`
+	LastRead           string   `json:"last_read,omitempty"`
+	Latest             Message  `json:"latest,omitempty"`
+	UnreadCount        int      `json:"unread_count,omitempty"`
+	UnreadCountDisplay int      `json:"unread_count_display,omitempty"`
 }
 
 // Channel contains information about the channel
 type Channel struct {
-	BaseChannel
-	Name               string         `json:"name"`
-	IsChannel          bool           `json:"is_channel"`
-	Creator            string         `json:"creator"`
-	IsArchived         bool           `json:"is_archived"`
-	IsGeneral          bool           `json:"is_general"`
-	Members            []string       `json:"members"`
-	Topic              ChannelTopic   `json:"topic"`
-	Purpose            ChannelPurpose `json:"purpose"`
-	IsMember           bool           `json:"is_member"`
-	LastRead           string         `json:"last_read,omitempty"`
-	Latest             *Message       `json:"latest,omitempty"`
-	UnreadCount        int            `json:"unread_count,omitempty"`
-	NumMembers         int            `json:"num_members,omitempty"`
+	baseChannel
+	Name        string         `json:"name"`
+	IsChannel   bool           `json:"is_channel"`
+	Creator     string         `json:"creator"`
+	IsArchived  bool           `json:"is_archived"`
+	IsGeneral   bool           `json:"is_general"`
+	Members     []string       `json:"members"`
+	Topic       ChannelTopic   `json:"topic"`
+	Purpose     ChannelPurpose `json:"purpose"`
+	IsMember    bool           `json:"is_member"`
+	LastRead    string         `json:"last_read,omitempty"`
+	Latest      *Message       `json:"latest,omitempty"`
+	UnreadCount int            `json:"unread_count,omitempty"`
+	NumMembers  int            `json:"num_members,omitempty"`
 }
 
 func channelRequest(path string, values url.Values, debug bool) (*channelResponseFull, error) {
@@ -71,10 +71,10 @@ func channelRequest(path string, values url.Values, debug bool) (*channelRespons
 }
 
 // ArchiveChannel archives the given channel
-func (api *Slack) ArchiveChannel(channelId string) error {
+func (api *Slack) ArchiveChannel(channel string) error {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {channelId},
+		"channel": {channel},
 	}
 	_, err := channelRequest("channels.archive", values, api.debug)
 	if err != nil {
@@ -84,10 +84,10 @@ func (api *Slack) ArchiveChannel(channelId string) error {
 }
 
 // UnarchiveChannel unarchives the given channel
-func (api *Slack) UnarchiveChannel(channelId string) error {
+func (api *Slack) UnarchiveChannel(channel string) error {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {channelId},
+		"channel": {channel},
 	}
 	_, err := channelRequest("channels.unarchive", values, api.debug)
 	if err != nil {
@@ -110,10 +110,10 @@ func (api *Slack) CreateChannel(channel string) (*Channel, error) {
 }
 
 // GetChannelHistory retrieves the channel history
-func (api *Slack) GetChannelHistory(channelId string, params HistoryParameters) (*History, error) {
+func (api *Slack) GetChannelHistory(channel string, params HistoryParameters) (*History, error) {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {channelId},
+		"channel": {channel},
 	}
 	if params.Latest != DEFAULT_HISTORY_LATEST {
 		values.Add("latest", params.Latest)
@@ -139,10 +139,10 @@ func (api *Slack) GetChannelHistory(channelId string, params HistoryParameters) 
 }
 
 // GetChannelInfo retrieves the given channel
-func (api *Slack) GetChannelInfo(channelId string) (*Channel, error) {
+func (api *Slack) GetChannelInfo(channel string) (*Channel, error) {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {channelId},
+		"channel": {channel},
 	}
 	response, err := channelRequest("channels.info", values, api.debug)
 	if err != nil {
@@ -152,11 +152,11 @@ func (api *Slack) GetChannelInfo(channelId string) (*Channel, error) {
 }
 
 // InviteUserToChannel invites a user to a given channel and returns a *Channel
-func (api *Slack) InviteUserToChannel(channelId, userId string) (*Channel, error) {
+func (api *Slack) InviteUserToChannel(channel, user string) (*Channel, error) {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {channelId},
-		"user":    {userId},
+		"channel": {channel},
+		"user":    {user},
 	}
 	response, err := channelRequest("channels.invite", values, api.debug)
 	if err != nil {
@@ -179,10 +179,10 @@ func (api *Slack) JoinChannel(channel string) (*Channel, error) {
 }
 
 // LeaveChannel makes the authenticated user leave the given channel
-func (api *Slack) LeaveChannel(channelId string) (bool, error) {
+func (api *Slack) LeaveChannel(channel string) (bool, error) {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {channelId},
+		"channel": {channel},
 	}
 	response, err := channelRequest("channels.leave", values, api.debug)
 	if err != nil {
@@ -195,11 +195,11 @@ func (api *Slack) LeaveChannel(channelId string) (bool, error) {
 }
 
 // KickUserFromChannel kicks a user from a given channel
-func (api *Slack) KickUserFromChannel(channelId, userId string) error {
+func (api *Slack) KickUserFromChannel(channel, user string) error {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {channelId},
-		"user":    {userId},
+		"channel": {channel},
+		"user":    {user},
 	}
 	_, err := channelRequest("channels.kick", values, api.debug)
 	if err != nil {
@@ -228,10 +228,10 @@ func (api *Slack) GetChannels(excludeArchived bool) ([]Channel, error) {
 // timer before making the call. In this way, any further updates needed during the timeout will not generate extra calls
 // (just one per channel). This is useful for when reading scroll-back history, or following a busy live channel. A
 // timeout of 5 seconds is a good starting point. Be sure to flush these calls on shutdown/logout.
-func (api *Slack) SetChannelReadMark(channelId, ts string) error {
+func (api *Slack) SetChannelReadMark(channel, ts string) error {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {channelId},
+		"channel": {channel},
 		"ts":      {ts},
 	}
 	_, err := channelRequest("channels.mark", values, api.debug)
@@ -242,10 +242,10 @@ func (api *Slack) SetChannelReadMark(channelId, ts string) error {
 }
 
 // RenameChannel renames a given channel
-func (api *Slack) RenameChannel(channelId, name string) (*Channel, error) {
+func (api *Slack) RenameChannel(channel, name string) (*Channel, error) {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {channelId},
+		"channel": {channel},
 		"name":    {name},
 	}
 	// XXX: the created entry in this call returns a string instead of a number
@@ -260,10 +260,10 @@ func (api *Slack) RenameChannel(channelId, name string) (*Channel, error) {
 
 // SetChannelPurpose sets the channel purpose and returns the purpose that was
 // successfully set
-func (api *Slack) SetChannelPurpose(channelId, purpose string) (string, error) {
+func (api *Slack) SetChannelPurpose(channel, purpose string) (string, error) {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {channelId},
+		"channel": {channel},
 		"purpose": {purpose},
 	}
 	response, err := channelRequest("channels.setPurpose", values, api.debug)
@@ -274,10 +274,10 @@ func (api *Slack) SetChannelPurpose(channelId, purpose string) (string, error) {
 }
 
 // SetChannelTopic sets the channel topic and returns the topic that was successfully set
-func (api *Slack) SetChannelTopic(channelId, topic string) (string, error) {
+func (api *Slack) SetChannelTopic(channel, topic string) (string, error) {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {channelId},
+		"channel": {channel},
 		"topic":   {topic},
 	}
 	response, err := channelRequest("channels.setTopic", values, api.debug)

--- a/chat.go
+++ b/chat.go
@@ -21,43 +21,10 @@ const (
 )
 
 type chatResponseFull struct {
-	ChannelId string `json:"channel"`
+	Channel   string `json:"channel"`
 	Timestamp string `json:"ts"`
 	Text      string `json:"text"`
 	SlackResponse
-}
-
-// AttachmentField contains information for an attachment field
-// An Attachment can contain multiple of these
-type AttachmentField struct {
-	Title string `json:"title"`
-	Value string `json:"value"`
-	Short bool   `json:"short"`
-}
-
-// Attachment contains all the information for an attachment
-type Attachment struct {
-	Fallback string `json:"fallback"`
-
-	Color string `json:"color,omitempty"`
-
-	Pretext string `json:"pretext,omitempty"`
-
-	AuthorName string `json:"author_name,omitempty"`
-	AuthorLink string `json:"author_link,omitempty"`
-	AuthorIcon string `json:"author_icon,omitempty"`
-
-	Title     string `json:"title,omitempty"`
-	TitleLink string `json:"title_link,omitempty"`
-
-	Text string `json:"text"`
-
-	ImageURL string `json:"image_url,omitempty"`
-	ThumbURL string `json:"thumb_url,omitempty"`
-
-	Fields []AttachmentField `json:"fields,omitempty"`
-
-	MarkdownIn []string `json:"mrkdwn_in,omitempty"`
 }
 
 // PostMessageParameters contains all the parameters necessary (including the optional ones) for a PostMessage() request
@@ -106,17 +73,17 @@ func chatRequest(path string, values url.Values, debug bool) (*chatResponseFull,
 }
 
 // DeleteMessage deletes a message in a channel
-func (api *Slack) DeleteMessage(channelId, messageTimestamp string) (string, string, error) {
+func (api *Slack) DeleteMessage(channel, messageTimestamp string) (string, string, error) {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {channelId},
+		"channel": {channel},
 		"ts":      {messageTimestamp},
 	}
 	response, err := chatRequest("chat.delete", values, api.debug)
 	if err != nil {
 		return "", "", err
 	}
-	return response.ChannelId, response.Timestamp, nil
+	return response.Channel, response.Timestamp, nil
 }
 
 func escapeMessage(message string) string {
@@ -131,13 +98,13 @@ func escapeMessage(message string) string {
 
 // PostMessage sends a message to a channel
 // Message is escaped by default according to https://api.slack.com/docs/formatting
-func (api *Slack) PostMessage(channelId string, text string, params PostMessageParameters) (channel string, timestamp string, err error) {
+func (api *Slack) PostMessage(channel string, text string, params PostMessageParameters) (string, string, error) {
 	if params.EscapeText {
 		text = escapeMessage(text)
 	}
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {channelId},
+		"channel": {channel},
 		"text":    {text},
 	}
 	if params.Username != DEFAULT_MESSAGE_USERNAME {
@@ -179,14 +146,14 @@ func (api *Slack) PostMessage(channelId string, text string, params PostMessageP
 	if err != nil {
 		return "", "", err
 	}
-	return response.ChannelId, response.Timestamp, nil
+	return response.Channel, response.Timestamp, nil
 }
 
 // UpdateMessage updates a message in a channel
-func (api *Slack) UpdateMessage(channelId, timestamp, text string) (string, string, string, error) {
+func (api *Slack) UpdateMessage(channel, timestamp, text string) (string, string, string, error) {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {channelId},
+		"channel": {channel},
 		"text":    {escapeMessage(text)},
 		"ts":      {timestamp},
 	}
@@ -194,5 +161,5 @@ func (api *Slack) UpdateMessage(channelId, timestamp, text string) (string, stri
 	if err != nil {
 		return "", "", "", err
 	}
-	return response.ChannelId, response.Timestamp, response.Text, nil
+	return response.Channel, response.Timestamp, response.Text, nil
 }

--- a/comment.go
+++ b/comment.go
@@ -1,0 +1,10 @@
+package slack
+
+// Comment contains all the information relative to a comment
+type Comment struct {
+	ID        string   `json:"id,omitempty"`
+	Created   JSONTime `json:"created,omitempty"`
+	Timestamp JSONTime `json:"timestamp,omitempty"`
+	User      string   `json:"user,omitempty"`
+	Comment   string   `json:"comment,omitempty"`
+}

--- a/dm.go
+++ b/dm.go
@@ -7,7 +7,7 @@ import (
 )
 
 type imChannel struct {
-	Id string `json:"id"`
+	ID string `json:"id"`
 }
 
 type imResponseFull struct {
@@ -22,10 +22,10 @@ type imResponseFull struct {
 
 // IM contains information related to the Direct Message channel
 type IM struct {
-	BaseChannel
-	IsIM               bool     `json:"is_im"`
-	UserId             string   `json:"user"`
-	IsUserDeleted      bool     `json:"is_user_deleted"`
+	baseChannel
+	IsIM          bool   `json:"is_im"`
+	User          string `json:"user"`
+	IsUserDeleted bool   `json:"is_user_deleted"`
 }
 
 func imRequest(path string, values url.Values, debug bool) (*imResponseFull, error) {
@@ -41,10 +41,10 @@ func imRequest(path string, values url.Values, debug bool) (*imResponseFull, err
 }
 
 // CloseIMChannel closes the direct message channel
-func (api *Slack) CloseIMChannel(channelId string) (bool, bool, error) {
+func (api *Slack) CloseIMChannel(channel string) (bool, bool, error) {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {channelId},
+		"channel": {channel},
 	}
 	response, err := imRequest("im.close", values, api.debug)
 	if err != nil {
@@ -54,24 +54,24 @@ func (api *Slack) CloseIMChannel(channelId string) (bool, bool, error) {
 }
 
 // OpenIMChannel opens a direct message channel to the user provided as argument
-// Returns some status and the channelId
-func (api *Slack) OpenIMChannel(userId string) (bool, bool, string, error) {
+// Returns some status and the channel
+func (api *Slack) OpenIMChannel(user string) (bool, bool, string, error) {
 	values := url.Values{
 		"token": {api.config.token},
-		"user":  {userId},
+		"user":  {user},
 	}
 	response, err := imRequest("im.open", values, api.debug)
 	if err != nil {
 		return false, false, "", err
 	}
-	return response.NoOp, response.AlreadyOpen, response.Channel.Id, nil
+	return response.NoOp, response.AlreadyOpen, response.Channel.ID, nil
 }
 
 // MarkIMChannel sets the read mark of a direct message channel to a specific point
-func (api *Slack) MarkIMChannel(channelId, ts string) (err error) {
+func (api *Slack) MarkIMChannel(channel, ts string) (err error) {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {channelId},
+		"channel": {channel},
 		"ts":      {ts},
 	}
 	_, err = imRequest("im.mark", values, api.debug)
@@ -82,10 +82,10 @@ func (api *Slack) MarkIMChannel(channelId, ts string) (err error) {
 }
 
 // GetIMHistory retrieves the direct message channel history
-func (api *Slack) GetIMHistory(channelId string, params HistoryParameters) (*History, error) {
+func (api *Slack) GetIMHistory(channel string, params HistoryParameters) (*History, error) {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {channelId},
+		"channel": {channel},
 	}
 	if params.Latest != DEFAULT_HISTORY_LATEST {
 		values.Add("latest", params.Latest)

--- a/examples/files/files.go
+++ b/examples/files/files.go
@@ -19,7 +19,7 @@ func main() {
 		fmt.Printf("%s\n", err)
 		return
 	}
-	fmt.Printf("Name: %s, Url: %s\n", file.Name, file.URL)
+	fmt.Printf("Name: %s, URL: %s\n", file.Name, file.URL)
 
 	err = api.DeleteFile(file.ID)
 	if err != nil {

--- a/examples/files/files.go
+++ b/examples/files/files.go
@@ -21,7 +21,7 @@ func main() {
 	}
 	fmt.Printf("Name: %s, Url: %s\n", file.Name, file.URL)
 
-	err = api.DeleteFile(file.Id)
+	err = api.DeleteFile(file.ID)
 	if err != nil {
 		fmt.Printf("%s\n", err)
 		return

--- a/examples/groups/groups.go
+++ b/examples/groups/groups.go
@@ -17,6 +17,6 @@ func main() {
 		return
 	}
 	for _, group := range groups {
-		fmt.Printf("Id: %s, Name: %s\n", group.Id, group.Name)
+		fmt.Printf("ID: %s, Name: %s\n", group.ID, group.Name)
 	}
 }

--- a/examples/messages/messages.go
+++ b/examples/messages/messages.go
@@ -23,10 +23,10 @@ func main() {
 		*/
 	}
 	params.Attachments = []slack.Attachment{attachment}
-	channelId, timestamp, err := api.PostMessage("CHANNEL_ID", "Some text", params)
+	channelID, timestamp, err := api.PostMessage("CHANNEL_ID", "Some text", params)
 	if err != nil {
 		fmt.Printf("%s\n", err)
 		return
 	}
-	fmt.Printf("Message successfully sent to channel %s at %s", channelId, timestamp)
+	fmt.Printf("Message successfully sent to channel %s at %s", channelID, timestamp)
 }

--- a/examples/reactions/reactions.go
+++ b/examples/reactions/reactions.go
@@ -39,11 +39,11 @@ func main() {
 
 	// Post as the authenticated user.
 	postAsUserName = authTest.User
-	postAsUserID = authTest.UserId
+	postAsUserID = authTest.UserID
 
 	// Posting to DM with self causes a conversation with slackbot.
 	postToUserName = authTest.User
-	postToUserID = authTest.UserId
+	postToUserID = authTest.UserID
 
 	// Find the channel.
 	_, _, chanID, err := api.OpenIMChannel(postToUserID)

--- a/examples/users/users.go
+++ b/examples/users/users.go
@@ -13,5 +13,5 @@ func main() {
 		fmt.Printf("%s\n", err)
 		return
 	}
-	fmt.Printf("Id: %s, Fullname: %s, Email: %s\n", user.Id, user.Profile.RealName, user.Profile.Email)
+	fmt.Printf("ID: %s, Fullname: %s, Email: %s\n", user.ID, user.Profile.RealName, user.Profile.Email)
 }

--- a/examples/websocket/websocket.go
+++ b/examples/websocket/websocket.go
@@ -19,7 +19,7 @@ func main() {
 	}
 	go wsAPI.HandleIncomingEvents(chReceiver)
 	go wsAPI.Keepalive(20 * time.Second)
-	go func(wsAPI *slack.SlackWS, chSender chan slack.OutgoingMessage) {
+	go func(wsAPI *slack.WS, chSender chan slack.OutgoingMessage) {
 		for {
 			select {
 			case msg := <-chSender:
@@ -43,8 +43,8 @@ func main() {
 			case slack.LatencyReport:
 				a := msg.Data.(slack.LatencyReport)
 				fmt.Printf("Current latency: %v\n", a.Value)
-			case *slack.SlackWSError:
-				error := msg.Data.(*slack.SlackWSError)
+			case *slack.WSError:
+				error := msg.Data.(*slack.WSError)
 				fmt.Printf("Error: %d - %s\n", error.Code, error.Msg)
 			default:
 				fmt.Printf("Unexpected: %v\n", msg.Data)

--- a/files.go
+++ b/files.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	// Add here the defaults in the siten
-	DEFAULT_FILES_USERID  = ""
+	DEFAULT_FILES_USER    = ""
 	DEFAULT_FILES_TS_FROM = 0
 	DEFAULT_FILES_TS_TO   = -1
 	DEFAULT_FILES_TYPES   = "all"
@@ -17,18 +17,9 @@ const (
 	DEFAULT_FILES_PAGE    = 1
 )
 
-// Comment contains all the information relative to a comment
-type Comment struct {
-	Id        string   `json:"id"`
-	Timestamp JSONTime `json:"timestamp"`
-	UserId    string   `json:"user"`
-	Comment   string   `json:"comment"`
-	Created   JSONTime `json:"created,omitempty"`
-}
-
 // File contains all the information for a file
 type File struct {
-	Id        string   `json:"id"`
+	ID        string   `json:"id"`
 	Created   JSONTime `json:"created"`
 	Timestamp JSONTime `json:"timestamp"`
 
@@ -37,7 +28,7 @@ type File struct {
 	Mimetype   string `json:"mimetype"`
 	Filetype   string `json:"filetype"`
 	PrettyType string `json:"pretty_type"`
-	UserId     string `json:"user"`
+	User       string `json:"user"`
 
 	Mode         string `json:"mode"`
 	Editable     bool   `json:"editable"`
@@ -87,7 +78,7 @@ type FileUploadParameters struct {
 
 // GetFilesParameters contains all the parameters necessary (including the optional ones) for a GetFiles() request
 type GetFilesParameters struct {
-	UserId        string
+	User          string
 	TimestampFrom JSONTime
 	TimestampTo   JSONTime
 	Types         string
@@ -107,7 +98,7 @@ type fileResponseFull struct {
 // NewGetFilesParameters provides an instance of GetFilesParameters with all the sane default values set
 func NewGetFilesParameters() GetFilesParameters {
 	return GetFilesParameters{
-		UserId:        DEFAULT_FILES_USERID,
+		User:          DEFAULT_FILES_USER,
 		TimestampFrom: DEFAULT_FILES_TS_FROM,
 		TimestampTo:   DEFAULT_FILES_TS_TO,
 		Types:         DEFAULT_FILES_TYPES,
@@ -129,10 +120,10 @@ func fileRequest(path string, values url.Values, debug bool) (*fileResponseFull,
 }
 
 // GetFileInfo retrieves a file and related comments
-func (api *Slack) GetFileInfo(fileId string, count, page int) (*File, []Comment, *Paging, error) {
+func (api *Slack) GetFileInfo(fileID string, count, page int) (*File, []Comment, *Paging, error) {
 	values := url.Values{
 		"token": {api.config.token},
-		"file":  {fileId},
+		"file":  {fileID},
 		"count": {strconv.Itoa(count)},
 		"page":  {strconv.Itoa(page)},
 	}
@@ -148,8 +139,8 @@ func (api *Slack) GetFiles(params GetFilesParameters) ([]File, *Paging, error) {
 	values := url.Values{
 		"token": {api.config.token},
 	}
-	if params.UserId != DEFAULT_FILES_USERID {
-		values.Add("user", params.UserId)
+	if params.User != DEFAULT_FILES_USER {
+		values.Add("user", params.User)
 	}
 	// XXX: this is broken. fix it with a proper unix timestamp
 	if params.TimestampFrom != DEFAULT_FILES_TS_FROM {
@@ -217,10 +208,10 @@ func (api *Slack) UploadFile(params FileUploadParameters) (file *File, err error
 }
 
 // DeleteFile deletes a file
-func (api *Slack) DeleteFile(fileId string) error {
+func (api *Slack) DeleteFile(fileID string) error {
 	values := url.Values{
 		"token": {api.config.token},
-		"file":  {fileId},
+		"file":  {fileID},
 	}
 	_, err := fileRequest("files.delete", values, api.debug)
 	if err != nil {

--- a/groups.go
+++ b/groups.go
@@ -8,7 +8,7 @@ import (
 
 // Group contains all the information for a group
 type Group struct {
-	BaseChannel
+	baseChannel
 	Name               string         `json:"name"`
 	IsGroup            bool           `json:"is_group"`
 	Creator            string         `json:"creator"`
@@ -52,10 +52,10 @@ func groupRequest(path string, values url.Values, debug bool) (*groupResponseFul
 }
 
 // ArchiveGroup archives a private group
-func (api *Slack) ArchiveGroup(groupId string) error {
+func (api *Slack) ArchiveGroup(group string) error {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {groupId},
+		"channel": {group},
 	}
 	_, err := groupRequest("groups.archive", values, api.debug)
 	if err != nil {
@@ -65,10 +65,10 @@ func (api *Slack) ArchiveGroup(groupId string) error {
 }
 
 // UnarchiveGroup unarchives a private group
-func (api *Slack) UnarchiveGroup(groupId string) error {
+func (api *Slack) UnarchiveGroup(group string) error {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {groupId},
+		"channel": {group},
 	}
 	_, err := groupRequest("groups.unarchive", values, api.debug)
 	if err != nil {
@@ -96,10 +96,10 @@ func (api *Slack) CreateGroup(group string) (*Group, error) {
 //   2. Archives the existing group.
 //   3. Creates a new group with the name of the existing group.
 //   4. Adds all members of the existing group to the new group.
-func (api *Slack) CreateChildGroup(groupId string) (*Group, error) {
+func (api *Slack) CreateChildGroup(group string) (*Group, error) {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {groupId},
+		"channel": {group},
 	}
 	response, err := groupRequest("groups.createChild", values, api.debug)
 	if err != nil {
@@ -109,10 +109,10 @@ func (api *Slack) CreateChildGroup(groupId string) (*Group, error) {
 }
 
 // CloseGroup closes a private group
-func (api *Slack) CloseGroup(groupId string) (bool, bool, error) {
+func (api *Slack) CloseGroup(group string) (bool, bool, error) {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {groupId},
+		"channel": {group},
 	}
 	response, err := imRequest("groups.close", values, api.debug)
 	if err != nil {
@@ -122,10 +122,10 @@ func (api *Slack) CloseGroup(groupId string) (bool, bool, error) {
 }
 
 // GetGroupHistory retrieves message history for a give group
-func (api *Slack) GetGroupHistory(groupId string, params HistoryParameters) (*History, error) {
+func (api *Slack) GetGroupHistory(group string, params HistoryParameters) (*History, error) {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {groupId},
+		"channel": {group},
 	}
 	if params.Latest != DEFAULT_HISTORY_LATEST {
 		values.Add("latest", params.Latest)
@@ -151,11 +151,11 @@ func (api *Slack) GetGroupHistory(groupId string, params HistoryParameters) (*Hi
 }
 
 // InviteUserToGroup invites a user to a group
-func (api *Slack) InviteUserToGroup(groupId, userId string) (*Group, bool, error) {
+func (api *Slack) InviteUserToGroup(group, user string) (*Group, bool, error) {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {groupId},
-		"user":    {userId},
+		"channel": {group},
+		"user":    {user},
 	}
 	response, err := groupRequest("groups.invite", values, api.debug)
 	if err != nil {
@@ -165,10 +165,10 @@ func (api *Slack) InviteUserToGroup(groupId, userId string) (*Group, bool, error
 }
 
 // LeaveGroup makes authenticated user leave the group
-func (api *Slack) LeaveGroup(groupId string) error {
+func (api *Slack) LeaveGroup(group string) error {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {groupId},
+		"channel": {group},
 	}
 	_, err := groupRequest("groups.leave", values, api.debug)
 	if err != nil {
@@ -178,11 +178,11 @@ func (api *Slack) LeaveGroup(groupId string) error {
 }
 
 // KickUserFromGroup kicks a user from a group
-func (api *Slack) KickUserFromGroup(groupId, userId string) error {
+func (api *Slack) KickUserFromGroup(group, user string) error {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {groupId},
-		"user":    {userId},
+		"channel": {group},
+		"user":    {user},
 	}
 	_, err := groupRequest("groups.kick", values, api.debug)
 	if err != nil {
@@ -207,10 +207,10 @@ func (api *Slack) GetGroups(excludeArchived bool) ([]Group, error) {
 }
 
 // GetGroupInfo retrieves the given group
-func (api *Slack) GetGroupInfo(groupId string) (*Group, error) {
+func (api *Slack) GetGroupInfo(group string) (*Group, error) {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {groupId},
+		"channel": {group},
 	}
 	response, err := groupRequest("groups.info", values, api.debug)
 	if err != nil {
@@ -224,10 +224,10 @@ func (api *Slack) GetGroupInfo(groupId string) (*Group, error) {
 // timer before making the call. In this way, any further updates needed during the timeout will not generate extra
 // calls (just one per channel). This is useful for when reading scroll-back history, or following a busy live
 // channel. A timeout of 5 seconds is a good starting point. Be sure to flush these calls on shutdown/logout.
-func (api *Slack) SetGroupReadMark(groupId, ts string) error {
+func (api *Slack) SetGroupReadMark(group, ts string) error {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {groupId},
+		"channel": {group},
 		"ts":      {ts},
 	}
 	_, err := groupRequest("groups.mark", values, api.debug)
@@ -238,10 +238,10 @@ func (api *Slack) SetGroupReadMark(groupId, ts string) error {
 }
 
 // OpenGroup opens a private group
-func (api *Slack) OpenGroup(groupId string) (bool, bool, error) {
+func (api *Slack) OpenGroup(group string) (bool, bool, error) {
 	values := url.Values{
 		"token": {api.config.token},
-		"user":  {groupId},
+		"user":  {group},
 	}
 	response, err := groupRequest("groups.open", values, api.debug)
 	if err != nil {
@@ -253,10 +253,10 @@ func (api *Slack) OpenGroup(groupId string) (bool, bool, error) {
 // RenameGroup renames a group
 // XXX: They return a channel, not a group. What is this crap? :(
 // Inconsistent api it seems.
-func (api *Slack) RenameGroup(groupId, name string) (*Channel, error) {
+func (api *Slack) RenameGroup(group, name string) (*Channel, error) {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {groupId},
+		"channel": {group},
 		"name":    {name},
 	}
 	// XXX: the created entry in this call returns a string instead of a number
@@ -270,10 +270,10 @@ func (api *Slack) RenameGroup(groupId, name string) (*Channel, error) {
 }
 
 // SetGroupPurpose sets the group purpose
-func (api *Slack) SetGroupPurpose(groupId, purpose string) (string, error) {
+func (api *Slack) SetGroupPurpose(group, purpose string) (string, error) {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {groupId},
+		"channel": {group},
 		"purpose": {purpose},
 	}
 	response, err := groupRequest("groups.setPurpose", values, api.debug)
@@ -284,10 +284,10 @@ func (api *Slack) SetGroupPurpose(groupId, purpose string) (string, error) {
 }
 
 // SetGroupTopic sets the group topic
-func (api *Slack) SetGroupTopic(groupId, topic string) (string, error) {
+func (api *Slack) SetGroupTopic(group, topic string) (string, error) {
 	values := url.Values{
 		"token":   {api.config.token},
-		"channel": {groupId},
+		"channel": {group},
 		"topic":   {topic},
 	}
 	response, err := groupRequest("groups.setTopic", values, api.debug)

--- a/info.go
+++ b/info.go
@@ -106,7 +106,7 @@ type UserPrefs struct {
 
 // UserDetails contains user details coming in the initial response from StartRTM
 type UserDetails struct {
-	Id             string    `json:"id"`
+	ID             string    `json:"id"`
 	Name           string    `json:"name"`
 	Created        JSONTime  `json:"created"`
 	ManualPresence string    `json:"manual_presence"`
@@ -124,7 +124,7 @@ func (t JSONTime) String() string {
 
 // Team contains details about a team
 type Team struct {
-	Id     string `json:"id"`
+	ID     string `json:"id"`
 	Name   string `json:"name"`
 	Domain string `json:"name"`
 }
@@ -136,7 +136,7 @@ type Icons struct {
 
 // Bot contains information about a bot
 type Bot struct {
-	Id      string `json:"id"`
+	ID      string `json:"id"`
 	Name    string `json:"name"`
 	Deleted bool   `json:"deleted"`
 	Icons   Icons  `json:"icons"`
@@ -160,30 +160,30 @@ type infoResponseFull struct {
 	SlackWSResponse
 }
 
-// GetBotById returns a bot given a bot id
-func (info Info) GetBotById(botId string) *Bot {
+// GetBotByID returns a bot given a bot id
+func (info Info) GetBotByID(botID string) *Bot {
 	for _, bot := range info.Bots {
-		if bot.Id == botId {
+		if bot.ID == botID {
 			return &bot
 		}
 	}
 	return nil
 }
 
-// GetUserById returns a user given a user id
-func (info Info) GetUserById(userId string) *User {
+// GetUserByID returns a user given a user id
+func (info Info) GetUserByID(userID string) *User {
 	for _, user := range info.Users {
-		if user.Id == userId {
+		if user.ID == userID {
 			return &user
 		}
 	}
 	return nil
 }
 
-// GetChannelById returns a channel given a channel id
-func (info Info) GetChannelById(channelId string) *Channel {
+// GetChannelByID returns a channel given a channel id
+func (info Info) GetChannelByID(channelID string) *Channel {
 	for _, channel := range info.Channels {
-		if channel.Id == channelId {
+		if channel.ID == channelID {
 			return &channel
 		}
 	}

--- a/info.go
+++ b/info.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-// XXX: Need to implement
+// UserPrefs needs to be implemented
 type UserPrefs struct {
 	// "highlight_words":"",
 	// "user_colors":"",
@@ -145,7 +145,7 @@ type Bot struct {
 // Info contains various details about Users, Channels, Bots and the authenticated user
 // It is returned by StartRTM
 type Info struct {
-	Url      string       `json:"url,omitempty"`
+	URL      string       `json:"url,omitempty"`
 	User     *UserDetails `json:"self,omitempty"`
 	Team     *Team        `json:"team,omitempty"`
 	Users    []User       `json:"users,omitempty"`
@@ -157,7 +157,7 @@ type Info struct {
 
 type infoResponseFull struct {
 	Info
-	SlackWSResponse
+	WSResponse
 }
 
 // GetBotByID returns a bot given a bot id
@@ -190,10 +190,10 @@ func (info Info) GetChannelByID(channelID string) *Channel {
 	return nil
 }
 
-// GetGroupById returns a group given a group id
-func (info Info) GetGroupById(groupId string) *Group {
+// GetGroupByID returns a group given a group id
+func (info Info) GetGroupByID(groupID string) *Group {
 	for _, group := range info.Groups {
-		if group.Id == groupId {
+		if group.ID == groupID {
 			return &group
 		}
 	}

--- a/item.go
+++ b/item.go
@@ -52,23 +52,23 @@ func NewGroupItem(ch string) Item {
 // CommentId, or the combination of ChannelId and Timestamp must be
 // specified.
 type ItemRef struct {
-	ChannelId string `json:"channel"`
+	Channel   string `json:"channel"`
 	Timestamp string `json:"timestamp"`
-	FileId    string `json:"file"`
-	CommentId string `json:"file_comment"`
+	File      string `json:"file"`
+	Comment   string `json:"file_comment"`
 }
 
 // NewRefToMessage initializes a reference to to a message.
-func NewRefToMessage(channelID, timestamp string) ItemRef {
-	return ItemRef{ChannelId: channelID, Timestamp: timestamp}
+func NewRefToMessage(channel, timestamp string) ItemRef {
+	return ItemRef{Channel: channel, Timestamp: timestamp}
 }
 
 // NewRefToFile initializes a reference to a file.
-func NewRefToFile(fileID string) ItemRef {
-	return ItemRef{FileId: fileID}
+func NewRefToFile(file string) ItemRef {
+	return ItemRef{File: file}
 }
 
 // NewRefToComment initializes a reference to a file comment.
-func NewRefToComment(commentID string) ItemRef {
-	return ItemRef{CommentId: commentID}
+func NewRefToComment(comment string) ItemRef {
+	return ItemRef{Comment: comment}
 }

--- a/item_test.go
+++ b/item_test.go
@@ -78,48 +78,48 @@ func TestNewGroupItem(t *testing.T) {
 
 func TestNewRefToMessage(t *testing.T) {
 	ref := NewRefToMessage("chan", "ts")
-	if got, want := ref.ChannelId, "chan"; got != want {
-		t.Errorf("ChannelId got %s, want %s", got, want)
+	if got, want := ref.Channel, "chan"; got != want {
+		t.Errorf("Channel got %s, want %s", got, want)
 	}
 	if got, want := ref.Timestamp, "ts"; got != want {
 		t.Errorf("Timestamp got %s, want %s", got, want)
 	}
-	if got, want := ref.FileId, ""; got != want {
-		t.Errorf("FileId got %s, want %s", got, want)
+	if got, want := ref.File, ""; got != want {
+		t.Errorf("File got %s, want %s", got, want)
 	}
-	if got, want := ref.CommentId, ""; got != want {
-		t.Errorf("CommentId got %s, want %s", got, want)
+	if got, want := ref.Comment, ""; got != want {
+		t.Errorf("Comment got %s, want %s", got, want)
 	}
 }
 
 func TestNewRefToFile(t *testing.T) {
 	ref := NewRefToFile("file")
-	if got, want := ref.ChannelId, ""; got != want {
-		t.Errorf("ChannelId got %s, want %s", got, want)
+	if got, want := ref.Channel, ""; got != want {
+		t.Errorf("Channel got %s, want %s", got, want)
 	}
 	if got, want := ref.Timestamp, ""; got != want {
 		t.Errorf("Timestamp got %s, want %s", got, want)
 	}
-	if got, want := ref.FileId, "file"; got != want {
-		t.Errorf("FileId got %s, want %s", got, want)
+	if got, want := ref.File, "file"; got != want {
+		t.Errorf("File got %s, want %s", got, want)
 	}
-	if got, want := ref.CommentId, ""; got != want {
-		t.Errorf("CommentId got %s, want %s", got, want)
+	if got, want := ref.Comment, ""; got != want {
+		t.Errorf("Comment got %s, want %s", got, want)
 	}
 }
 
 func TestNewRefToComment(t *testing.T) {
 	ref := NewRefToComment("file_comment")
-	if got, want := ref.ChannelId, ""; got != want {
-		t.Errorf("ChannelId got %s, want %s", got, want)
+	if got, want := ref.Channel, ""; got != want {
+		t.Errorf("Channel got %s, want %s", got, want)
 	}
 	if got, want := ref.Timestamp, ""; got != want {
 		t.Errorf("Timestamp got %s, want %s", got, want)
 	}
-	if got, want := ref.FileId, ""; got != want {
-		t.Errorf("FileId got %s, want %s", got, want)
+	if got, want := ref.File, ""; got != want {
+		t.Errorf("File got %s, want %s", got, want)
 	}
-	if got, want := ref.CommentId, "file_comment"; got != want {
-		t.Errorf("CommentId got %s, want %s", got, want)
+	if got, want := ref.Comment, "file_comment"; got != want {
+		t.Errorf("Comment got %s, want %s", got, want)
 	}
 }

--- a/messages.go
+++ b/messages.go
@@ -102,12 +102,12 @@ type Pong struct {
 }
 
 // NewOutgoingMessage prepares an OutgoingMessage that the user can use to send a message
-func (api *SlackWS) NewOutgoingMessage(text string, channel string) *OutgoingMessage {
+func (api *WS) NewOutgoingMessage(text string, channel string) *OutgoingMessage {
 	api.mutex.Lock()
 	defer api.mutex.Unlock()
-	api.messageId++
+	api.messageID++
 	return &OutgoingMessage{
-		ID:      api.messageId,
+		ID:      api.messageID,
 		Type:    "message",
 		Channel: channel,
 		Text:    text,

--- a/messages.go
+++ b/messages.go
@@ -1,10 +1,11 @@
 package slack
 
+// OutgoingMessage is used for the realtime API, and seems incomplete.
 type OutgoingMessage struct {
-	Id        int    `json:"id"`
-	ChannelId string `json:"channel,omitempty"`
-	Text      string `json:"text,omitempty"`
-	Type      string `json:"type,omitempty"`
+	ID      int    `json:"id"`
+	Channel string `json:"channel,omitempty"`
+	Text    string `json:"text,omitempty"`
+	Type    string `json:"type,omitempty"`
 }
 
 // Message is an auxiliary type to allow us to have a message containing sub messages
@@ -15,32 +16,72 @@ type Message struct {
 
 // Msg contains information about a slack message
 type Msg struct {
-	Id        string `json:"id"`
-	BotId     string `json:"bot_id,omitempty"`
-	UserId    string `json:"user,omitempty"`
-	Username  string `json:"username,omitempty"`
-	ChannelId string `json:"channel,omitempty"`
-	Timestamp string `json:"ts,omitempty"`
-	Text      string `json:"text,omitempty"`
-	Team      string `json:"team,omitempty"`
-	File      *File  `json:"file,omitempty"`
-	// Type may come if it's part of a message list
-	// e.g.: channel.history
-	Type      string `json:"type,omitempty"`
-	IsStarred bool   `json:"is_starred,omitempty"`
-	// Submessage
-	SubType          string       `json:"subtype,omitempty"`
-	Hidden           bool         `json:"bool,omitempty"`
-	DeletedTimestamp string       `json:"deleted_ts,omitempty"`
-	Attachments      []Attachment `json:"attachments,omitempty"`
-	ReplyTo          int          `json:"reply_to,omitempty"`
-	Upload           bool         `json:"upload,omitempty"`
+	// Basic Message
+	Type        string       `json:"type,omitempty"`
+	Channel     string       `json:"channel,omitempty"`
+	User        string       `json:"user,omitempty"`
+	Text        string       `json:"text,omitempty"`
+	Timestamp   string       `json:"ts,omitempty"`
+	IsStarred   bool         `json:"is_starred,omitempty"`
+	Attachments []Attachment `json:"attachments,omitempty"`
+	Edited      *Edited      `json:"edited,omitempty"`
+
+	// Message Subtypes
+	SubType string `json:"subtype,omitempty"`
+
+	// Hidden Subtypes
+	Hidden           bool   `json:"hidden,omitempty"`     // message_changed, message_deleted, unpinned_item
+	DeletedTimestamp string `json:"deleted_ts,omitempty"` // message_deleted
+	EventTimestamp   string `json:"event_ts,omitempty"`
+
+	// bot_message (https://api.slack.com/events/message/bot_message)
+	BotID    string `json:"bot_id,omitempty"`
+	Username string `json:"username,omitempty"`
+	Icons    *Icon  `json:"icons,omitempty"`
+
+	// channel_join, group_join
+	Inviter string `json:"inviter,omitempty"`
+
+	// channel_topic, group_topic
+	Topic string `json:"topic,omitempty"`
+
+	// channel_purpose, group_purpose
+	Purpose string `json:"purpose,omitempty"`
+
+	// channel_name, group_name
+	Name    string `json:"name,omitempty"`
+	OldName string `json:"old_name,omitempty"`
+
+	// channel_archive, group_archive
+	Members []string `json:"members,omitempty"`
+
+	// file_share, file_comment, file_mention
+	File *File `json:"file,omitempty"`
+
+	// file_share
+	Upload bool `json:"upload,omitempty"`
+
+	// file_comment
+	Comment *Comment `json:"comment,omitempty"`
+
+	// pinned_item
+	ItemType string `json:"item_type,omitempty"`
+
+	// https://api.slack.com/rtm
+	ReplyTo int    `json:"reply_to,omitempty"`
+	Team    string `json:"team,omitempty"`
 }
 
-// Presence XXX: not used yet
-type Presence struct {
-	Presence string `json:"presence"`
-	UserId   string `json:"user"`
+// Icon is used for bot messages
+type Icon struct {
+	IconURL   string `json:"icon_url,omitempty"`
+	IconEmoji string `json:"icon_emoji,omitempty"`
+}
+
+// Edited indicates that a message has been edited.
+type Edited struct {
+	User      string `json:"user,omitempty"`
+	Timestamp string `json:"ts,omitempty"`
 }
 
 // Event contains the event type
@@ -50,7 +91,7 @@ type Event struct {
 
 // Ping contains information about a Ping Event
 type Ping struct {
-	Id   int    `json:"id"`
+	ID   int    `json:"id"`
 	Type string `json:"type"`
 }
 
@@ -60,15 +101,15 @@ type Pong struct {
 	ReplyTo int    `json:"reply_to"`
 }
 
-// NewOutGoingMessage prepares an OutgoingMessage that the user can use to send a message
+// NewOutgoingMessage prepares an OutgoingMessage that the user can use to send a message
 func (api *SlackWS) NewOutgoingMessage(text string, channel string) *OutgoingMessage {
 	api.mutex.Lock()
 	defer api.mutex.Unlock()
 	api.messageId++
 	return &OutgoingMessage{
-		Id:        api.messageId,
-		Type:      "message",
-		ChannelId: channel,
-		Text:      text,
+		ID:      api.messageId,
+		Type:    "message",
+		Channel: channel,
+		Text:    text,
 	}
 }

--- a/messages_test.go
+++ b/messages_test.go
@@ -1,0 +1,304 @@
+package slack
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var simpleMessage = `{
+    "type": "message",
+    "channel": "C2147483705",
+    "user": "U2147483697",
+    "text": "Hello world",
+    "ts": "1355517523.000005"
+}`
+
+func unmarshalMessage(j string) (*Message, error) {
+	message := &Message{}
+	if err := json.Unmarshal([]byte(j), &message); err != nil {
+		return nil, err
+	}
+	return message, nil
+}
+
+func TestSimpleMessage(t *testing.T) {
+	message, err := unmarshalMessage(simpleMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "C2147483705", message.Channel)
+	assert.Equal(t, "U2147483697", message.User)
+	assert.Equal(t, "Hello world", message.Text)
+	assert.Equal(t, "1355517523.000005", message.Timestamp)
+}
+
+var starredMessage = `{
+    "text": "is testing",
+    "type": "message",
+    "subtype": "me_message",
+    "user": "U2147483697",
+    "ts": "1433314126.000003",
+    "is_starred": true
+}`
+
+func TestStarredMessage(t *testing.T) {
+	message, err := unmarshalMessage(starredMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "is testing", message.Text)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "me_message", message.SubType)
+	assert.Equal(t, "U2147483697", message.User)
+	assert.Equal(t, "1433314126.000003", message.Timestamp)
+	assert.Equal(t, true, message.IsStarred)
+}
+
+var editedMessage = `{
+    "type": "message",
+    "user": "U2147483697",
+    "text": "hello edited",
+    "edited": {
+        "user": "U2147483697",
+        "ts": "1433314416.000000"
+    },
+    "ts": "1433314408.000004"
+}`
+
+func TestEditedMessage(t *testing.T) {
+	message, err := unmarshalMessage(editedMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "U2147483697", message.User)
+	assert.Equal(t, "hello edited", message.Text)
+	assert.NotNil(t, message.Edited)
+	assert.Equal(t, "U2147483697", message.Edited.User)
+	assert.Equal(t, "1433314416.000000", message.Edited.Timestamp)
+	assert.Equal(t, "1433314408.000004", message.Timestamp)
+}
+
+var uploadedFile = `{
+    "type": "message",
+    "subtype": "file_share",
+    "text": "<@U2147483697|tester> uploaded a file: <https:\/\/test.slack.com\/files\/tester\/abc\/test.txt|test.txt> and commented: test comment here",
+    "file": {
+        "id": "abc",
+        "created": 1433314757,
+        "timestamp": 1433314757,
+        "name": "test.txt",
+        "title": "test.txt",
+        "mimetype": "text\/plain",
+        "filetype": "text",
+        "pretty_type": "Plain Text",
+        "user": "U2147483697",
+        "editable": true,
+        "size": 5,
+        "mode": "snippet",
+        "is_external": false,
+        "external_type": "",
+        "is_public": true,
+        "public_url_shared": false,
+        "url": "https:\/\/slack-files.com\/files-pub\/abc-def-ghi\/test.txt",
+        "url_download": "https:\/\/slack-files.com\/files-pub\/abc-def-ghi\/download\/test.txt",
+        "url_private": "https:\/\/files.slack.com\/files-pri\/abc-def\/test.txt",
+        "url_private_download": "https:\/\/files.slack.com\/files-pri\/abc-def\/download\/test.txt",
+        "permalink": "https:\/\/test.slack.com\/files\/tester\/abc\/test.txt",
+        "permalink_public": "https:\/\/slack-files.com\/abc-def-ghi",
+        "edit_link": "https:\/\/test.slack.com\/files\/tester\/abc\/test.txt\/edit",
+        "preview": "test\n",
+        "preview_highlight": "<div class=\"sssh-code\"><div class=\"sssh-line\"><pre>test<\/pre><\/div>\n<div class=\"sssh-line\"><pre><\/pre><\/div>\n<\/div>",
+        "lines": 2,
+        "lines_more": 0,
+        "channels": [
+            "C2147483705"
+        ],
+        "groups": [],
+        "ims": [],
+        "comments_count": 1,
+        "initial_comment": {
+            "id": "Fc066YLGKH",
+            "created": 1433314757,
+            "timestamp": 1433314757,
+            "user": "U2147483697",
+            "comment": "test comment here"
+        }
+    },
+    "user": "U2147483697",
+    "upload": true,
+    "ts": "1433314757.000006"
+}`
+
+func TestUploadedFile(t *testing.T) {
+	message, err := unmarshalMessage(uploadedFile)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "file_share", message.SubType)
+	assert.Equal(t, "<@U2147483697|tester> uploaded a file: <https://test.slack.com/files/tester/abc/test.txt|test.txt> and commented: test comment here", message.Text)
+	// TODO: Assert File
+	assert.Equal(t, "U2147483697", message.User)
+	assert.True(t, message.Upload)
+	assert.Equal(t, "1433314757.000006", message.Timestamp)
+}
+
+var testPost = `{
+    "type": "message",
+    "subtype": "file_share",
+    "text": "<@U2147483697|tester> shared a file: <https:\/\/test.slack.com\/files\/tester\/abc\/test_post|test post>",
+    "file": {
+        "id": "abc",
+        "created": 1433315398,
+        "timestamp": 1433315398,
+        "name": "test_post",
+        "title": "test post",
+        "mimetype": "text\/plain",
+        "filetype": "post",
+        "pretty_type": "Post",
+        "user": "U2147483697",
+        "editable": true,
+        "size": 14,
+        "mode": "post",
+        "is_external": false,
+        "external_type": "",
+        "is_public": true,
+        "public_url_shared": false,
+        "url": "https:\/\/slack-files.com\/files-pub\/abc-def-ghi\/test_post",
+        "url_download": "https:\/\/slack-files.com\/files-pub\/abc-def-ghi\/download\/test_post",
+        "url_private": "https:\/\/files.slack.com\/files-pri\/abc-def\/test_post",
+        "url_private_download": "https:\/\/files.slack.com\/files-pri\/abc-def\/download\/test_post",
+        "permalink": "https:\/\/test.slack.com\/files\/tester\/abc\/test_post",
+        "permalink_public": "https:\/\/slack-files.com\/abc-def-ghi",
+        "edit_link": "https:\/\/test.slack.com\/files\/tester\/abc\/test_post\/edit",
+        "preview": "test post body",
+        "channels": [
+            "C2147483705"
+        ],
+        "groups": [],
+        "ims": [],
+        "comments_count": 1
+    },
+    "user": "U2147483697",
+    "upload": false,
+    "ts": "1433315416.000008"
+}`
+
+func TestPost(t *testing.T) {
+	message, err := unmarshalMessage(testPost)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "file_share", message.SubType)
+	assert.Equal(t, "<@U2147483697|tester> shared a file: <https://test.slack.com/files/tester/abc/test_post|test post>", message.Text)
+	// TODO: Assert File
+	assert.Equal(t, "U2147483697", message.User)
+	assert.False(t, message.Upload)
+	assert.Equal(t, "1433315416.000008", message.Timestamp)
+}
+
+var testComment = `{
+    "type": "message",
+    "subtype": "file_comment",
+    "text": "<@U2147483697|tester> commented on <@U2147483697|tester>'s file <https:\/\/test.slack.com\/files\/tester\/abc\/test_post|test post>: another comment",
+    "file": {
+        "id": "abc",
+        "created": 1433315398,
+        "timestamp": 1433315398,
+        "name": "test_post",
+        "title": "test post",
+        "mimetype": "text\/plain",
+        "filetype": "post",
+        "pretty_type": "Post",
+        "user": "U2147483697",
+        "editable": true,
+        "size": 14,
+        "mode": "post",
+        "is_external": false,
+        "external_type": "",
+        "is_public": true,
+        "public_url_shared": false,
+        "url": "https:\/\/slack-files.com\/files-pub\/abc-def-ghi\/test_post",
+        "url_download": "https:\/\/slack-files.com\/files-pub\/abc-def-ghi\/download\/test_post",
+        "url_private": "https:\/\/files.slack.com\/files-pri\/abc-def\/test_post",
+        "url_private_download": "https:\/\/files.slack.com\/files-pri\/abc-def\/download\/test_post",
+        "permalink": "https:\/\/test.slack.com\/files\/tester\/abc\/test_post",
+        "permalink_public": "https:\/\/slack-files.com\/abc-def-ghi",
+        "edit_link": "https:\/\/test.slack.com\/files\/tester\/abc\/test_post\/edit",
+        "preview": "test post body",
+        "channels": [
+            "C2147483705"
+        ],
+        "groups": [],
+        "ims": [],
+        "comments_count": 2
+    },
+    "comment": {
+        "id": "xyz",
+        "created": 1433316360,
+        "timestamp": 1433316360,
+        "user": "U2147483697",
+        "comment": "another comment"
+    },
+    "ts": "1433316360.000009"
+}`
+
+func TestComment(t *testing.T) {
+	message, err := unmarshalMessage(testComment)
+	fmt.Println(err)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "file_comment", message.SubType)
+	assert.Equal(t, "<@U2147483697|tester> commented on <@U2147483697|tester>'s file <https://test.slack.com/files/tester/abc/test_post|test post>: another comment", message.Text)
+	// TODO: Assert File
+	// TODO: Assert Comment
+	assert.Equal(t, "1433316360.000009", message.Timestamp)
+}
+
+var botMessage = `{
+    "type": "message",
+    "subtype": "bot_message",
+    "ts": "1358877455.000010",
+    "text": "Pushing is the answer",
+    "bot_id": "BB12033",
+    "username": "github",
+    "icons": {}
+}`
+
+func TestBotMessage(t *testing.T) {
+	message, err := unmarshalMessage(botMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "bot_message", message.SubType)
+	assert.Equal(t, "1358877455.000010", message.Timestamp)
+	assert.Equal(t, "Pushing is the answer", message.Text)
+	assert.Equal(t, "BB12033", message.BotID)
+	assert.Equal(t, "github", message.Username)
+	assert.NotNil(t, message.Icons)
+	assert.Empty(t, message.Icons.IconURL)
+	assert.Empty(t, message.Icons.IconEmoji)
+}
+
+var meMessage = `{
+    "type": "message",
+    "subtype": "me_message",
+    "channel": "C2147483705",
+    "user": "U2147483697",
+    "text": "is doing that thing",
+    "ts": "1355517523.000005"
+}`
+
+func TestMeMessage(t *testing.T) {
+	message, err := unmarshalMessage(meMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "me_message", message.SubType)
+	assert.Equal(t, "C2147483705", message.Channel)
+	assert.Equal(t, "U2147483697", message.User)
+	assert.Equal(t, "is doing that thing", message.Text)
+	assert.Equal(t, "1355517523.000005", message.Timestamp)
+}

--- a/messages_test.go
+++ b/messages_test.go
@@ -302,3 +302,454 @@ func TestMeMessage(t *testing.T) {
 	assert.Equal(t, "is doing that thing", message.Text)
 	assert.Equal(t, "1355517523.000005", message.Timestamp)
 }
+
+var messageChangedMessage = `{
+    "type": "message",
+    "subtype": "message_changed",
+    "hidden": true,
+    "channel": "C2147483705",
+    "ts": "1358878755.000001",
+    "message": {
+        "type": "message",
+        "user": "U2147483697",
+        "text": "Hello, world!",
+        "ts": "1355517523.000005",
+        "edited": {
+            "user": "U2147483697",
+            "ts": "1358878755.000001"
+        }
+    }
+}`
+
+func TestMessageChangedMessage(t *testing.T) {
+	message, err := unmarshalMessage(messageChangedMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "message_changed", message.SubType)
+	assert.True(t, message.Hidden)
+	assert.Equal(t, "C2147483705", message.Channel)
+	assert.NotNil(t, message.SubMessage)
+	assert.Equal(t, "message", message.SubMessage.Type)
+	assert.Equal(t, "U2147483697", message.SubMessage.User)
+	assert.Equal(t, "Hello, world!", message.SubMessage.Text)
+	assert.Equal(t, "1355517523.000005", message.SubMessage.Timestamp)
+	assert.NotNil(t, message.SubMessage.Edited)
+	assert.Equal(t, "U2147483697", message.SubMessage.Edited.User)
+	assert.Equal(t, "1358878755.000001", message.SubMessage.Edited.Timestamp)
+	assert.Equal(t, "1358878755.000001", message.Timestamp)
+}
+
+var messageDeletedMessage = `{
+    "type": "message",
+    "subtype": "message_deleted",
+    "hidden": true,
+    "channel": "C2147483705",
+    "ts": "1358878755.000001",
+    "deleted_ts": "1358878749.000002"
+}`
+
+func TestMessageDeletedMessage(t *testing.T) {
+	message, err := unmarshalMessage(messageDeletedMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "message_deleted", message.SubType)
+	assert.True(t, message.Hidden)
+	assert.Equal(t, "C2147483705", message.Channel)
+	assert.Equal(t, "1358878755.000001", message.Timestamp)
+	assert.Equal(t, "1358878749.000002", message.DeletedTimestamp)
+}
+
+var channelJoinMessage = `{
+    "type": "message",
+    "subtype": "channel_join",
+    "ts": "1358877458.000011",
+    "user": "U2147483828",
+    "text": "<@U2147483828|cal> has joined the channel"
+}`
+
+func TestChannelJoinMessage(t *testing.T) {
+	message, err := unmarshalMessage(channelJoinMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "channel_join", message.SubType)
+	assert.Equal(t, "1358877458.000011", message.Timestamp)
+	assert.Equal(t, "U2147483828", message.User)
+	assert.Equal(t, "<@U2147483828|cal> has joined the channel", message.Text)
+}
+
+var channelJoinInvitedMessage = `{
+    "type": "message",
+    "subtype": "channel_join",
+    "ts": "1358877458.000011",
+    "user": "U2147483828",
+    "text": "<@U2147483828|cal> has joined the channel",
+		"inviter": "U2147483829"
+}`
+
+func TestChannelJoinInvitedMessage(t *testing.T) {
+	message, err := unmarshalMessage(channelJoinInvitedMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "channel_join", message.SubType)
+	assert.Equal(t, "1358877458.000011", message.Timestamp)
+	assert.Equal(t, "U2147483828", message.User)
+	assert.Equal(t, "<@U2147483828|cal> has joined the channel", message.Text)
+	assert.Equal(t, "U2147483829", message.Inviter)
+}
+
+var channelLeaveMessage = `{
+    "type": "message",
+    "subtype": "channel_leave",
+    "ts": "1358877455.000010",
+    "user": "U2147483828",
+    "text": "<@U2147483828|cal> has left the channel"
+}`
+
+func TestChannelLeaveMessage(t *testing.T) {
+	message, err := unmarshalMessage(channelLeaveMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "channel_leave", message.SubType)
+	assert.Equal(t, "1358877455.000010", message.Timestamp)
+	assert.Equal(t, "U2147483828", message.User)
+	assert.Equal(t, "<@U2147483828|cal> has left the channel", message.Text)
+}
+
+var channelTopicMessage = `{
+    "type": "message",
+    "subtype": "channel_topic",
+    "ts": "1358877455.000010",
+    "user": "U2147483828",
+    "topic": "hello world",
+    "text": "<@U2147483828|cal> set the channel topic: hello world"
+}`
+
+func TestChannelTopicMessage(t *testing.T) {
+	message, err := unmarshalMessage(channelTopicMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "channel_topic", message.SubType)
+	assert.Equal(t, "1358877455.000010", message.Timestamp)
+	assert.Equal(t, "U2147483828", message.User)
+	assert.Equal(t, "hello world", message.Topic)
+	assert.Equal(t, "<@U2147483828|cal> set the channel topic: hello world", message.Text)
+}
+
+var channelPurposeMessage = `{
+    "type": "message",
+    "subtype": "channel_purpose",
+    "ts": "1358877455.000010",
+    "user": "U2147483828",
+    "purpose": "whatever",
+    "text": "<@U2147483828|cal> set the channel purpose: whatever"
+}`
+
+func TestChannelPurposeMessage(t *testing.T) {
+	message, err := unmarshalMessage(channelPurposeMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "channel_purpose", message.SubType)
+	assert.Equal(t, "1358877455.000010", message.Timestamp)
+	assert.Equal(t, "U2147483828", message.User)
+	assert.Equal(t, "whatever", message.Purpose)
+	assert.Equal(t, "<@U2147483828|cal> set the channel purpose: whatever", message.Text)
+}
+
+var channelNameMessage = `{
+    "type": "message",
+    "subtype": "channel_name",
+    "ts": "1358877455.000010",
+    "user": "U2147483828",
+    "old_name": "random",
+    "name": "watercooler",
+    "text": "<@U2147483828|cal> has renamed the channel from \"random\" to \"watercooler\""
+}`
+
+func TestChannelNameMessage(t *testing.T) {
+	message, err := unmarshalMessage(channelNameMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "channel_name", message.SubType)
+	assert.Equal(t, "1358877455.000010", message.Timestamp)
+	assert.Equal(t, "U2147483828", message.User)
+	assert.Equal(t, "random", message.OldName)
+	assert.Equal(t, "watercooler", message.Name)
+	assert.Equal(t, "<@U2147483828|cal> has renamed the channel from \"random\" to \"watercooler\"", message.Text)
+}
+
+var channelArchiveMessage = `{
+    "type": "message",
+    "subtype": "channel_archive",
+    "ts": "1361482916.000003",
+    "text": "<U1234|@cal> archived the channel",
+    "user": "U1234",
+    "members": ["U1234", "U5678"]
+}`
+
+func TestChannelArchiveMessage(t *testing.T) {
+	message, err := unmarshalMessage(channelArchiveMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "channel_archive", message.SubType)
+	assert.Equal(t, "1361482916.000003", message.Timestamp)
+	assert.Equal(t, "<U1234|@cal> archived the channel", message.Text)
+	assert.Equal(t, "U1234", message.User)
+	assert.NotNil(t, message.Members)
+	assert.Equal(t, 2, len(message.Members))
+}
+
+var channelUnarchiveMessage = `{
+    "type": "message",
+    "subtype": "channel_unarchive",
+    "ts": "1361482916.000003",
+    "text": "<U1234|@cal> un-archived the channel",
+    "user": "U1234"
+}`
+
+func TestChannelUnarchiveMessage(t *testing.T) {
+	message, err := unmarshalMessage(channelUnarchiveMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "channel_unarchive", message.SubType)
+	assert.Equal(t, "1361482916.000003", message.Timestamp)
+	assert.Equal(t, "<U1234|@cal> un-archived the channel", message.Text)
+	assert.Equal(t, "U1234", message.User)
+}
+
+var groupJoinMessage = `{
+    "type": "message",
+    "subtype": "group_join",
+    "ts": "1358877458.000011",
+    "user": "U2147483828",
+    "text": "<@U2147483828|cal> has joined the group"
+}`
+
+func TestGroupJoinMessage(t *testing.T) {
+	message, err := unmarshalMessage(groupJoinMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "group_join", message.SubType)
+	assert.Equal(t, "1358877458.000011", message.Timestamp)
+	assert.Equal(t, "U2147483828", message.User)
+	assert.Equal(t, "<@U2147483828|cal> has joined the group", message.Text)
+}
+
+var groupJoinInvitedMessage = `{
+    "type": "message",
+    "subtype": "group_join",
+    "ts": "1358877458.000011",
+    "user": "U2147483828",
+    "text": "<@U2147483828|cal> has joined the group",
+		"inviter": "U2147483829"
+}`
+
+func TestGroupJoinInvitedMessage(t *testing.T) {
+	message, err := unmarshalMessage(groupJoinInvitedMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "group_join", message.SubType)
+	assert.Equal(t, "1358877458.000011", message.Timestamp)
+	assert.Equal(t, "U2147483828", message.User)
+	assert.Equal(t, "<@U2147483828|cal> has joined the group", message.Text)
+	assert.Equal(t, "U2147483829", message.Inviter)
+}
+
+var groupLeaveMessage = `{
+    "type": "message",
+    "subtype": "group_leave",
+    "ts": "1358877455.000010",
+    "user": "U2147483828",
+    "text": "<@U2147483828|cal> has left the group"
+}`
+
+func TestGroupLeaveMessage(t *testing.T) {
+	message, err := unmarshalMessage(groupLeaveMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "group_leave", message.SubType)
+	assert.Equal(t, "1358877455.000010", message.Timestamp)
+	assert.Equal(t, "U2147483828", message.User)
+	assert.Equal(t, "<@U2147483828|cal> has left the group", message.Text)
+}
+
+var groupTopicMessage = `{
+    "type": "message",
+    "subtype": "group_topic",
+    "ts": "1358877455.000010",
+    "user": "U2147483828",
+    "topic": "hello world",
+    "text": "<@U2147483828|cal> set the group topic: hello world"
+}`
+
+func TestGroupTopicMessage(t *testing.T) {
+	message, err := unmarshalMessage(groupTopicMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "group_topic", message.SubType)
+	assert.Equal(t, "1358877455.000010", message.Timestamp)
+	assert.Equal(t, "U2147483828", message.User)
+	assert.Equal(t, "hello world", message.Topic)
+	assert.Equal(t, "<@U2147483828|cal> set the group topic: hello world", message.Text)
+}
+
+var groupPurposeMessage = `{
+    "type": "message",
+    "subtype": "group_purpose",
+    "ts": "1358877455.000010",
+    "user": "U2147483828",
+    "purpose": "whatever",
+    "text": "<@U2147483828|cal> set the group purpose: whatever"
+}`
+
+func TestGroupPurposeMessage(t *testing.T) {
+	message, err := unmarshalMessage(groupPurposeMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "group_purpose", message.SubType)
+	assert.Equal(t, "1358877455.000010", message.Timestamp)
+	assert.Equal(t, "U2147483828", message.User)
+	assert.Equal(t, "whatever", message.Purpose)
+	assert.Equal(t, "<@U2147483828|cal> set the group purpose: whatever", message.Text)
+}
+
+var groupNameMessage = `{
+    "type": "message",
+    "subtype": "group_name",
+    "ts": "1358877455.000010",
+    "user": "U2147483828",
+    "old_name": "random",
+    "name": "watercooler",
+    "text": "<@U2147483828|cal> has renamed the group from \"random\" to \"watercooler\""
+}`
+
+func TestGroupNameMessage(t *testing.T) {
+	message, err := unmarshalMessage(groupNameMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "group_name", message.SubType)
+	assert.Equal(t, "1358877455.000010", message.Timestamp)
+	assert.Equal(t, "U2147483828", message.User)
+	assert.Equal(t, "random", message.OldName)
+	assert.Equal(t, "watercooler", message.Name)
+	assert.Equal(t, "<@U2147483828|cal> has renamed the group from \"random\" to \"watercooler\"", message.Text)
+}
+
+var groupArchiveMessage = `{
+    "type": "message",
+    "subtype": "group_archive",
+    "ts": "1361482916.000003",
+    "text": "<U1234|@cal> archived the group",
+    "user": "U1234",
+    "members": ["U1234", "U5678"]
+}`
+
+func TestGroupArchiveMessage(t *testing.T) {
+	message, err := unmarshalMessage(groupArchiveMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "group_archive", message.SubType)
+	assert.Equal(t, "1361482916.000003", message.Timestamp)
+	assert.Equal(t, "<U1234|@cal> archived the group", message.Text)
+	assert.Equal(t, "U1234", message.User)
+	assert.NotNil(t, message.Members)
+	assert.Equal(t, 2, len(message.Members))
+}
+
+var groupUnarchiveMessage = `{
+    "type": "message",
+    "subtype": "group_unarchive",
+    "ts": "1361482916.000003",
+    "text": "<U1234|@cal> un-archived the group",
+    "user": "U1234"
+}`
+
+func TestGroupUnarchiveMessage(t *testing.T) {
+	message, err := unmarshalMessage(groupUnarchiveMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "group_unarchive", message.SubType)
+	assert.Equal(t, "1361482916.000003", message.Timestamp)
+	assert.Equal(t, "<U1234|@cal> un-archived the group", message.Text)
+	assert.Equal(t, "U1234", message.User)
+}
+
+var fileShareMessage = `{
+    "type": "message",
+    "subtype": "file_share",
+    "ts": "1358877455.000010",
+    "text": "<@cal> uploaded a file: <https:...7.png|7.png>",
+    "file": {
+        "id" : "F2147483862",
+        "created" : 1356032811,
+        "timestamp" : 1356032811,
+        "name" : "file.htm",
+        "title" : "My HTML file",
+        "mimetype" : "text\/plain",
+        "filetype" : "text",
+        "pretty_type": "Text",
+        "user" : "U2147483697",
+        "mode" : "hosted",
+        "editable" : true,
+        "is_external": false,
+        "external_type": "",
+        "size" : 12345,
+        "url": "https:\/\/slack-files.com\/files-pub\/T024BE7LD-F024BERPE-09acb6\/1.png",
+        "url_download": "https:\/\/slack-files.com\/files-pub\/T024BE7LD-F024BERPE-09acb6\/download\/1.png",
+        "url_private": "https:\/\/slack.com\/files-pri\/T024BE7LD-F024BERPE\/1.png",
+        "url_private_download": "https:\/\/slack.com\/files-pri\/T024BE7LD-F024BERPE\/download\/1.png",
+        "thumb_64": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_64.png",
+        "thumb_80": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_80.png",
+        "thumb_360": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_360.png",
+        "thumb_360_gif": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_360.gif",
+        "thumb_360_w": 100,
+        "thumb_360_h": 100,
+        "permalink" : "https:\/\/tinyspeck.slack.com\/files\/cal\/F024BERPE\/1.png",
+        "edit_link" : "https:\/\/tinyspeck.slack.com\/files\/cal\/F024BERPE\/1.png/edit",
+        "preview" : "&lt;!DOCTYPE html&gt;\n&lt;html&gt;\n&lt;meta charset='utf-8'&gt;",
+        "preview_highlight" : "&lt;div class=\"sssh-code\"&gt;&lt;div class=\"sssh-line\"&gt;&lt;pre&gt;&lt;!DOCTYPE html...",
+        "lines" : 123,
+        "lines_more": 118,
+        "is_public": true,
+        "public_url_shared": false,
+        "channels": ["C024BE7LT"],
+        "groups": ["G12345"],
+        "ims": ["D12345"],
+        "initial_comment": {},
+        "num_stars": 7,
+        "is_starred": true
+    },
+    "user": "U2147483697",
+    "upload": true
+}`
+
+func TestFileShareMessage(t *testing.T) {
+	message, err := unmarshalMessage(fileShareMessage)
+	fmt.Println(err)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "file_share", message.SubType)
+	assert.Equal(t, "1358877455.000010", message.Timestamp)
+	assert.Equal(t, "<@cal> uploaded a file: <https:...7.png|7.png>", message.Text)
+	assert.Equal(t, "U2147483697", message.User)
+	assert.True(t, message.Upload)
+	assert.NotNil(t, message.File)
+}

--- a/oauth.go
+++ b/oauth.go
@@ -12,9 +12,9 @@ type oAuthResponseFull struct {
 }
 
 // GetOAuthToken retrieves an AccessToken
-func GetOAuthToken(clientId, clientSecret, code, redirectURI string, debug bool) (accessToken string, scope string, err error) {
+func GetOAuthToken(clientID, clientSecret, code, redirectURI string, debug bool) (accessToken string, scope string, err error) {
 	values := url.Values{
-		"client_id":     {clientId},
+		"client_id":     {clientID},
 		"client_secret": {clientSecret},
 		"code":          {code},
 		"redirect_uri":  {redirectURI},

--- a/reactions.go
+++ b/reactions.go
@@ -59,28 +59,28 @@ func (res getReactionsResponseFull) extractReactions() []ItemReaction {
 }
 
 const (
-	DEFAULT_REACTIONS_USERID = ""
-	DEFAULT_REACTIONS_COUNT  = 100
-	DEFAULT_REACTIONS_PAGE   = 1
-	DEFAULT_REACTIONS_FULL   = false
+	DEFAULT_REACTIONS_USER  = ""
+	DEFAULT_REACTIONS_COUNT = 100
+	DEFAULT_REACTIONS_PAGE  = 1
+	DEFAULT_REACTIONS_FULL  = false
 )
 
 // ListReactionsParameters is the inputs to find all reactions by a user.
 type ListReactionsParameters struct {
-	UserId string
-	Count  int
-	Page   int
-	Full   bool
+	User  string
+	Count int
+	Page  int
+	Full  bool
 }
 
 // NewListReactionsParameters initializes the inputs to find all reactions
 // performed by a user.
 func NewListReactionsParameters() ListReactionsParameters {
 	return ListReactionsParameters{
-		UserId: DEFAULT_REACTIONS_USERID,
-		Count:  DEFAULT_REACTIONS_COUNT,
-		Page:   DEFAULT_REACTIONS_PAGE,
-		Full:   DEFAULT_REACTIONS_FULL,
+		User:  DEFAULT_REACTIONS_USER,
+		Count: DEFAULT_REACTIONS_COUNT,
+		Page:  DEFAULT_REACTIONS_PAGE,
+		Full:  DEFAULT_REACTIONS_FULL,
 	}
 }
 
@@ -136,17 +136,17 @@ func (api *Slack) AddReaction(name string, item ItemRef) error {
 	if name != "" {
 		values.Set("name", name)
 	}
-	if item.ChannelId != "" {
-		values.Set("channel", string(item.ChannelId))
+	if item.Channel != "" {
+		values.Set("channel", string(item.Channel))
 	}
 	if item.Timestamp != "" {
 		values.Set("timestamp", string(item.Timestamp))
 	}
-	if item.FileId != "" {
-		values.Set("file", string(item.FileId))
+	if item.File != "" {
+		values.Set("file", string(item.File))
 	}
-	if item.CommentId != "" {
-		values.Set("file_comment", string(item.CommentId))
+	if item.Comment != "" {
+		values.Set("file_comment", string(item.Comment))
 	}
 	response := &SlackResponse{}
 	if err := parseResponse("reactions.add", values, response, api.debug); err != nil {
@@ -166,17 +166,17 @@ func (api *Slack) RemoveReaction(name string, item ItemRef) error {
 	if name != "" {
 		values.Set("name", name)
 	}
-	if item.ChannelId != "" {
-		values.Set("channel", string(item.ChannelId))
+	if item.Channel != "" {
+		values.Set("channel", string(item.Channel))
 	}
 	if item.Timestamp != "" {
 		values.Set("timestamp", string(item.Timestamp))
 	}
-	if item.FileId != "" {
-		values.Set("file", string(item.FileId))
+	if item.File != "" {
+		values.Set("file", string(item.File))
 	}
-	if item.CommentId != "" {
-		values.Set("file_comment", string(item.CommentId))
+	if item.Comment != "" {
+		values.Set("file_comment", string(item.Comment))
 	}
 	response := &SlackResponse{}
 	if err := parseResponse("reactions.remove", values, response, api.debug); err != nil {
@@ -193,17 +193,17 @@ func (api *Slack) GetReactions(item ItemRef, params GetReactionsParameters) ([]I
 	values := url.Values{
 		"token": {api.config.token},
 	}
-	if item.ChannelId != "" {
-		values.Set("channel", string(item.ChannelId))
+	if item.Channel != "" {
+		values.Set("channel", string(item.Channel))
 	}
 	if item.Timestamp != "" {
 		values.Set("timestamp", string(item.Timestamp))
 	}
-	if item.FileId != "" {
-		values.Set("file", string(item.FileId))
+	if item.File != "" {
+		values.Set("file", string(item.File))
 	}
-	if item.CommentId != "" {
-		values.Set("file_comment", string(item.CommentId))
+	if item.Comment != "" {
+		values.Set("file_comment", string(item.Comment))
 	}
 	if params.Full != DEFAULT_REACTIONS_FULL {
 		values.Set("full", strconv.FormatBool(params.Full))
@@ -223,8 +223,8 @@ func (api *Slack) ListReactions(params ListReactionsParameters) ([]ReactedItem, 
 	values := url.Values{
 		"token": {api.config.token},
 	}
-	if params.UserId != DEFAULT_REACTIONS_USERID {
-		values.Add("user", params.UserId)
+	if params.User != DEFAULT_REACTIONS_USER {
+		values.Add("user", params.User)
 	}
 	if params.Count != DEFAULT_REACTIONS_COUNT {
 		values.Add("count", strconv.Itoa(params.Count))

--- a/reactions_test.go
+++ b/reactions_test.go
@@ -337,13 +337,13 @@ func TestSlack_ListReactions(t *testing.T) {
 		},
 	}
 	wantParams := map[string]string{
-		"user":  "UserID",
+		"user":  "User",
 		"count": "200",
 		"page":  "2",
 		"full":  "true",
 	}
 	params := NewListReactionsParameters()
-	params.UserId = "UserID"
+	params.User = "User"
 	params.Count = 200
 	params.Page = 2
 	params.Full = true

--- a/search.go
+++ b/search.go
@@ -23,12 +23,12 @@ type SearchParameters struct {
 }
 
 type CtxChannel struct {
-	Id   string `json:"id"`
+	ID   string `json:"id"`
 	Name string `json:"name"`
 }
 
 type CtxMessage struct {
-	UserId    string `json:"user"`
+	User      string `json:"user"`
 	Username  string `json:"username"`
 	Text      string `json:"text"`
 	Timestamp string `json:"ts"`
@@ -38,7 +38,7 @@ type CtxMessage struct {
 type SearchMessage struct {
 	Type      string     `json:"type"`
 	Channel   CtxChannel `json:"channel"`
-	UserId    string     `json:"user"`
+	User      string     `json:"user"`
 	Username  string     `json:"username"`
 	Timestamp string     `json:"ts"`
 	Text      string     `json:"text"`

--- a/slack.go
+++ b/slack.go
@@ -17,7 +17,7 @@ type SlackResponse struct {
 }
 
 type AuthTestResponse struct {
-	Url    string `json:"url"`
+	URL    string `json:"url"`
 	Team   string `json:"team"`
 	User   string `json:"user"`
 	TeamID string `json:"team_id"`

--- a/slack.go
+++ b/slack.go
@@ -20,8 +20,8 @@ type AuthTestResponse struct {
 	Url    string `json:"url"`
 	Team   string `json:"team"`
 	User   string `json:"user"`
-	TeamId string `json:"team_id"`
-	UserId string `json:"user_id"`
+	TeamID string `json:"team_id"`
+	UserID string `json:"user_id"`
 }
 
 type authTestResponseFull struct {

--- a/stars.go
+++ b/stars.go
@@ -7,9 +7,9 @@ import (
 )
 
 const (
-	DEFAULT_STARS_USERID = ""
-	DEFAULT_STARS_COUNT  = 100
-	DEFAULT_STARS_PAGE   = 1
+	DEFAULT_STARS_USER  = ""
+	DEFAULT_STARS_COUNT = 100
+	DEFAULT_STARS_PAGE  = 1
 )
 
 type StarsParameters struct {
@@ -31,7 +31,7 @@ type starsResponseFull struct {
 
 func NewStarsParameters() StarsParameters {
 	return StarsParameters{
-		User:  DEFAULT_STARS_USERID,
+		User:  DEFAULT_STARS_USER,
 		Count: DEFAULT_STARS_COUNT,
 		Page:  DEFAULT_STARS_PAGE,
 	}
@@ -51,7 +51,7 @@ func (api *Slack) GetStarred(params StarsParameters) ([]StarredItem, *Paging, er
 	values := url.Values{
 		"token": {api.config.token},
 	}
-	if params.User != DEFAULT_STARS_USERID {
+	if params.User != DEFAULT_STARS_USER {
 		values.Add("user", params.User)
 	}
 	if params.Count != DEFAULT_STARS_COUNT {

--- a/stars_test.go
+++ b/stars_test.go
@@ -118,18 +118,18 @@ func TestSlack_GetStarred(t *testing.T) {
 	for i, test := range tests {
 		sh = newStarsHandler()
 		sh.response = test.json
-		response_items, response_paging, err := api.GetStarred(test.params)
+		responseItems, responsePaging, err := api.GetStarred(test.params)
 		if err != nil {
 			t.Fatalf("%d Unexpected error: %s", i, err)
 		}
 		if !reflect.DeepEqual(sh.gotParams, test.wantParams) {
 			t.Errorf("%d got %v; want %v", i, sh.gotParams, test.wantParams)
 		}
-		if !reflect.DeepEqual(response_items, test.starredItems) {
-			t.Errorf("%d got %v; want %v", i, response_items, test.starredItems)
+		if !reflect.DeepEqual(responseItems, test.starredItems) {
+			t.Errorf("%d got %v; want %v", i, responseItems, test.starredItems)
 		}
-		if !reflect.DeepEqual(response_paging, test.paging) {
-			t.Errorf("%d got %v; want %v", i, response_paging, test.paging)
+		if !reflect.DeepEqual(responsePaging, test.paging) {
+			t.Errorf("%d got %v; want %v", i, responsePaging, test.paging)
 		}
 	}
 }

--- a/users.go
+++ b/users.go
@@ -25,7 +25,7 @@ type UserProfile struct {
 
 // User contains all the information of a user
 type User struct {
-	Id                string      `json:"id"`
+	ID                string      `json:"id"`
 	Name              string      `json:"name"`
 	Deleted           bool        `json:"deleted"`
 	Color             string      `json:"color"`
@@ -75,10 +75,10 @@ func userRequest(path string, values url.Values, debug bool) (*userResponseFull,
 }
 
 // GetUserPresence will retrieve the current presence status of given user.
-func (api *Slack) GetUserPresence(userId string) (*UserPresence, error) {
+func (api *Slack) GetUserPresence(user string) (*UserPresence, error) {
 	values := url.Values{
 		"token": {api.config.token},
-		"user":  {userId},
+		"user":  {user},
 	}
 	response, err := userRequest("users.getPresence", values, api.debug)
 	if err != nil {
@@ -88,10 +88,10 @@ func (api *Slack) GetUserPresence(userId string) (*UserPresence, error) {
 }
 
 // GetUserInfo will retrive the complete user information
-func (api *Slack) GetUserInfo(userId string) (*User, error) {
+func (api *Slack) GetUserInfo(user string) (*User, error) {
 	values := url.Values{
 		"token": {api.config.token},
-		"user":  {userId},
+		"user":  {user},
 	}
 	response, err := userRequest("users.info", values, api.debug)
 	if err != nil {

--- a/websocket.go
+++ b/websocket.go
@@ -113,7 +113,7 @@ func (api *SlackWS) Ping() error {
 	api.mutex.Lock()
 	defer api.mutex.Unlock()
 	api.messageId++
-	msg := &Ping{Id: api.messageId, Type: "ping"}
+	msg := &Ping{ID: api.messageId, Type: "ping"}
 	if err := websocket.JSON.Send(api.conn, msg); err != nil {
 		return err
 	}

--- a/websocket.go
+++ b/websocket.go
@@ -16,9 +16,9 @@ import (
 
 type MessageEvent Message
 
-type SlackWS struct {
+type WS struct {
 	conn      *websocket.Conn
-	messageId int
+	messageID int
 	mutex     sync.Mutex
 	pings     map[int]time.Time
 	Slack
@@ -29,15 +29,15 @@ type AckMessage struct {
 	ReplyTo   int    `json:"reply_to"`
 	Timestamp string `json:"ts"`
 	Text      string `json:"text"`
-	SlackWSResponse
+	WSResponse
 }
 
-type SlackWSResponse struct {
-	Ok    bool          `json:"ok"`
-	Error *SlackWSError `json:"error"`
+type WSResponse struct {
+	Ok    bool     `json:"ok"`
+	Error *WSError `json:"error"`
 }
 
-type SlackWSError struct {
+type WSError struct {
 	Code int
 	Msg  string
 }
@@ -64,13 +64,13 @@ func (t JSONTimeString) String() string {
 	return fmt.Sprintf("\"%s\"", tm.Format("Mon Jan _2"))
 }
 
-func (s SlackWSError) Error() string {
+func (s WSError) Error() string {
 	return s.Msg
 }
 
 var portMapping = map[string]string{"ws": "80", "wss": "443"}
 
-func fixUrlPort(orig string) (string, error) {
+func fixURLPort(orig string) (string, error) {
 	urlObj, err := url.ParseRequestURI(orig)
 	if err != nil {
 		return "", err
@@ -82,7 +82,7 @@ func fixUrlPort(orig string) (string, error) {
 	return orig, nil
 }
 
-func (api *Slack) StartRTM(protocol, origin string) (*SlackWS, error) {
+func (api *Slack) StartRTM(protocol, origin string) (*WS, error) {
 	response := &infoResponseFull{}
 	err := parseResponse("rtm.start", url.Values{"token": {api.config.token}}, response, api.debug)
 	if err != nil {
@@ -95,34 +95,34 @@ func (api *Slack) StartRTM(protocol, origin string) (*SlackWS, error) {
 	// websocket.Dial does not accept url without the port (yet)
 	// Fixed by: https://github.com/golang/net/commit/5058c78c3627b31e484a81463acd51c7cecc06f3
 	// but slack returns the address with no port, so we have to fix it
-	api.info.Url, err = fixUrlPort(api.info.Url)
+	api.info.URL, err = fixURLPort(api.info.URL)
 	if err != nil {
 		return nil, err
 	}
 	api.config.protocol, api.config.origin = protocol, origin
-	wsApi := &SlackWS{Slack: *api}
-	wsApi.conn, err = websocket.Dial(api.info.Url, api.config.protocol, api.config.origin)
+	wsAPI := &WS{Slack: *api}
+	wsAPI.conn, err = websocket.Dial(api.info.URL, api.config.protocol, api.config.origin)
 	if err != nil {
 		return nil, err
 	}
-	wsApi.pings = make(map[int]time.Time)
-	return wsApi, nil
+	wsAPI.pings = make(map[int]time.Time)
+	return wsAPI, nil
 }
 
-func (api *SlackWS) Ping() error {
+func (api *WS) Ping() error {
 	api.mutex.Lock()
 	defer api.mutex.Unlock()
-	api.messageId++
-	msg := &Ping{ID: api.messageId, Type: "ping"}
+	api.messageID++
+	msg := &Ping{ID: api.messageID, Type: "ping"}
 	if err := websocket.JSON.Send(api.conn, msg); err != nil {
 		return err
 	}
 	// TODO: What happens if we already have this id?
-	api.pings[api.messageId] = time.Now()
+	api.pings[api.messageID] = time.Now()
 	return nil
 }
 
-func (api *SlackWS) Keepalive(interval time.Duration) {
+func (api *WS) Keepalive(interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
@@ -136,7 +136,7 @@ func (api *SlackWS) Keepalive(interval time.Duration) {
 	}
 }
 
-func (api *SlackWS) SendMessage(msg *OutgoingMessage) error {
+func (api *WS) SendMessage(msg *OutgoingMessage) error {
 	if msg == nil {
 		return fmt.Errorf("Can't send a nil message")
 	}
@@ -147,7 +147,7 @@ func (api *SlackWS) SendMessage(msg *OutgoingMessage) error {
 	return nil
 }
 
-func (api *SlackWS) HandleIncomingEvents(ch chan SlackEvent) {
+func (api *WS) HandleIncomingEvents(ch chan SlackEvent) {
 	for {
 		event := json.RawMessage{}
 		if err := websocket.JSON.Receive(api.conn, &event); err == io.EOF {
@@ -157,7 +157,7 @@ func (api *SlackWS) HandleIncomingEvents(ch chan SlackEvent) {
 			//}
 			// should we reconnect here?
 			if !api.conn.IsClientConn() {
-				api.conn, err = websocket.Dial(api.info.Url, api.config.protocol, api.config.origin)
+				api.conn, err = websocket.Dial(api.info.URL, api.config.protocol, api.config.origin)
 				if err != nil {
 					log.Panic(err)
 				}
@@ -180,7 +180,7 @@ func (api *SlackWS) HandleIncomingEvents(ch chan SlackEvent) {
 	}
 }
 
-func (api *SlackWS) handleEvent(ch chan SlackEvent, event json.RawMessage) {
+func (api *WS) handleEvent(ch chan SlackEvent, event json.RawMessage) {
 	em := Event{}
 	err := json.Unmarshal(event, &em)
 	if err != nil {

--- a/websocket_channels.go
+++ b/websocket_channels.go
@@ -7,7 +7,7 @@ type ChannelCreatedEvent struct {
 }
 
 type ChannelCreatedInfo struct {
-	Id        string         `json:"id"`
+	ID        string         `json:"id"`
 	IsChannel bool           `json:"is_channel"`
 	Name      string         `json:"name"`
 	Created   JSONTimeString `json:"created"`
@@ -25,8 +25,8 @@ type ChannelInfoEvent struct {
 	// channel_archive
 	// channel_unarchive
 	Type      string          `json:"type"`
-	ChannelId string          `json:"channel"`
-	UserId    string          `json:"user,omitempty"`
+	Channel   string          `json:"channel"`
+	User      string          `json:"user,omitempty"`
 	Timestamp *JSONTimeString `json:"ts,omitempty"`
 }
 
@@ -36,7 +36,7 @@ type ChannelRenameEvent struct {
 }
 
 type ChannelRenameInfo struct {
-	Id      string         `json:"id"`
+	ID      string         `json:"id"`
 	Name    string         `json:"name"`
 	Created JSONTimeString `json:"created"`
 }

--- a/websocket_dm.go
+++ b/websocket_dm.go
@@ -2,7 +2,7 @@ package slack
 
 type IMCreatedEvent struct {
 	Type    string             `json:"type"`
-	UserId  string             `json:"user"`
+	User    string             `json:"user"`
 	Channel ChannelCreatedInfo `json:"channel"`
 }
 

--- a/websocket_files.go
+++ b/websocket_files.go
@@ -4,8 +4,8 @@ type fileActionEvent struct {
 	Type           string         `json:"type"`
 	EventTimestamp JSONTimeString `json:"event_ts"`
 	File           File           `json:"file"`
-	// FileId is used for FileDeletedEvent
-	FileId string `json:"file_id,omitempty"`
+	// FileID is used for FileDeletedEvent
+	FileID string `json:"file_id,omitempty"`
 }
 
 type FileCreatedEvent fileActionEvent
@@ -28,5 +28,5 @@ type FileCommentEditedEvent struct {
 
 type FileCommentDeletedEvent struct {
 	fileActionEvent
-	CommentId string `json:"comment"`
+	Comment string `json:"comment"`
 }

--- a/websocket_groups.go
+++ b/websocket_groups.go
@@ -2,7 +2,7 @@ package slack
 
 type GroupCreatedEvent struct {
 	Type    string             `json:"type"`
-	UserId  string             `json:"user"`
+	User    string             `json:"user"`
 	Channel ChannelCreatedInfo `json:"channel"`
 }
 

--- a/websocket_misc.go
+++ b/websocket_misc.go
@@ -12,13 +12,13 @@ type HelloEvent struct{}
 type PresenceChangeEvent struct {
 	Type     string `json:"type"`
 	Presence string `json:"presence"`
-	UserId   string `json:"user"`
+	User     string `json:"user"`
 }
 
 type UserTypingEvent struct {
-	Type      string `json:"type"`
-	UserId    string `json:"user"`
-	ChannelId string `json:"channel"`
+	Type    string `json:"type"`
+	User    string `json:"user"`
+	Channel string `json:"channel"`
 }
 
 type LatencyReport struct {

--- a/websocket_stars.go
+++ b/websocket_stars.go
@@ -2,7 +2,7 @@ package slack
 
 type starEvent struct {
 	Type           string         `json:"type"`
-	UserId         string         `json:"user"`
+	User           string         `json:"user"`
 	Item           StarredItem    `json:"item"`
 	EventTimestamp JSONTimeString `json:"event_ts"`
 }

--- a/websocket_teams.go
+++ b/websocket_teams.go
@@ -19,7 +19,7 @@ type TeamPrefChangeEvent struct {
 
 type TeamDomainChangeEvent struct {
 	Type   string `json:"type"`
-	Url    string `json:"url"`
+	URL    string `json:"url"`
 	Domain string `json:"domain"`
 }
 


### PR DESCRIPTION
:rotating_light: WIP - Still Adding Tests :rotating_light: 

This:
- Adds missing fields for message subtypes
- Adds tests for message mapping, based on actual API examples as of June 3rd, 2015 and the examples at https://api.slack.com/events/message
- Removes redundant and mis-cased `Id` usage across the entire library (fixing a vast number of lint issues in both this library and consumers of it: https://github.com/golang/lint/blob/master/lint.go#L712)
