### PR TITLE
GroupConversation: open and centralize some boolean flags.

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -19,9 +19,6 @@ type channelResponseFull struct {
 // Channel contains information about the channel
 type Channel struct {
 	GroupConversation
-	IsChannel bool `json:"is_channel"`
-	IsGeneral bool `json:"is_general"`
-	IsMember  bool `json:"is_member"`
 }
 
 func channelRequest(path string, values url.Values, debug bool) (*channelResponseFull, error) {

--- a/channels.go
+++ b/channels.go
@@ -18,7 +18,7 @@ type channelResponseFull struct {
 
 // Channel contains information about the channel
 type Channel struct {
-	groupConversation
+	GroupConversation
 	IsChannel bool `json:"is_channel"`
 	IsGeneral bool `json:"is_general"`
 	IsMember  bool `json:"is_member"`

--- a/conversation.go
+++ b/conversation.go
@@ -16,6 +16,10 @@ type GroupConversation struct {
 	Conversation
 	Name       string   `json:"name"`
 	Creator    string   `json:"creator"`
+	IsChannel  bool     `json:"is_channel"`
+	IsGroup    bool     `json:"is_group"`
+	IsGeneral  bool     `json:"is_general"`
+	IsMember   bool     `json:"is_member"`
 	IsArchived bool     `json:"is_archived"`
 	Members    []string `json:"members"`
 	NumMembers int      `json:"num_members,omitempty"`

--- a/conversation.go
+++ b/conversation.go
@@ -1,7 +1,7 @@
 package slack
 
 // Conversation is the foundation for IM and BaseGroupConversation
-type conversation struct {
+type Conversation struct {
 	ID                 string   `json:"id"`
 	Created            JSONTime `json:"created"`
 	IsOpen             bool     `json:"is_open"`
@@ -12,8 +12,8 @@ type conversation struct {
 }
 
 // GroupConversation is the foundation for Group and Channel
-type groupConversation struct {
-	conversation
+type GroupConversation struct {
+	Conversation
 	Name       string   `json:"name"`
 	Creator    string   `json:"creator"`
 	IsArchived bool     `json:"is_archived"`

--- a/groups.go
+++ b/groups.go
@@ -8,7 +8,7 @@ import (
 
 // Group contains all the information for a group
 type Group struct {
-	groupConversation
+	GroupConversation
 	IsGroup bool `json:"is_group"`
 }
 

--- a/groups.go
+++ b/groups.go
@@ -9,7 +9,6 @@ import (
 // Group contains all the information for a group
 type Group struct {
 	GroupConversation
-	IsGroup bool `json:"is_group"`
 }
 
 type groupResponseFull struct {

--- a/im.go
+++ b/im.go
@@ -22,7 +22,7 @@ type imResponseFull struct {
 
 // IM contains information related to the Direct Message channel
 type IM struct {
-	conversation
+	Conversation
 	IsIM          bool   `json:"is_im"`
 	User          string `json:"user"`
 	IsUserDeleted bool   `json:"is_user_deleted"`

--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -112,7 +112,7 @@ func (rtm *RTM) startRTMAndDial() (*Info, *websocket.Conn, error) {
 		return nil, nil, err
 	}
 
-	conn, err := websocket.Dial(url, "", "http://api.slack.com")
+	conn, err := websocketProxyDial(url, "http://api.slack.com")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/websocket_proxy.go
+++ b/websocket_proxy.go
@@ -1,0 +1,83 @@
+package slack
+
+import (
+	"crypto/tls"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strings"
+
+	"golang.org/x/net/websocket"
+)
+
+// Taken and reworked from: https://gist.github.com/madmo/8548738
+func websocketHTTPConnect(proxy, urlString string) (net.Conn, error) {
+	p, err := net.Dial("tcp", proxy)
+	if err != nil {
+		return nil, err
+	}
+
+	turl, err := url.Parse(urlString)
+	if err != nil {
+		return nil, err
+	}
+
+	req := http.Request{
+		Method: "CONNECT",
+		URL:    &url.URL{},
+		Host:   turl.Host,
+	}
+
+	cc := httputil.NewProxyClientConn(p, nil)
+	cc.Do(&req)
+	if err != nil && err != httputil.ErrPersistEOF {
+		return nil, err
+	}
+
+	rwc, _ := cc.Hijack()
+
+	return rwc, nil
+}
+
+func websocketProxyDial(urlString, origin string) (ws *websocket.Conn, err error) {
+	if os.Getenv("HTTP_PROXY") == "" {
+		return websocket.Dial(urlString, "", origin)
+	}
+
+	purl, err := url.Parse(os.Getenv("HTTP_PROXY"))
+	if err != nil {
+		return nil, err
+	}
+
+	config, err := websocket.NewConfig(urlString, origin)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := websocketHTTPConnect(purl.Host, urlString)
+	if err != nil {
+		return nil, err
+	}
+
+	switch config.Location.Scheme {
+	case "ws":
+	case "wss":
+		tlsClient := tls.Client(client, &tls.Config{
+			ServerName: strings.Split(config.Location.Host, ":")[0],
+		})
+		err := tlsClient.Handshake()
+		if err != nil {
+			tlsClient.Close()
+			return nil, err
+		}
+		client = tlsClient
+
+	default:
+		return nil, errors.New("invalid websocket schema")
+	}
+
+	return websocket.NewClient(config, client)
+}


### PR DESCRIPTION
In https://github.com/abourget/slick .. I keep references to those channels and conversations, and I sometimes tweak them... I need to be able to create some and keep them updated..

any reasons to keep those internal ?

This is just a proposition.. nothing fixed in stone here..
