### PR TITLE
Support full OAauth response (for adding hooks and bot users via OAuth)

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -5,27 +5,50 @@ import (
 	"net/url"
 )
 
-type oAuthResponseFull struct {
-	AccessToken string `json:"access_token"`
-	Scope       string `json:"scope"`
+type OAuthResponseIncomingWebhook struct {
+	URL              string `json:"url"`
+	Channel          string `json:"channel"`
+	ConfigurationURL string `json:"configuration_url"`
+}
+
+type OAuthResponseBot struct {
+	BotUserID      string `json:"bot_user_id"`
+	BotAccessToken string `json:"bot_access_token"`
+}
+
+type OAuthResponse struct {
+	AccessToken     string                       `json:"access_token"`
+	Scope           string                       `json:"scope"`
+	TeamName        string                       `json:"team_name"`
+	TeamID          string                       `json:"team_id"`
+	IncomingWebhook OAuthResponseIncomingWebhook `json:"incoming_webhook"`
+	Bot             OAuthResponseBot             `json:"bot"`
 	SlackResponse
 }
 
 // GetOAuthToken retrieves an AccessToken
 func GetOAuthToken(clientID, clientSecret, code, redirectURI string, debug bool) (accessToken string, scope string, err error) {
+	response, err := GetOAuthResponse(clientID, clientSecret, code, redirectURI, debug)
+	if err != nil {
+		return "", "", err
+	}
+	return response.AccessToken, response.Scope, nil
+}
+
+func GetOAuthResponse(clientID, clientSecret, code, redirectURI string, debug bool) (resp *OAuthResponse, err error) {
 	values := url.Values{
 		"client_id":     {clientID},
 		"client_secret": {clientSecret},
 		"code":          {code},
 		"redirect_uri":  {redirectURI},
 	}
-	response := &oAuthResponseFull{}
+	response := &OAuthResponse{}
 	err = post("oauth.access", values, response, debug)
 	if err != nil {
-		return "", "", err
+		return nil, err
 	}
 	if !response.Ok {
-		return "", "", errors.New(response.Error)
+		return nil, errors.New(response.Error)
 	}
-	return response.AccessToken, response.Scope, nil
+	return response, nil
 }


### PR DESCRIPTION
Because `GetOAuthToken`'s signature is unchanged, this should be fully compatible with existing code that uses `oauth.go`
