### PR TITLE
Groundwork for supporting `usergroups` and `usergroups.users` methods

### DIFF
--- a/usergroups.go
+++ b/usergroups.go
@@ -1,0 +1,83 @@
+package slack
+
+import (
+	"errors"
+	"net/url"
+)
+
+
+// User contains all the information of a user group
+type UserGroup struct {
+	ID                string      `json:"id"`
+  Name              string      `json:"name"`
+  TeamId            string      `json:"team_id"`
+  IsUserGroup       bool        `json:"is_usergroup"`
+  Description       string      `json:"description"`
+  Handle            string      `json:"handle"`
+  IsExternal        bool        `json:"is_external"`
+  AutoType          string      `json:"auto_type"`
+  CreatedBy         string      `json:"created_by"`
+  UpdatedBy         string      `json:"updated_by"`
+  DeletedBy         string      `json:"deleted_by"`
+  Prefs             struct{
+    Channels        []string    `json:"channels"`
+    Groups          []string    `json:"groups"`
+  }                             `json:"prefs"`
+  Users             []string
+  UserCount         int         `json:"user_count"`
+}
+
+type userGroupResponseFull struct {
+  UserGroups   []UserGroup             `json:"usergroups"`
+  UserGroup    UserGroup               `json:"usergroup"`
+	SlackResponse
+}
+
+func userGroupRequest(path string, values url.Values, debug bool) (*userGroupResponseFull, error) {
+	response := &userGroupResponseFull{}
+	err := post(path, values, response, debug)
+	if err != nil {
+		return nil, err
+	}
+	if !response.Ok {
+		return nil, errors.New(response.Error)
+	}
+	return response, nil
+}
+
+// GetUserGroups returns a list of user groups for the team
+func (api *Client) GetUserGroups() ([]UserGroup, error){
+  values := url.Values{
+		"token": {api.config.token},
+	}
+	response, err := userGroupRequest("usergroups.list", values, api.debug)
+	if err != nil {
+		return nil, err
+	}
+	return response.UserGroups, nil
+}
+
+func (api *Client) UpdateUserGroup(userGroup UserGroup) (UserGroup, error){
+  values := url.Values{
+		"token": {api.config.token},
+    "usergroup": {userGroup.ID},
+	}
+
+  if userGroup.Name != ""{
+    values["name"] = []string{userGroup.Name}
+  }
+
+  if userGroup.Handle != ""{
+    values["handle"] = []string{userGroup.Handle}
+  }
+
+  if userGroup.Description != ""{
+    values["description"] = []string{userGroup.Description}
+  }
+
+	response, err := userGroupRequest("usergroups.update", values, api.debug)
+	if err != nil {
+		return UserGroup{}, err
+	}
+	return response.UserGroup, nil
+}

