### PR TITLE
add GetGroupById; fix ChannelRenameInfo time.

### DIFF
--- a/info.go
+++ b/info.go
@@ -189,3 +189,13 @@ func (info Info) GetChannelById(channelId string) *Channel {
 	}
 	return nil
 }
+
+// GetGroupById returns a group given a group id
+func (info Info) GetGroupById(groupId string) *Group {
+	for _, group := range info.Groups {
+		if group.Id == groupId {
+			return &group
+		}
+	}
+	return nil
+}

--- a/websocket_channels.go
+++ b/websocket_channels.go
@@ -36,9 +36,9 @@ type ChannelRenameEvent struct {
 }
 
 type ChannelRenameInfo struct {
-	Id      string   `json:"id"`
-	Name    string   `json:"name"`
-	Created JSONTime `json:"created"`
+	Id      string         `json:"id"`
+	Name    string         `json:"name"`
+	Created JSONTimeString `json:"created"`
 }
 
 type ChannelHistoryChangedEvent struct {


### PR DESCRIPTION
Added info.GetGroupById method.
Fixed created time in ChannelRenameInfo.
