### PR TITLE
Handle "reconnect_url" event

### DIFF
--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -419,4 +419,6 @@ var eventMapping = map[string]interface{}{
 	"bot_changed": BotChangedEvent{},
 
 	"accounts_changed": AccountsChangedEvent{},
+
+	"reconnect_url": ReconnectUrlEvent{},
 }

--- a/websocket_misc.go
+++ b/websocket_misc.go
@@ -109,3 +109,9 @@ type BotChangedEvent struct {
 type AccountsChangedEvent struct {
 	Type string `json:"type"`
 }
+
+// ReconnectUrlEvent represents the receiving reconnect url event
+type ReconnectUrlEvent struct {
+	Type string `json:"type"`
+	URL  string `json:"url"`
+}


### PR DESCRIPTION
as of Feb 2016 (or so), slack started to send "reconnect_url" event via RTM API, and this causes unmasharling_error event (which is not desirable). and this will simply handle the event (Slack API documentation still [says nothing](https://api.slack.com/events/reconnect_url) about this event, so just handling the event, not anymore.