--- a/usergroups.go
+++ b/usergroups.go
@@ -29,6 +29,7 @@ type UserGroup struct {
 type userGroupResponseFull struct {
 	UserGroups []UserGroup `json:"usergroups"`
 	UserGroup  UserGroup   `json:"usergroup"`
+	Users      []string    `json:"users"`
 	SlackResponse
 }
 
@@ -79,6 +80,18 @@ func (api *Client) UpdateUserGroup(userGroup UserGroup) (UserGroup, error) {
 		return UserGroup{}, err
 	}
 	return response.UserGroup, nil
+}
+
+func (api *Client) GetUserGroupMembers(userGroup string) ([]string, error) {
+	values := url.Values{
+		"token":     {api.config.token},
+		"usergroup": {userGroup},
+	}
+	response, err := userGroupRequest("usergroups.users.list", values, api.debug)
+	if err != nil {
+		return []string{}, err
+	}
+	return response.Users, nil
 }
 
 func (api *Client) UpdateUserGroupMembers(userGroup string, members string) (UserGroup, error) {

--- a/usergroups.go
+++ b/usergroups.go
@@ -5,31 +5,30 @@ import (
 	"net/url"
 )
 
-
 // User contains all the information of a user group
 type UserGroup struct {
-	ID                string      `json:"id"`
-  Name              string      `json:"name"`
-  TeamId            string      `json:"team_id"`
-  IsUserGroup       bool        `json:"is_usergroup"`
-  Description       string      `json:"description"`
-  Handle            string      `json:"handle"`
-  IsExternal        bool        `json:"is_external"`
-  AutoType          string      `json:"auto_type"`
-  CreatedBy         string      `json:"created_by"`
-  UpdatedBy         string      `json:"updated_by"`
-  DeletedBy         string      `json:"deleted_by"`
-  Prefs             struct{
-    Channels        []string    `json:"channels"`
-    Groups          []string    `json:"groups"`
-  }                             `json:"prefs"`
-  Users             []string
-  UserCount         int         `json:"user_count"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	TeamId      string `json:"team_id"`
+	IsUserGroup bool   `json:"is_usergroup"`
+	Description string `json:"description"`
+	Handle      string `json:"handle"`
+	IsExternal  bool   `json:"is_external"`
+	AutoType    string `json:"auto_type"`
+	CreatedBy   string `json:"created_by"`
+	UpdatedBy   string `json:"updated_by"`
+	DeletedBy   string `json:"deleted_by"`
+	Prefs       struct {
+		Channels []string `json:"channels"`
+		Groups   []string `json:"groups"`
+	} `json:"prefs"`
+	Users     []string
+	UserCount int `json:"user_count"`
 }
 
 type userGroupResponseFull struct {
-  UserGroups   []UserGroup             `json:"usergroups"`
-  UserGroup    UserGroup               `json:"usergroup"`
+	UserGroups []UserGroup `json:"usergroups"`
+	UserGroup  UserGroup   `json:"usergroup"`
 	SlackResponse
 }
 
@@ -46,8 +45,8 @@ func userGroupRequest(path string, values url.Values, debug bool) (*userGroupRes
 }
 
 // GetUserGroups returns a list of user groups for the team
-func (api *Client) GetUserGroups() ([]UserGroup, error){
-  values := url.Values{
+func (api *Client) GetUserGroups() ([]UserGroup, error) {
+	values := url.Values{
 		"token": {api.config.token},
 	}
 	response, err := userGroupRequest("usergroups.list", values, api.debug)
@@ -57,23 +56,23 @@ func (api *Client) GetUserGroups() ([]UserGroup, error){
 	return response.UserGroups, nil
 }
 
-func (api *Client) UpdateUserGroup(userGroup UserGroup) (UserGroup, error){
-  values := url.Values{
-		"token": {api.config.token},
-    "usergroup": {userGroup.ID},
+func (api *Client) UpdateUserGroup(userGroup UserGroup) (UserGroup, error) {
+	values := url.Values{
+		"token":     {api.config.token},
+		"usergroup": {userGroup.ID},
 	}
 
-  if userGroup.Name != ""{
-    values["name"] = []string{userGroup.Name}
-  }
+	if userGroup.Name != "" {
+		values["name"] = []string{userGroup.Name}
+	}
 
-  if userGroup.Handle != ""{
-    values["handle"] = []string{userGroup.Handle}
-  }
+	if userGroup.Handle != "" {
+		values["handle"] = []string{userGroup.Handle}
+	}
 
-  if userGroup.Description != ""{
-    values["description"] = []string{userGroup.Description}
-  }
+	if userGroup.Description != "" {
+		values["description"] = []string{userGroup.Description}
+	}
 
 	response, err := userGroupRequest("usergroups.update", values, api.debug)
 	if err != nil {
@@ -82,11 +81,11 @@ func (api *Client) UpdateUserGroup(userGroup UserGroup) (UserGroup, error){
 	return response.UserGroup, nil
 }
 
-func (api *Client) UpdateUserGroupMembers(userGroup string, members string) (UserGroup, error){
-  values := url.Values{
-		"token": {api.config.token},
-    "usergroup": {userGroup.ID},
-    "users": {members}
+func (api *Client) UpdateUserGroupMembers(userGroup string, members string) (UserGroup, error) {
+	values := url.Values{
+		"token":     {api.config.token},
+		"usergroup": {userGroup.ID},
+		"users":     {members},
 	}
 
 	response, err := userGroupRequest("usergroups.users.update", values, api.debug)

--- a/usergroups.go
+++ b/usergroups.go
@@ -84,7 +84,7 @@ func (api *Client) UpdateUserGroup(userGroup UserGroup) (UserGroup, error) {
 func (api *Client) UpdateUserGroupMembers(userGroup string, members string) (UserGroup, error) {
 	values := url.Values{
 		"token":     {api.config.token},
-		"usergroup": {userGroup.ID},
+		"usergroup": {userGroup},
 		"users":     {members},
 	}
 

--- a/usergroups.go
+++ b/usergroups.go
@@ -81,3 +81,17 @@ func (api *Client) UpdateUserGroup(userGroup UserGroup) (UserGroup, error){
 	}
 	return response.UserGroup, nil
 }
+
+func (api *Client) UpdateUserGroupMembers(userGroup string, members string) (UserGroup, error){
+  values := url.Values{
+		"token": {api.config.token},
+    "usergroup": {userGroup.ID},
+    "users": {members}
+	}
+
+	response, err := userGroupRequest("usergroups.users.update", values, api.debug)
+	if err != nil {
+		return UserGroup{}, err
+	}
+	return response.UserGroup, nil
+}


### PR DESCRIPTION
RE #63 

Not yet complete but base for the methods
- `usergroups.list`
- `usergroups.update`
- `usergroups.users.list`
- `usergroups.users.update`

I needed these specific functions so prioritised them, but will try to look at adding the rest at some point this week if I get chance, but wanted to shoot this back over anyway.
