### PR TITLE
reaction item only contains IDs

### DIFF
--- a/websocket_reactions.go
+++ b/websocket_reactions.go
@@ -1,9 +1,18 @@
 package slack
 
+// reactionItem is a lighter-weight item than is returned by the reactions list.
+type reactionItem struct {
+	Type        string `json:"type"`
+	Channel     string `json:"channel,omitempty"`
+	File        string `json:"file,omitempty"`
+	FileComment string `json:"file_comment,omitempty"`
+	Timestamp   string `json:"ts,omitempty"`
+}
+
 type reactionEvent struct {
 	Type           string         `json:"type"`
 	User           string         `json:"user"`
-	Item           ReactedItem    `json:"item"`
+	Item           reactionItem   `json:"item"`
 	Reaction       string         `json:"reaction"`
 	EventTimestamp JSONTimeString `json:"event_ts"`
 }


### PR DESCRIPTION
The `reaction_added` and `reaction_removed` events [do not include](https://api.slack.com/events/reaction_added) the embedded items the same as when retrieving the reaction list.
