### PR TITLE
adding account_inactive to fatal errors during websocket connection

### DIFF
--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -86,7 +86,7 @@ func (rtm *RTM) connect(connectionCount int) (*Info, *websocket.Conn, error) {
 			return info, conn, nil
 		}
 		// check for fatal errors - currently only invalid_auth
-		if sErr, ok := err.(*WebError); ok && sErr.Error() == "invalid_auth" {
+		if sErr, ok := err.(*WebError); ok && (sErr.Error() == "invalid_auth" || sErr.Error() == "account_inactive") {
 			rtm.IncomingEvents <- RTMEvent{"invalid_auth", &InvalidAuthEvent{}}
 			return nil, nil, sErr
 		}


### PR DESCRIPTION
Fixes #65. This accounts for when users de-auth the slack app, and the bot user becomes 'inactive'
