### PR TITLE
In other events, the User is not a pointer

### DIFF
--- a/websocket_teams.go
+++ b/websocket_teams.go
@@ -3,7 +3,7 @@ package slack
 // TeamJoinEvent represents the Team join event
 type TeamJoinEvent struct {
 	Type string `json:"type"`
-	User User   `json:"user,omitempty"`
+	User User   `json:"user"`
 }
 
 // TeamRenameEvent represents the Team rename event

--- a/websocket_teams.go
+++ b/websocket_teams.go
@@ -3,7 +3,7 @@ package slack
 // TeamJoinEvent represents the Team join event
 type TeamJoinEvent struct {
 	Type string `json:"type"`
-	User *User  `json:"user,omitempty"`
+	User User   `json:"user,omitempty"`
 }
 
 // TeamRenameEvent represents the Team rename event


### PR DESCRIPTION
For consistency and Least Surprise it's nice if the TeamJoinEvent also returns a `User`.
See https://github.com/nlopes/slack/issues/30
