### PR TITLE
Add missing fields to the File

### DIFF
--- a/files.go
+++ b/files.go
@@ -23,12 +23,13 @@ type File struct {
 	Created   JSONTime `json:"created"`
 	Timestamp JSONTime `json:"timestamp"`
 
-	Name       string `json:"name"`
-	Title      string `json:"title"`
-	Mimetype   string `json:"mimetype"`
-	Filetype   string `json:"filetype"`
-	PrettyType string `json:"pretty_type"`
-	User       string `json:"user"`
+	Name              string `json:"name"`
+	Title             string `json:"title"`
+	Mimetype          string `json:"mimetype"`
+	ImageExifRotation int    `json:"image_exif_rotation"`
+	Filetype          string `json:"filetype"`
+	PrettyType        string `json:"pretty_type"`
+	User              string `json:"user"`
 
 	Mode         string `json:"mode"`
 	Editable     bool   `json:"editable"`
@@ -37,19 +38,36 @@ type File struct {
 
 	Size int `json:"size"`
 
-	URL                string `json:"url"`
-	URLDownload        string `json:"url_download"`
+	URL                string `json:"url"`          // Deprecated - never set
+	URLDownload        string `json:"url_download"` // Deprecated - never set
 	URLPrivate         string `json:"url_private"`
 	URLPrivateDownload string `json:"url_private_download"`
 
+	OriginalH   int    `json:"original_h"`
+	OriginalW   int    `json:"original_w"`
 	Thumb64     string `json:"thumb_64"`
 	Thumb80     string `json:"thumb_80"`
+	Thumb160    string `json:"thumb_160"`
 	Thumb360    string `json:"thumb_360"`
 	Thumb360Gif string `json:"thumb_360_gif"`
 	Thumb360W   int    `json:"thumb_360_w"`
 	Thumb360H   int    `json:"thumb_360_h"`
+	Thumb480    string `json:"thumb_480"`
+	Thumb480W   int    `json:"thumb_480_w"`
+	Thumb480H   int    `json:"thumb_480_h"`
+	Thumb720    string `json:"thumb_720"`
+	Thumb720W   int    `json:"thumb_720_w"`
+	Thumb720H   int    `json:"thumb_720_h"`
+	Thumb960    string `json:"thumb_960"`
+	Thumb960W   int    `json:"thumb_960_w"`
+	Thumb960H   int    `json:"thumb_960_h"`
+	Thumb1024   string `json:"thumb_1024"`
+	Thumb1024W  int    `json:"thumb_1024_w"`
+	Thumb1024H  int    `json:"thumb_1024_h"`
 
-	Permalink        string `json:"permalink"`
+	Permalink       string `json:"permalink"`
+	PermalinkPublic string `json:"permalink_public"`
+
 	EditLink         string `json:"edit_link"`
 	Preview          string `json:"preview"`
 	PreviewHighlight string `json:"preview_highlight"`
@@ -60,7 +78,9 @@ type File struct {
 	PublicURLShared bool     `json:"public_url_shared"`
 	Channels        []string `json:"channels"`
 	Groups          []string `json:"groups"`
+	IMs             []string `json:"ims"`
 	InitialComment  Comment  `json:"initial_comment"`
+	CommentsCount   int      `json:"comments_count"`
 	NumStars        int      `json:"num_stars"`
 	IsStarred       bool     `json:"is_starred"`
 }


### PR DESCRIPTION
Starting on Jan 4 the Slack API wrt files changed substantially. The blog post outlining the changes is here: https://medium.com/slack-developer-blog/important-changes-to-files-in-the-web-api-eb38f2a9c1e7#.dwnc9pp7o
The information in the blog post is incomplete and in reality the data that comes in over the wire is actually different still. For example there are numerous new thumbnail sizes (is a 1024px file still a "thumbnail"? :).
The PR leaves the now removed `URL` and `URLDownload` members in the `File` struct. I'm happy to remove them if you prefer. It depends on what you think the best way of dealing with such breaking changes is.

The closest equivalent to `URL` is the new `PermalinkPublic` field. It's worth knowing that when such a link is accessed for the first time, the slackbot will mention it in a private message to the user, giving them the option to revoke the permissions on the file (accessing it again yields a 404).
