### PR TITLE
Refactor stars

### DIFF
--- a/examples/stars/stars.go
+++ b/examples/stars/stars.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/nlopes/slack"
+)
+
+func main() {
+	var (
+		apiToken string
+		debug    bool
+	)
+
+	flag.StringVar(&apiToken, "token", "YOUR_TOKEN_HERE", "Your Slack API Token")
+	flag.BoolVar(&debug, "debug", false, "Show JSON output")
+	flag.Parse()
+
+	api := slack.New(apiToken)
+	if debug {
+		api.SetDebug(true)
+	}
+
+	// Get all stars for the usr.
+	params := slack.NewStarsParameters()
+	starredItems, _, err := api.GetStarred(params)
+	if err != nil {
+		fmt.Printf("Error getting stars: %s\n", err)
+		return
+	}
+	for _, s := range starredItems {
+		var desc string
+		switch s.Type {
+		case slack.TYPE_MESSAGE:
+			desc = s.Message.Text
+		case slack.TYPE_FILE:
+			desc = s.File.Name
+		case slack.TYPE_FILE_COMMENT:
+			desc = s.File.Name + " - " + s.Comment.Comment
+		case slack.TYPE_CHANNEL, slack.TYPE_IM, slack.TYPE_GROUP:
+			desc = s.Channel
+		}
+		fmt.Printf("Starred %s: %s\n", s.Type, desc)
+	}
+}

--- a/item.go
+++ b/item.go
@@ -4,6 +4,9 @@ const (
 	TYPE_MESSAGE      = "message"
 	TYPE_FILE         = "file"
 	TYPE_FILE_COMMENT = "file_comment"
+	TYPE_CHANNEL      = "channel"
+	TYPE_IM           = "im"
+	TYPE_GROUP        = "group"
 )
 
 // Item is any type of slack message - message, file, or file comment.
@@ -28,6 +31,21 @@ func NewFileItem(f *File) Item {
 // NewFileCommentItem turns a file and comment into a typed file_comment struct.
 func NewFileCommentItem(f *File, c *Comment) Item {
 	return Item{Type: TYPE_FILE_COMMENT, File: f, Comment: c}
+}
+
+// NewChannelItem turns a channel id into a typed channel struct.
+func NewChannelItem(ch string) Item {
+	return Item{Type: TYPE_CHANNEL, Channel: ch}
+}
+
+// NewIMItem turns a channel id into a typed im struct.
+func NewIMItem(ch string) Item {
+	return Item{Type: TYPE_IM, Channel: ch}
+}
+
+// NewGroupItem turns a channel id into a typed group struct.
+func NewGroupItem(ch string) Item {
+	return Item{Type: TYPE_GROUP, Channel: ch}
 }
 
 // ItemRef is a reference to a message of any type. One of FileID,

--- a/item_test.go
+++ b/item_test.go
@@ -43,6 +43,39 @@ func TestNewFileCommentItem(t *testing.T) {
 	}
 }
 
