### PR TITLE
Fix nil pointer dereference in websocket.go example

### DIFF
--- a/examples/websocket/websocket.go
+++ b/examples/websocket/websocket.go
@@ -2,12 +2,16 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"os"
 
 	"github.com/nlopes/slack"
 )
 
 func main() {
 	api := slack.New("YOUR TOKEN HERE")
+	logger := log.New(os.Stdout, "slack-bot: ", log.Lshortfile|log.LstdFlags)
+	slack.SetLogger(logger)
 	api.SetDebug(true)
 
 	rtm := api.NewRTM()


### PR DESCRIPTION
This fixes RTM example, currently it explodes because the logger is nil

```
$ go run examples/websocket/websocket.go

Event Received: panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x19f836]

goroutine 5 [running]:
panic(0x390d20, 0xc82000a100)
    /usr/local/Cellar/go/1.6.2/libexec/src/runtime/panic.go:481 +0x3e6
log.(*Logger).Output(0x0, 0x2, 0xc820324380, 0x37, 0x0, 0x0)
    /usr/local/Cellar/go/1.6.2/libexec/src/log/log.go:147 +0x4e6
log.(*Logger).Printf(0x0, 0x45cb50, 0x16, 0xc820047b08, 0x1, 0x1)
    /usr/local/Cellar/go/1.6.2/libexec/src/log/log.go:173 +0x7e
github.com/nlopes/slack.parseResponseBody(0x3241088, 0xc820324240, 0xc82000afc0, 0xc820082001, 0x0, 0x0)
    /Users/pavel/Coding/Assembla/breakout.slack-bot/_vendor/src/github.com/nlopes/slack/misc.go:79 +0x238
github.com/nlopes/slack.postForm(0xc8200c07e0, 0x1f, 0xc820014ff0, 0x3be300, 0xc8200c4160, 0xc8200c0701, 0x0, 0x0)
    /Users/pavel/Coding/Assembla/breakout.slack-bot/_vendor/src/github.com/nlopes/slack/misc.go:108 +0x14b
github.com/nlopes/slack.post(0x41dc70, 0x9, 0xc820014ff0, 0x3be300, 0xc8200c4160, 0x1, 0x0, 0x0)
    /Users/pavel/Coding/Assembla/breakout.slack-bot/_vendor/src/github.com/nlopes/slack/misc.go:112 +0xa0
github.com/nlopes/slack.(*Client).StartRTM(0xc820085490, 0x50d50, 0x0, 0x0, 0x0, 0x0)
    /Users/pavel/Coding/Assembla/breakout.slack-bot/_vendor/src/github.com/nlopes/slack/rtm.go:15 +0x1cb
github.com/nlopes/slack.(*RTM).startRTMAndDial(0xc820085440, 0xc82005c300, 0xc820023ef0, 0x0, 0x0)
    /Users/pavel/Coding/Assembla/breakout.slack-bot/_vendor/src/github.com/nlopes/slack/websocket_managed_conn.go:110 +0x47
github.com/nlopes/slack.(*RTM).connect(0xc820085440, 0x1, 0x0, 0x0, 0x0, 0x0)
    /Users/pavel/Coding/Assembla/breakout.slack-bot/_vendor/src/github.com/nlopes/slack/websocket_managed_conn.go:84 +0x19f
github.com/nlopes/slack.(*RTM).ManageConnection(0xc820085440)
    /Users/pavel/Coding/Assembla/breakout.slack-bot/_vendor/src/github.com/nlopes/slack/websocket_managed_conn.go:32 +0x3f
created by main.main
    /Users/pavel/Coding/slack/examples/websocket/websocket.go:18 +0x42a
exit status 2
```
