### PR TITLE
Fix Redundancy In Conversation Types (IM / Channel / Group)

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -18,7 +18,7 @@ type channelResponseFull struct {
 
 // Channel contains information about the channel
 type Channel struct {
-	BaseGroupConversation
+	groupConversation
 	IsChannel bool `json:"is_channel"`
 	IsGeneral bool `json:"is_general"`
 	IsMember  bool `json:"is_member"`

--- a/channels.go
+++ b/channels.go
@@ -16,46 +16,12 @@ type channelResponseFull struct {
 	SlackResponse
 }
 
-// ChannelTopic contains information about the channel topic
-type ChannelTopic struct {
-	Value   string   `json:"value"`
-	Creator string   `json:"creator"`
-	LastSet JSONTime `json:"last_set"`
-}
-
-// ChannelPurpose contains information about the channel purpose
-type ChannelPurpose struct {
-	Value   string   `json:"value"`
-	Creator string   `json:"creator"`
-	LastSet JSONTime `json:"last_set"`
-}
-
-type baseChannel struct {
-	ID                 string   `json:"id"`
-	Created            JSONTime `json:"created"`
-	IsOpen             bool     `json:"is_open"`
-	LastRead           string   `json:"last_read,omitempty"`
-	Latest             Message  `json:"latest,omitempty"`
-	UnreadCount        int      `json:"unread_count,omitempty"`
-	UnreadCountDisplay int      `json:"unread_count_display,omitempty"`
-}
-
 // Channel contains information about the channel
 type Channel struct {
-	baseChannel
-	Name        string         `json:"name"`
-	IsChannel   bool           `json:"is_channel"`
-	Creator     string         `json:"creator"`
-	IsArchived  bool           `json:"is_archived"`
-	IsGeneral   bool           `json:"is_general"`
-	Members     []string       `json:"members"`
-	Topic       ChannelTopic   `json:"topic"`
-	Purpose     ChannelPurpose `json:"purpose"`
-	IsMember    bool           `json:"is_member"`
-	LastRead    string         `json:"last_read,omitempty"`
-	Latest      *Message       `json:"latest,omitempty"`
-	UnreadCount int            `json:"unread_count,omitempty"`
-	NumMembers  int            `json:"num_members,omitempty"`
+	BaseGroupConversation
+	IsChannel bool `json:"is_channel"`
+	IsGeneral bool `json:"is_general"`
+	IsMember  bool `json:"is_member"`
 }
 
 func channelRequest(path string, values url.Values, debug bool) (*channelResponseFull, error) {

--- a/conversation.go
+++ b/conversation.go
@@ -1,7 +1,7 @@
 package slack
 
-// BaseConversation is the foundation for IM and BaseGroupConversation
-type BaseConversation struct {
+// Conversation is the foundation for IM and BaseGroupConversation
+type conversation struct {
 	ID                 string   `json:"id"`
 	Created            JSONTime `json:"created"`
 	IsOpen             bool     `json:"is_open"`
@@ -11,9 +11,9 @@ type BaseConversation struct {
 	UnreadCountDisplay int      `json:"unread_count_display,omitempty"`
 }
 
-// BaseGroupConversation is the foundation for Group and Channel
-type BaseGroupConversation struct {
-	BaseConversation
+// GroupConversation is the foundation for Group and Channel
+type groupConversation struct {
+	conversation
 	Name       string   `json:"name"`
 	Creator    string   `json:"creator"`
 	IsArchived bool     `json:"is_archived"`

--- a/conversation.go
+++ b/conversation.go
@@ -1,0 +1,38 @@
+package slack
+
+// BaseConversation is the foundation for IM and BaseGroupConversation
+type BaseConversation struct {
+	ID                 string   `json:"id"`
+	Created            JSONTime `json:"created"`
+	IsOpen             bool     `json:"is_open"`
+	LastRead           string   `json:"last_read,omitempty"`
+	Latest             *Message `json:"latest,omitempty"`
+	UnreadCount        int      `json:"unread_count,omitempty"`
+	UnreadCountDisplay int      `json:"unread_count_display,omitempty"`
+}
+
+// BaseGroupConversation is the foundation for Group and Channel
+type BaseGroupConversation struct {
+	BaseConversation
+	Name       string   `json:"name"`
+	Creator    string   `json:"creator"`
+	IsArchived bool     `json:"is_archived"`
+	Members    []string `json:"members"`
+	NumMembers int      `json:"num_members,omitempty"`
+	Topic      Topic    `json:"topic"`
+	Purpose    Purpose  `json:"purpose"`
+}
+
+// Topic contains information about the topic
+type Topic struct {
+	Value   string   `json:"value"`
+	Creator string   `json:"creator"`
+	LastSet JSONTime `json:"last_set"`
+}
+
+// Purpose contains information about the purpose
+type Purpose struct {
+	Value   string   `json:"value"`
+	Creator string   `json:"creator"`
+	LastSet JSONTime `json:"last_set"`
+}

--- a/conversation_test.go
+++ b/conversation_test.go
@@ -1,0 +1,200 @@
+package slack
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Channel
+var simpleChannel = `{
+    "id": "C024BE91L",
+    "name": "fun",
+    "is_channel": true,
+    "created": 1360782804,
+    "creator": "U024BE7LH",
+    "is_archived": false,
+    "is_general": false,
+    "members": [
+        "U024BE7LH"
+    ],
+    "topic": {
+        "value": "Fun times",
+        "creator": "U024BE7LV",
+        "last_set": 1369677212
+    },
+    "purpose": {
+        "value": "This channel is for fun",
+        "creator": "U024BE7LH",
+        "last_set": 1360782804
+    },
+    "is_member": true,
+    "last_read": "1401383885.000061",
+    "unread_count": 0,
+    "unread_count_display": 0
+}`
+
+func unmarshalChannel(j string) (*Channel, error) {
+	channel := &Channel{}
+	if err := json.Unmarshal([]byte(j), &channel); err != nil {
+		return nil, err
+	}
+	return channel, nil
+}
+
+func TestSimpleChannel(t *testing.T) {
+	channel, err := unmarshalChannel(simpleChannel)
+	assert.Nil(t, err)
+	assertSimpleChannel(t, channel)
+}
+
+func assertSimpleChannel(t *testing.T, channel *Channel) {
+	assert.NotNil(t, channel)
+	assert.Equal(t, "C024BE91L", channel.ID)
+	assert.Equal(t, "fun", channel.Name)
+	assert.Equal(t, true, channel.IsChannel)
+	assert.Equal(t, JSONTime(1360782804), channel.Created)
+	assert.Equal(t, "U024BE7LH", channel.Creator)
+	assert.Equal(t, false, channel.IsArchived)
+	assert.Equal(t, false, channel.IsGeneral)
+	assert.Equal(t, true, channel.IsMember)
+	assert.Equal(t, "1401383885.000061", channel.LastRead)
+	assert.Equal(t, 0, channel.UnreadCount)
+	assert.Equal(t, 0, channel.UnreadCountDisplay)
+}
+
+func TestCreateSimpleChannel(t *testing.T) {
+	channel := &Channel{}
+	channel.ID = "C024BE91L"
+	channel.Name = "fun"
+	channel.IsChannel = true
+	channel.Created = JSONTime(1360782804)
+	channel.Creator = "U024BE7LH"
+	channel.IsArchived = false
+	channel.IsGeneral = false
+	channel.IsMember = true
+	channel.LastRead = "1401383885.000061"
+	channel.UnreadCount = 0
+	channel.UnreadCountDisplay = 0
+	assertSimpleChannel(t, channel)
+}
+
+// Group
+var simpleGroup = `{
+    "id": "G024BE91L",
+    "name": "secretplans",
+    "is_group": true,
+    "created": 1360782804,
+    "creator": "U024BE7LH",
+    "is_archived": false,
+    "members": [
+        "U024BE7LH"
+    ],
+    "topic": {
+        "value": "Secret plans on hold",
+        "creator": "U024BE7LV",
+        "last_set": 1369677212
+    },
+    "purpose": {
+        "value": "Discuss secret plans that no-one else should know",
+        "creator": "U024BE7LH",
+        "last_set": 1360782804
+    },
+    "last_read": "1401383885.000061",
+    "unread_count": 0,
+    "unread_count_display": 0
+}`
+
+func unmarshalGroup(j string) (*Group, error) {
+	group := &Group{}
+	if err := json.Unmarshal([]byte(j), &group); err != nil {
+		return nil, err
+	}
+	return group, nil
+}
+
+func TestSimpleGroup(t *testing.T) {
+	group, err := unmarshalGroup(simpleGroup)
+	assert.Nil(t, err)
+	assertSimpleGroup(t, group)
+}
+
+func assertSimpleGroup(t *testing.T, group *Group) {
+	assert.NotNil(t, group)
+	assert.Equal(t, "G024BE91L", group.ID)
+	assert.Equal(t, "secretplans", group.Name)
+	assert.Equal(t, true, group.IsGroup)
+	assert.Equal(t, JSONTime(1360782804), group.Created)
+	assert.Equal(t, "U024BE7LH", group.Creator)
+	assert.Equal(t, false, group.IsArchived)
+	assert.Equal(t, "1401383885.000061", group.LastRead)
+	assert.Equal(t, 0, group.UnreadCount)
+	assert.Equal(t, 0, group.UnreadCountDisplay)
+}
+
+func TestCreateSimpleGroup(t *testing.T) {
+	group := &Group{}
+	group.ID = "G024BE91L"
+	group.Name = "secretplans"
+	group.IsGroup = true
+	group.Created = JSONTime(1360782804)
+	group.Creator = "U024BE7LH"
+	group.IsArchived = false
+	group.LastRead = "1401383885.000061"
+	group.UnreadCount = 0
+	group.UnreadCountDisplay = 0
+	assertSimpleGroup(t, group)
+}
+
+// IM
+var simpleIM = `{
+    "id": "D024BFF1M",
+    "is_im": true,
+    "user": "U024BE7LH",
+    "created": 1360782804,
+    "is_user_deleted": false,
+    "is_open": true,
+    "last_read": "1401383885.000061",
+    "unread_count": 0,
+    "unread_count_display": 0
+}`
+
+func unmarshalIM(j string) (*IM, error) {
+	im := &IM{}
+	if err := json.Unmarshal([]byte(j), &im); err != nil {
+		return nil, err
+	}
+	return im, nil
+}
+
+func TestSimpleIM(t *testing.T) {
+	im, err := unmarshalIM(simpleIM)
+	assert.Nil(t, err)
+	assertSimpleIM(t, im)
+}
+
+func assertSimpleIM(t *testing.T, im *IM) {
+	assert.NotNil(t, im)
+	assert.Equal(t, "D024BFF1M", im.ID)
+	assert.Equal(t, true, im.IsIM)
+	assert.Equal(t, JSONTime(1360782804), im.Created)
+	assert.Equal(t, false, im.IsUserDeleted)
+	assert.Equal(t, true, im.IsOpen)
+	assert.Equal(t, "1401383885.000061", im.LastRead)
+	assert.Equal(t, 0, im.UnreadCount)
+	assert.Equal(t, 0, im.UnreadCountDisplay)
+}
+
+func TestCreateSimpleIM(t *testing.T) {
+	im := &IM{}
+	im.ID = "D024BFF1M"
+	im.IsIM = true
+	im.Created = JSONTime(1360782804)
+	im.IsUserDeleted = false
+	im.IsOpen = true
+	im.LastRead = "1401383885.000061"
+	im.UnreadCount = 0
+	im.UnreadCountDisplay = 0
+	assertSimpleIM(t, im)
+}

--- a/examples/websocket/websocket.go
+++ b/examples/websocket/websocket.go
@@ -15,7 +15,7 @@ func main() {
 	api.SetDebug(true)
 	wsAPI, err := api.StartRTM("", "http://example.com")
 	if err != nil {
-		fmt.Errorf("%s\n", err)
+		_ = fmt.Errorf("%s\n", err)
 	}
 	go wsAPI.HandleIncomingEvents(chReceiver)
 	go wsAPI.Keepalive(20 * time.Second)

--- a/groups.go
+++ b/groups.go
@@ -8,7 +8,7 @@ import (
 
 // Group contains all the information for a group
 type Group struct {
-	BaseGroupConversation
+	groupConversation
 	IsGroup bool `json:"is_group"`
 }
 

--- a/groups.go
+++ b/groups.go
@@ -8,20 +8,8 @@ import (
 
 // Group contains all the information for a group
 type Group struct {
-	baseChannel
-	Name               string         `json:"name"`
-	IsGroup            bool           `json:"is_group"`
-	Creator            string         `json:"creator"`
-	IsArchived         bool           `json:"is_archived"`
-	IsOpen             bool           `json:"is_open,omitempty"`
-	Members            []string       `json:"members"`
-	Topic              ChannelTopic   `json:"topic"`
-	Purpose            ChannelPurpose `json:"purpose"`
-	LastRead           string         `json:"last_read,omitempty"`
-	Latest             *Message       `json:"latest,omitempty"`
-	UnreadCount        int            `json:"unread_count,omitempty"`
-	NumMembers         int            `json:"num_members,omitempty"`
-	UnreadCountDisplay int            `json:"unread_count_display,omitempty"`
+	BaseGroupConversation
+	IsGroup bool `json:"is_group"`
 }
 
 type groupResponseFull struct {

--- a/im.go
+++ b/im.go
@@ -22,7 +22,7 @@ type imResponseFull struct {
 
 // IM contains information related to the Direct Message channel
 type IM struct {
-	BaseConversation
+	conversation
 	IsIM          bool   `json:"is_im"`
 	User          string `json:"user"`
 	IsUserDeleted bool   `json:"is_user_deleted"`

--- a/im.go
+++ b/im.go
@@ -22,7 +22,7 @@ type imResponseFull struct {
 
 // IM contains information related to the Direct Message channel
 type IM struct {
-	baseChannel
+	BaseConversation
 	IsIM          bool   `json:"is_im"`
 	User          string `json:"user"`
 	IsUserDeleted bool   `json:"is_user_deleted"`

--- a/messages.go
+++ b/messages.go
@@ -23,6 +23,7 @@ type Msg struct {
 	Text        string       `json:"text,omitempty"`
 	Timestamp   string       `json:"ts,omitempty"`
 	IsStarred   bool         `json:"is_starred,omitempty"`
+	PinnedTo    []string     `json:"pinned_to, omitempty"`
 	Attachments []Attachment `json:"attachments,omitempty"`
 	Edited      *Edited      `json:"edited,omitempty"`
 

--- a/websocket.go
+++ b/websocket.go
@@ -14,8 +14,10 @@ import (
 	"golang.org/x/net/websocket"
 )
 
+// MessageEvent represents the Message event
 type MessageEvent Message
 
+// WS contains websocket metadata
 type WS struct {
 	conn      *websocket.Conn
 	messageID int
@@ -32,21 +34,25 @@ type AckMessage struct {
 	WSResponse
 }
 
+// WSResponse is a websocket response
 type WSResponse struct {
 	Ok    bool     `json:"ok"`
 	Error *WSError `json:"error"`
 }
 
+// WSError is a websocket error
 type WSError struct {
 	Code int
 	Msg  string
 }
 
+// SlackEvent is a Slack event
 type SlackEvent struct {
 	Type uint64
 	Data interface{}
 }
 
+// JSONTimeString is a JSON unix timestamp
 type JSONTimeString string
 
 // String converts the unix timestamp into a string

--- a/websocket_channels.go
+++ b/websocket_channels.go
@@ -1,24 +1,28 @@
 package slack
 
+// ChannelCreatedEvent represents the Channel created event
 type ChannelCreatedEvent struct {
 	Type           string             `json:"type"`
 	Channel        ChannelCreatedInfo `json:"channel"`
 	EventTimestamp JSONTimeString     `json:"event_ts"`
 }
 
+// ChannelCreatedInfo represents the information associated with the Channel created event
 type ChannelCreatedInfo struct {
-	Id        string `json:"id"`
+	ID        string `json:"id"`
 	IsChannel bool   `json:"is_channel"`
 	Name      string `json:"name"`
 	Created   int    `json:"created"`
 	Creator   string `json:"creator"`
 }
 
+// ChannelJoinedEvent represents the Channel joined event
 type ChannelJoinedEvent struct {
 	Type    string  `json:"type"`
 	Channel Channel `json:"channel"`
 }
 
+// ChannelInfoEvent represents the Channel info event
 type ChannelInfoEvent struct {
 	// channel_left
 	// channel_deleted
@@ -30,17 +34,20 @@ type ChannelInfoEvent struct {
 	Timestamp *JSONTimeString `json:"ts,omitempty"`
 }
 
+// ChannelRenameEvent represents the Channel rename event
 type ChannelRenameEvent struct {
 	Type    string            `json:"type"`
 	Channel ChannelRenameInfo `json:"channel"`
 }
 
+// ChannelRenameInfo represents the information associated with a Channel rename event
 type ChannelRenameInfo struct {
 	ID      string         `json:"id"`
 	Name    string         `json:"name"`
 	Created JSONTimeString `json:"created"`
 }
 
+// ChannelHistoryChangedEvent represents the Channel history changed event
 type ChannelHistoryChangedEvent struct {
 	Type           string         `json:"type"`
 	Latest         JSONTimeString `json:"latest"`
@@ -48,8 +55,17 @@ type ChannelHistoryChangedEvent struct {
 	EventTimestamp JSONTimeString `json:"event_ts"`
 }
 
+// ChannelMarkedEvent represents the Channel marked event
 type ChannelMarkedEvent ChannelInfoEvent
+
+// ChannelLeftEvent represents the Channel left event
 type ChannelLeftEvent ChannelInfoEvent
+
+// ChannelDeletedEvent represents the Channel deleted event
 type ChannelDeletedEvent ChannelInfoEvent
+
+// ChannelArchiveEvent represents the Channel archive event
 type ChannelArchiveEvent ChannelInfoEvent
+
+// ChannelUnarchiveEvent represents the Channel unarchive event
 type ChannelUnarchiveEvent ChannelInfoEvent

--- a/websocket_dm.go
+++ b/websocket_dm.go
@@ -1,13 +1,23 @@
 package slack
 
+// IMCreatedEvent represents the IM created event
 type IMCreatedEvent struct {
 	Type    string             `json:"type"`
 	User    string             `json:"user"`
 	Channel ChannelCreatedInfo `json:"channel"`
 }
 
+// IMHistoryChangedEvent represents the IM history changed event
 type IMHistoryChangedEvent ChannelHistoryChangedEvent
+
+// IMOpenEvent represents the IM open event
 type IMOpenEvent ChannelInfoEvent
+
+// IMCloseEvent represents the IM close event
 type IMCloseEvent ChannelInfoEvent
+
+// IMMarkedEvent represents the IM marked event
 type IMMarkedEvent ChannelInfoEvent
+
+// IMMarkedHistoryChanged represents the IM marked history changed event
 type IMMarkedHistoryChanged ChannelInfoEvent

--- a/websocket_files.go
+++ b/websocket_files.go
@@ -1,5 +1,6 @@
 package slack
 
+// FileActionEvent represents the File action event
 type fileActionEvent struct {
 	Type           string         `json:"type"`
 	EventTimestamp JSONTimeString `json:"event_ts"`
@@ -8,24 +9,40 @@ type fileActionEvent struct {
 	FileID string `json:"file_id,omitempty"`
 }
 
+// FileCreatedEvent represents the File created event
 type FileCreatedEvent fileActionEvent
+
+// FileSharedEvent represents the File shared event
 type FileSharedEvent fileActionEvent
+
+// FilePublicEvent represents the File public event
 type FilePublicEvent fileActionEvent
+
+// FileUnsharedEvent represents the File unshared event
 type FileUnsharedEvent fileActionEvent
+
+// FileChangeEvent represents the File change event
 type FileChangeEvent fileActionEvent
+
+// FileDeletedEvent represents the File deleted event
 type FileDeletedEvent fileActionEvent
+
+// FilePrivateEvent represents the File private event
 type FilePrivateEvent fileActionEvent
 
+// FileCommentAddedEvent represents the File comment added event
 type FileCommentAddedEvent struct {
 	fileActionEvent
 	Comment Comment `json:"comment"`
 }
 
+// FileCommentEditedEvent represents the File comment edited event
 type FileCommentEditedEvent struct {
 	fileActionEvent
 	Comment Comment `json:"comment"`
 }
 
+// FileCommentDeletedEvent represents the File comment deleted event
 type FileCommentDeletedEvent struct {
 	fileActionEvent
 	Comment string `json:"comment"`

--- a/websocket_groups.go
+++ b/websocket_groups.go
@@ -1,5 +1,6 @@
 package slack
 
+// GroupCreatedEvent represents the Group created event
 type GroupCreatedEvent struct {
 	Type    string             `json:"type"`
 	User    string             `json:"user"`
@@ -8,12 +9,30 @@ type GroupCreatedEvent struct {
 
 // XXX: Should we really do this? event.Group is probably nicer than event.Channel
 // even though the api returns "channel"
+
+// GroupMarkedEvent represents the Group marked event
 type GroupMarkedEvent ChannelInfoEvent
+
+// GroupOpenEvent represents the Group open event
 type GroupOpenEvent ChannelInfoEvent
+
+// GroupCloseEvent represents the Group close event
 type GroupCloseEvent ChannelInfoEvent
+
+// GroupArchiveEvent represents the Group archive event
 type GroupArchiveEvent ChannelInfoEvent
+
+// GroupUnarchiveEvent represents the Group unarchive event
 type GroupUnarchiveEvent ChannelInfoEvent
+
+// GroupLeftEvent represents the Group left event
 type GroupLeftEvent ChannelInfoEvent
+
+// GroupJoinedEvent represents the Group joined event
 type GroupJoinedEvent ChannelJoinedEvent
+
+// GroupRenameEvent represents the Group rename event
 type GroupRenameEvent ChannelRenameEvent
+
+// GroupHistoryChangedEvent represents the Group history changed event
 type GroupHistoryChangedEvent ChannelHistoryChangedEvent

--- a/websocket_misc.go
+++ b/websocket_misc.go
@@ -7,59 +7,79 @@ import (
 
 // TODO: Probably need an error event
 
+// HelloEvent represents the hello event
 type HelloEvent struct{}
 
+// PresenceChangeEvent represents the presence change event
 type PresenceChangeEvent struct {
 	Type     string `json:"type"`
 	Presence string `json:"presence"`
 	User     string `json:"user"`
 }
 
+// UserTypingEvent represents the user typing event
 type UserTypingEvent struct {
 	Type    string `json:"type"`
 	User    string `json:"user"`
 	Channel string `json:"channel"`
 }
 
+// LatencyReport represents the latency report
 type LatencyReport struct {
 	Value time.Duration
 }
 
+// PrefChangeEvent represents the preference change event
 type PrefChangeEvent struct {
 	Type  string          `json:"type"`
 	Name  string          `json:"name"`
 	Value json.RawMessage `json:"value"`
 }
 
+// ManualPresenceChangeEvent represents the manual presence change event
 type ManualPresenceChangeEvent struct {
 	Type     string `json:"type"`
 	Presence string `json:"presence"`
 }
+
+// UserChangeEvent represents the user change event
 type UserChangeEvent struct {
 	Type string `json:"type"`
 	User User   `json:"user"`
 }
+
+// EmojiChangedEvent represents the emoji changed event
 type EmojiChangedEvent struct {
 	Type           string         `json:"type"`
 	EventTimestamp JSONTimeString `json:"event_ts"`
 }
+
+// CommandsChangedEvent represents the commands changed event
 type CommandsChangedEvent struct {
 	Type           string         `json:"type"`
 	EventTimestamp JSONTimeString `json:"event_ts"`
 }
+
+// EmailDomainChangedEvent represents the email domain changed event
 type EmailDomainChangedEvent struct {
 	Type           string         `json:"type"`
 	EventTimestamp JSONTimeString `json:"event_ts"`
 	EmailDomain    string         `json:"email_domain"`
 }
+
+// BotAddedEvent represents the bot added event
 type BotAddedEvent struct {
 	Type string `json:"type"`
 	Bot  Bot    `json:"bot"`
 }
+
+// BotChangedEvent represents the bot changed event
 type BotChangedEvent struct {
 	Type string `json:"type"`
 	Bot  Bot    `json:"bot"`
 }
+
+// AccountsChangedEvent represents the accounts changed event
 type AccountsChangedEvent struct {
 	Type string `json:"type"`
 }

--- a/websocket_reactions.go
+++ b/websocket_reactions.go
@@ -2,10 +2,14 @@ package slack
 
 type reactionEvent struct {
 	Type           string         `json:"type"`
-	UserId         string         `json:"user"`
+	User           string         `json:"user"`
 	Item           ReactedItem    `json:"item"`
 	Reaction       string         `json:"reaction"`
 	EventTimestamp JSONTimeString `json:"event_ts"`
 }
+
+// ReactionAddedEvent represents the Reaction added event
 type ReactionAddedEvent reactionEvent
+
+// ReactionRemovedEvent represents the Reaction removed event
 type ReactionRemovedEvent reactionEvent

--- a/websocket_stars.go
+++ b/websocket_stars.go
@@ -6,5 +6,9 @@ type starEvent struct {
 	Item           StarredItem    `json:"item"`
 	EventTimestamp JSONTimeString `json:"event_ts"`
 }
+
+// StarAddedEvent represents the Star added event
 type StarAddedEvent starEvent
+
+// StarRemovedEvent represents the Star removed event
 type StarRemovedEvent starEvent

--- a/websocket_teams.go
+++ b/websocket_teams.go
@@ -1,28 +1,33 @@
 package slack
 
+// TeamJoinEvent represents the Team join event
 type TeamJoinEvent struct {
 	Type string `json:"type"`
 	User *User  `json:"user,omitempty"`
 }
 
+// TeamRenameEvent represents the Team rename event
 type TeamRenameEvent struct {
 	Type           string          `json:"type"`
 	Name           string          `json:"name,omitempty"`
 	EventTimestamp *JSONTimeString `json:"event_ts,omitempty"`
 }
 
+// TeamPrefChangeEvent represents the Team preference change event
 type TeamPrefChangeEvent struct {
 	Type  string   `json:"type"`
 	Name  string   `json:"name,omitempty"`
 	Value []string `json:"value,omitempty"`
 }
 
+// TeamDomainChangeEvent represents the Team domain change event
 type TeamDomainChangeEvent struct {
 	Type   string `json:"type"`
 	URL    string `json:"url"`
 	Domain string `json:"domain"`
 }
 
+// TeamMigrationStartedEvent represents the Team migration started event
 type TeamMigrationStartedEvent struct {
 	Type string `json:"type"`
 }


### PR DESCRIPTION
This PR:
- Fixes a merge error from the prior WIP PR that was merged
- Extracts base types for conversation into specific file
- Adds tests for conversation types (IM / Channel / Group)
- Unexports the embedded types
- Rationalizes fields across IM / Channel / Group / Conversation / GroupConversation