+func TestNewChannelItem(t *testing.T) {
+	c := "C1"
+	ci := NewChannelItem(c)
+	if ci.Type != TYPE_CHANNEL {
+		t.Errorf("got Type %s, want %s", ci.Type, TYPE_CHANNEL)
+	}
+	if ci.Channel != "C1" {
+		t.Errorf("got Channel %v, want %v", ci.Channel, "C1")
+	}
+}
+
+func TestNewIMItem(t *testing.T) {
+	c := "D1"
+	ci := NewIMItem(c)
+	if ci.Type != TYPE_IM {
+		t.Errorf("got Type %s, want %s", ci.Type, TYPE_IM)
+	}
+	if ci.Channel != "D1" {
+		t.Errorf("got Channel %v, want %v", ci.Channel, "D1")
+	}
+}
+
+func TestNewGroupItem(t *testing.T) {
+	c := "G1"
+	ci := NewGroupItem(c)
+	if ci.Type != TYPE_GROUP {
+		t.Errorf("got Type %s, want %s", ci.Type, TYPE_GROUP)
+	}
+	if ci.Channel != "G1" {
+		t.Errorf("got Channel %v, want %v", ci.Channel, "G1")
+	}
+}
+
 func TestNewRefToMessage(t *testing.T) {
 	ref := NewRefToMessage("chan", "ts")
 	if got, want := ref.ChannelId, "chan"; got != want {

--- a/stars.go
+++ b/stars.go
@@ -18,14 +18,9 @@ type StarsParameters struct {
 	Page  int
 }
 
-// TODO: Verify this. The whole thing is complicated. I don't like the way they mixed things
-// It also appears to be a bug in parsing the message
+// StarredItem is an item that has been starred.
 type StarredItem struct {
-	Type      string `json:"type"`
-	ChannelId string `json:"channel"`
-	Message   `json:"message,omitempty"`
-	File      `json:"file,omitempty"`
-	Comment   `json:"comment,omitempty"`
+	Item
 }
 
 type starsResponseFull struct {
@@ -53,7 +48,6 @@ func NewStarsParameters() StarsParameters {
 //        }
 //    }
 func (api *Slack) GetStarred(params StarsParameters) ([]StarredItem, *Paging, error) {
-	response := &starsResponseFull{}
 	values := url.Values{
 		"token": {api.config.token},
 	}
@@ -66,6 +60,7 @@ func (api *Slack) GetStarred(params StarsParameters) ([]StarredItem, *Paging, er
 	if params.Page != DEFAULT_STARS_PAGE {
 		values.Add("page", strconv.Itoa(params.Page))
 	}
+	response := &starsResponseFull{}
 	err := parseResponse("stars.list", values, response, api.debug)
 	if err != nil {
 		return nil, nil, err

--- a/stars_test.go
+++ b/stars_test.go
@@ -15,19 +15,38 @@ var starsTests = struct {
     "items": [
         {
             "type": "message",
-            "channel": "C2147483705"
+            "channel": "C2147483705",
+            "message": {
+                "text": "hello"
+            }
         },
         {
-            "type": "file"
+            "type": "file",
+            "file": {
+                "name": "toy"
+            }
         },
         {
-            "type": "file_comment"
+            "type": "file_comment",
+            "file": {
+                "name": "toy"
+            },
+            "comment": {
+                "comment": "nice"
+            }
         },
         {
             "type": "channel",
             "channel": "C2147483705"
+        },
+        {
+            "type": "im",
+            "channel": "D1"
+        },
+        {
+            "type": "group",
+            "channel": "G1"
         }
-
     ],
     "paging": {
         "count": 100,
@@ -36,20 +55,12 @@ var starsTests = struct {
         "pages": 1
     }}`),
 	[]StarredItem{
-		{
-			Type:      "message",
-			ChannelId: "C2147483705",
-		},
-		{
-			Type: "file",
-		},
-		{
-			Type: "file_comment",
-		},
-		{
-			Type:      "channel",
-			ChannelId: "C2147483705",
-		},
+		{Item: NewMessageItem("C2147483705", &Message{Msg: Msg{Text: "hello"}})},
+		{Item: NewFileItem(&File{Name: "toy"})},
+		{Item: NewFileCommentItem(&File{Name: "toy"}, &Comment{Comment: "nice"})},
+		{Item: NewChannelItem("C2147483705")},
+		{Item: NewIMItem("D1")},
+		{Item: NewGroupItem("G1")},
 	},
 	&Paging{
 		Count: 100,

--- a/stars_test.go
+++ b/stars_test.go
@@ -6,12 +6,26 @@ import (
 	"testing"
 )
 
-var starsTests = struct {
-	in        []byte
-	outItems  []StarredItem
-	outPaging *Paging
-}{
-	[]byte(`{"ok": true,
+type starsHandler struct {
+	response string
+}
+
+func (rh *starsHandler) handler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte(rh.response))
+}
+
+func TestSlack_GetStarred(t *testing.T) {
+	once.Do(startServer)
+	SLACK_API = "http://" + serverAddr + "/"
+	api := New("testing-token")
+	tests := []struct {
+		json         string
+		starredItems []StarredItem
+		paging       *Paging
+	}{
+		{
+			`{"ok": true,
     "items": [
         {
             "type": "message",
@@ -53,46 +67,37 @@ var starsTests = struct {
         "total": 4,
         "page": 1,
         "pages": 1
-    }}`),
-	[]StarredItem{
-		{Item: NewMessageItem("C2147483705", &Message{Msg: Msg{Text: "hello"}})},
-		{Item: NewFileItem(&File{Name: "toy"})},
-		{Item: NewFileCommentItem(&File{Name: "toy"}, &Comment{Comment: "nice"})},
-		{Item: NewChannelItem("C2147483705")},
-		{Item: NewIMItem("D1")},
-		{Item: NewGroupItem("G1")},
-	},
-	&Paging{
-		Count: 100,
-		Total: 4,
-		Page:  1,
-		Pages: 1,
-	},
-}
-
-func getStarredHandler(rw http.ResponseWriter, r *http.Request) {
-	rw.Header().Set("Content-Type", "application/json")
-	// XXX: I stripped the actual content just to test this test Oo
-	// At some point I should add valid content here
-	rw.Write(starsTests.in)
-}
-
-func TestGetStarred(t *testing.T) {
-	http.HandleFunc("/stars.list", getStarredHandler)
-	once.Do(startServer)
-	SLACK_API = "http://" + serverAddr + "/"
-	api := New("testing-token")
-	response_items, response_paging, err := api.GetStarred(NewStarsParameters())
-	if err != nil {
-		t.Errorf("Unexpected error: %s", err)
-		return
+    }}`,
+			[]StarredItem{
+				{Item: NewMessageItem("C2147483705", &Message{Msg: Msg{Text: "hello"}})},
+				{Item: NewFileItem(&File{Name: "toy"})},
+				{Item: NewFileCommentItem(&File{Name: "toy"}, &Comment{Comment: "nice"})},
+				{Item: NewChannelItem("C2147483705")},
+				{Item: NewIMItem("D1")},
+				{Item: NewGroupItem("G1")},
+			},
+			&Paging{
+				Count: 100,
+				Total: 4,
+				Page:  1,
+				Pages: 1,
+			},
+		},
 	}
-	eq := reflect.DeepEqual(response_items, starsTests.outItems)
-	if !eq {
-		t.Errorf("got %v; want %v", response_items, starsTests.outItems)
-	}
-	eq = reflect.DeepEqual(response_paging, starsTests.outPaging)
-	if !eq {
-		t.Errorf("got %v; want %v", response_paging, starsTests.outPaging)
+	var sh *starsHandler
+	http.HandleFunc("/stars.list", func(w http.ResponseWriter, r *http.Request) { sh.handler(w, r) })
+	for i, test := range tests {
+		sh = &starsHandler{}
+		sh.response = test.json
+		response_items, response_paging, err := api.GetStarred(NewStarsParameters())
+		if err != nil {
+			t.Fatalf("%d Unexpected error: %s", i, err)
+		}
+		if !reflect.DeepEqual(response_items, test.starredItems) {
+			t.Errorf("%d got %v; want %v", i, response_items, test.starredItems)
+		}
+		if !reflect.DeepEqual(response_paging, test.paging) {
+			t.Errorf("%d got %v; want %v", i, response_paging, test.paging)
+		}
 	}
 }


### PR DESCRIPTION
**WIP until #31 is merged**. Here is the [incremental diff](https://github.com/rcarver/slack/compare/rc-reactions...rcarver:rc-stars).

This refactors the `GetStarred` implementation and tests to mirror the approach used for reactions. 

As far as I can tell, reactions and stars are the two things that can be applied to many different types of things. By implementing them similarly it will be easier to iterate over lists of starred or reacted to items.
