### PR TITLE
Posting message as user shouldn't unfurls links

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -125,6 +125,11 @@ func (api *Client) PostMessage(channel, text string, params PostMessageParameter
 	if params.UnfurlLinks != DEFAULT_MESSAGE_UNFURL_LINKS {
 		values.Set("unfurl_links", "true")
 	}
+	// I want to send a message with explicit `as_user` `true` and `unfurl_links` `false` in request.
+	// Because setting `as_user` to `true` will change the default value for `unfurl_links` to `true` on Slack API side.
+	if params.AsUser != DEFAULT_MESSAGE_ASUSER && params.UnfurlLinks == DEFAULT_MESSAGE_UNFURL_LINKS {
+		values.Set("unfurl_links", "false")
+	}
 	if params.UnfurlMedia != DEFAULT_MESSAGE_UNFURL_MEDIA {
 		values.Set("unfurl_media", "false")
 	}


### PR DESCRIPTION
[Unfurling documentation](https://api.slack.com/docs/unfurling) says that message posted with `chat.postMessage` won't unfurl links:

> For messages posted via webhooks or the chat.postMessage API method, we will unfurl links to media, but not other links.

but posting message `as_user` will unfurl links by default:

> By default we unfurl all links in any messages posted by users. 

I've wrote a message to Slack support, and they said this: 

> I apologize for the confusion in the documentation here. The `By default we unfurl all links in any messages posted by users. referenced in (https://api.slack.com/docs/unfurling)` appears to be overriding the `chat.postMessage` exception when the `as_user` parameter is set to true.

So we should explicitly send `unfurl_links: false` when `as_user: true`. This patch fixes this behaviour.
