### PR TITLE
Let slack use an external logger

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -77,7 +76,7 @@ func parseResponseBody(body io.ReadCloser, intf *interface{}, debug bool) error 
 
 	// FIXME: will be api.Debugf
 	if debug {
-		log.Printf("parseResponseBody: %s\n", string(response))
+		logger.Printf("parseResponseBody: %s\n", string(response))
 	}
 
 	err = json.Unmarshal(response, &intf)

--- a/slack.go
+++ b/slack.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 )
 
+var logger *log.Logger // A logger that can be set by consumers
 /*
   Added as a var so that we can change this for testing purposes
 */
@@ -38,6 +39,12 @@ type Client struct {
 	debug bool
 }
 
+// SetLogger let's library users supply a logger, so that api debugging
+// can be logged along with the application's debugging info.
+func SetLogger(l *log.Logger) {
+	logger = l
+}
+
 func New(token string) *Client {
 	s := &Client{}
 	s.config.token = token
@@ -66,12 +73,12 @@ func (api *Client) SetDebug(debug bool) {
 
 func (api *Client) Debugf(format string, v ...interface{}) {
 	if api.debug {
-		log.Printf(format, v...)
+		logger.Printf(format, v...)
 	}
 }
 
 func (api *Client) Debugln(v ...interface{}) {
 	if api.debug {
-		log.Println(v...)
+		logger.Println(v...)
 	}
 }

--- a/websocket.go
+++ b/websocket.go
@@ -3,7 +3,6 @@ package slack
 import (
 	"encoding/json"
 	"errors"
-	"log"
 	"time"
 
 	"golang.org/x/net/websocket"
@@ -69,7 +68,7 @@ func (rtm *RTM) Disconnect() error {
 
 // Reconnect only makes sense if you've successfully disconnectd with Disconnect().
 func (rtm *RTM) Reconnect() error {
-	log.Println("RTM::Reconnect not implemented!")
+	logger.Println("RTM::Reconnect not implemented!")
 	return nil
 }
 


### PR DESCRIPTION
I wanted to supply a logger to your lib so I could fold in api debug logs with my chatbots logs. If you'd rather it be a struct member of api, I could do that; there are only a couple of places in the code that don't use api.DebugX.

Thanks for the great lib, made it pretty easy to get gopherbot going.
