### PR TITLE
Remove JSONTimeString

### DIFF
--- a/websocket_channels.go
+++ b/websocket_channels.go
@@ -4,7 +4,7 @@ package slack
 type ChannelCreatedEvent struct {
 	Type           string             `json:"type"`
 	Channel        ChannelCreatedInfo `json:"channel"`
-	EventTimestamp JSONTimeString     `json:"event_ts"`
+	EventTimestamp string             `json:"event_ts"`
 }
 
 // ChannelCreatedInfo represents the information associated with the Channel created event
@@ -28,10 +28,10 @@ type ChannelInfoEvent struct {
 	// channel_deleted
 	// channel_archive
 	// channel_unarchive
-	Type      string          `json:"type"`
-	Channel   string          `json:"channel"`
-	User      string          `json:"user,omitempty"`
-	Timestamp *JSONTimeString `json:"ts,omitempty"`
+	Type      string `json:"type"`
+	Channel   string `json:"channel"`
+	User      string `json:"user,omitempty"`
+	Timestamp string `json:"ts,omitempty"`
 }
 
 // ChannelRenameEvent represents the Channel rename event
@@ -43,17 +43,17 @@ type ChannelRenameEvent struct {
 
 // ChannelRenameInfo represents the information associated with a Channel rename event
 type ChannelRenameInfo struct {
-	ID      string          `json:"id"`
-	Name    string          `json:"name"`
-	Created *JSONTimeString `json:"created"`
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Created string `json:"created"`
 }
 
 // ChannelHistoryChangedEvent represents the Channel history changed event
 type ChannelHistoryChangedEvent struct {
-	Type           string         `json:"type"`
-	Latest         JSONTimeString `json:"latest"`
-	Timestamp      JSONTimeString `json:"ts"`
-	EventTimestamp JSONTimeString `json:"event_ts"`
+	Type           string `json:"type"`
+	Latest         string `json:"latest"`
+	Timestamp      string `json:"ts"`
+	EventTimestamp string `json:"event_ts"`
 }
 
 // ChannelMarkedEvent represents the Channel marked event

--- a/websocket_files.go
+++ b/websocket_files.go
@@ -2,9 +2,9 @@ package slack
 
 // FileActionEvent represents the File action event
 type fileActionEvent struct {
-	Type           string         `json:"type"`
-	EventTimestamp JSONTimeString `json:"event_ts"`
-	File           File           `json:"file"`
+	Type           string `json:"type"`
+	EventTimestamp string `json:"event_ts"`
+	File           File   `json:"file"`
 	// FileID is used for FileDeletedEvent
 	FileID string `json:"file_id,omitempty"`
 }

--- a/websocket_misc.go
+++ b/websocket_misc.go
@@ -76,21 +76,21 @@ type UserChangeEvent struct {
 
 // EmojiChangedEvent represents the emoji changed event
 type EmojiChangedEvent struct {
-	Type           string         `json:"type"`
-	EventTimestamp JSONTimeString `json:"event_ts"`
+	Type           string `json:"type"`
+	EventTimestamp string `json:"event_ts"`
 }
 
 // CommandsChangedEvent represents the commands changed event
 type CommandsChangedEvent struct {
-	Type           string         `json:"type"`
-	EventTimestamp JSONTimeString `json:"event_ts"`
+	Type           string `json:"type"`
+	EventTimestamp string `json:"event_ts"`
 }
 
 // EmailDomainChangedEvent represents the email domain changed event
 type EmailDomainChangedEvent struct {
-	Type           string         `json:"type"`
-	EventTimestamp JSONTimeString `json:"event_ts"`
-	EmailDomain    string         `json:"email_domain"`
+	Type           string `json:"type"`
+	EventTimestamp string `json:"event_ts"`
+	EmailDomain    string `json:"email_domain"`
 }
 
 // BotAddedEvent represents the bot added event

--- a/websocket_pins.go
+++ b/websocket_pins.go
@@ -1,12 +1,12 @@
 package slack
 
 type pinEvent struct {
-	Type           string         `json:"type"`
-	User           string         `json:"user"`
-	Item           Item           `json:"item"`
-	Channel        string         `json:"channel_id"`
-	EventTimestamp JSONTimeString `json:"event_ts"`
-	HasPins        bool           `json:"has_pins,omitempty"`
+	Type           string `json:"type"`
+	User           string `json:"user"`
+	Item           Item   `json:"item"`
+	Channel        string `json:"channel_id"`
+	EventTimestamp string `json:"event_ts"`
+	HasPins        bool   `json:"has_pins,omitempty"`
 }
 
 // PinAddedEvent represents the Pin added event

--- a/websocket_reactions.go
+++ b/websocket_reactions.go
@@ -1,11 +1,11 @@
 package slack
 
 type reactionEvent struct {
-	Type           string         `json:"type"`
-	User           string         `json:"user"`
-	Item           ReactedItem    `json:"item"`
-	Reaction       string         `json:"reaction"`
-	EventTimestamp JSONTimeString `json:"event_ts"`
+	Type           string      `json:"type"`
+	User           string      `json:"user"`
+	Item           ReactedItem `json:"item"`
+	Reaction       string      `json:"reaction"`
+	EventTimestamp string      `json:"event_ts"`
 }
 
 // ReactionAddedEvent represents the Reaction added event

--- a/websocket_stars.go
+++ b/websocket_stars.go
@@ -1,10 +1,10 @@
 package slack
 
 type starEvent struct {
-	Type           string         `json:"type"`
-	User           string         `json:"user"`
-	Item           StarredItem    `json:"item"`
-	EventTimestamp JSONTimeString `json:"event_ts"`
+	Type           string      `json:"type"`
+	User           string      `json:"user"`
+	Item           StarredItem `json:"item"`
+	EventTimestamp string      `json:"event_ts"`
 }
 
 // StarAddedEvent represents the Star added event

--- a/websocket_teams.go
+++ b/websocket_teams.go
@@ -8,9 +8,9 @@ type TeamJoinEvent struct {
 
 // TeamRenameEvent represents the Team rename event
 type TeamRenameEvent struct {
-	Type           string          `json:"type"`
-	Name           string          `json:"name,omitempty"`
-	EventTimestamp *JSONTimeString `json:"event_ts,omitempty"`
+	Type           string `json:"type"`
+	Name           string `json:"name,omitempty"`
+	EventTimestamp string `json:"event_ts,omitempty"`
 }
 
 // TeamPrefChangeEvent represents the Team preference change event

--- a/websocket_utils.go
+++ b/websocket_utils.go
@@ -1,38 +1,9 @@
 package slack
 
 import (
-	"fmt"
-	"log"
 	"net"
 	"net/url"
-	"strconv"
-	"time"
 )
-
-// JSONTimeString is an auxiliary type to allow us to format the time as we wish
-type JSONTimeString string
-
-// String converts the unix timestamp into a string
-func (t JSONTimeString) String() string {
-	tm := t.Time()
-	if tm.IsZero() {
-		return ""
-	}
-	return fmt.Sprintf("\"%s\"", tm.Format("Mon Jan _2"))
-}
-
-// Time converts the timestamp string to time.Time
-func (t JSONTimeString) Time() time.Time {
-	if t == "" {
-		return time.Time{}
-	}
-	floatN, err := strconv.ParseFloat(string(t), 64)
-	if err != nil {
-		log.Println("ERROR parsing a JSONTimeString!", err)
-		return time.Time{}
-	}
-	return time.Unix(int64(floatN), 0)
-}
 
 var portMapping = map[string]string{"ws": "80", "wss": "443"}
 


### PR DESCRIPTION
The Slack API docs explicitly states that their funny timestamps are to be treated as a sort of message IDs and are guaranteed to be unique in the channel. In update and delete calls it is necessary to know the timestamp-string or the call will fail. Client code will use these timestamp-strings for things like checking for duplicate messages.

Instead of casting incoming timestamp-strings to (english speaking) human-readable strings like "Sun Jan 31" I think it's wise to let the client do its own formatting and leave the timestamp-strings be.

[Slack docs](https://api.slack.com/rtm):

```
All messages within a single channel are guaranteed to have a unique timestamp which is 
ASCII sortable. Given the precision of the timestamp, clients should treat these timestamps 
as strings, not floats/doubles.
```
