### PR TITLE
Avoid using globals to expose http.Client

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 )
 
@@ -11,9 +12,9 @@ type adminResponse struct {
 	Error string `json:"error"`
 }
 
-func adminRequest(method string, teamName string, values url.Values, debug bool) (*adminResponse, error) {
+func adminRequest(httpcl *http.Client, method string, teamName string, values url.Values, debug bool) (*adminResponse, error) {
 	adminResponse := &adminResponse{}
-	err := parseAdminResponse(method, teamName, values, adminResponse, debug)
+	err := parseAdminResponse(httpcl, method, teamName, values, adminResponse, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -34,7 +35,7 @@ func (api *Client) DisableUser(teamName string, uid string) error {
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest("setInactive", teamName, values, api.debug)
+	_, err := adminRequest(api.HTTPClient, "setInactive", teamName, values, api.debug)
 	if err != nil {
 		return fmt.Errorf("Failed to disable user with id '%s': %s", uid, err)
 	}
@@ -61,7 +62,7 @@ func (api *Client) InviteGuest(
 		"_attempts":        {"1"},
 	}
 
-	_, err := adminRequest("invite", teamName, values, api.debug)
+	_, err := adminRequest(api.HTTPClient, "invite", teamName, values, api.debug)
 	if err != nil {
 		return fmt.Errorf("Failed to invite single-channel guest: %s", err)
 	}
@@ -88,7 +89,7 @@ func (api *Client) InviteRestricted(
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest("invite", teamName, values, api.debug)
+	_, err := adminRequest(api.HTTPClient, "invite", teamName, values, api.debug)
 	if err != nil {
 		return fmt.Errorf("Failed to restricted account: %s", err)
 	}
@@ -112,7 +113,7 @@ func (api *Client) InviteToTeam(
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest("invite", teamName, values, api.debug)
+	_, err := adminRequest(api.HTTPClient, "invite", teamName, values, api.debug)
 	if err != nil {
 		return fmt.Errorf("Failed to invite to team: %s", err)
 	}
@@ -129,7 +130,7 @@ func (api *Client) SetRegular(teamName string, user string) error {
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest("setRegular", teamName, values, api.debug)
+	_, err := adminRequest(api.HTTPClient, "setRegular", teamName, values, api.debug)
 	if err != nil {
 		return fmt.Errorf("Failed to change the user (%s) to a regular user: %s", user, err)
 	}
@@ -146,7 +147,7 @@ func (api *Client) SendSSOBindingEmail(teamName string, user string) error {
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest("sendSSOBind", teamName, values, api.debug)
+	_, err := adminRequest(api.HTTPClient, "sendSSOBind", teamName, values, api.debug)
 	if err != nil {
 		return fmt.Errorf("Failed to send SSO binding email for user (%s): %s", user, err)
 	}
@@ -164,7 +165,7 @@ func (api *Client) SetUltraRestricted(teamName, uid, channel string) error {
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest("setUltraRestricted", teamName, values, api.debug)
+	_, err := adminRequest(api.HTTPClient, "setUltraRestricted", teamName, values, api.debug)
 	if err != nil {
 		return fmt.Errorf("Failed to ultra-restrict account: %s", err)
 	}
@@ -181,7 +182,7 @@ func (api *Client) SetRestricted(teamName, uid string) error {
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest("setRestricted", teamName, values, api.debug)
+	_, err := adminRequest(api.HTTPClient, "setRestricted", teamName, values, api.debug)
 	if err != nil {
 		return fmt.Errorf("Failed to restrict account: %s", err)
 	}

--- a/attachments.go
+++ b/attachments.go
@@ -10,8 +10,10 @@ type AttachmentField struct {
 
 // Attachment contains all the information for an attachment
 type Attachment struct {
-	Color    string `json:"color,omitempty"`
-	Fallback string `json:"fallback"`
+	Color      string `json:"color,omitempty"`
+	Fallback   string `json:"fallback"`
+	Footer     string `json:"footer"`
+	FooterIcon string `json:"footer_icon"`
 
 	AuthorName    string `json:"author_name,omitempty"`
 	AuthorSubname string `json:"author_subname,omitempty"`

--- a/channels.go
+++ b/channels.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"errors"
+	"net/http"
 	"net/url"
 	"strconv"
 )
@@ -24,9 +25,9 @@ type Channel struct {
 	IsMember  bool `json:"is_member"`
 }
 
-func channelRequest(path string, values url.Values, debug bool) (*channelResponseFull, error) {
+func channelRequest(httpcl *http.Client, path string, values url.Values, debug bool) (*channelResponseFull, error) {
 	response := &channelResponseFull{}
-	err := post(path, values, response, debug)
+	err := post(httpcl, path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +43,7 @@ func (api *Client) ArchiveChannel(channel string) error {
 		"token":   {api.config.token},
 		"channel": {channel},
 	}
-	_, err := channelRequest("channels.archive", values, api.debug)
+	_, err := channelRequest(api.HTTPClient, "channels.archive", values, api.debug)
 	if err != nil {
 		return err
 	}
@@ -55,7 +56,7 @@ func (api *Client) UnarchiveChannel(channel string) error {
 		"token":   {api.config.token},
 		"channel": {channel},
 	}
-	_, err := channelRequest("channels.unarchive", values, api.debug)
+	_, err := channelRequest(api.HTTPClient, "channels.unarchive", values, api.debug)
 	if err != nil {
 		return err
 	}
@@ -68,7 +69,7 @@ func (api *Client) CreateChannel(channel string) (*Channel, error) {
 		"token": {api.config.token},
 		"name":  {channel},
 	}
-	response, err := channelRequest("channels.create", values, api.debug)
+	response, err := channelRequest(api.HTTPClient, "channels.create", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +105,7 @@ func (api *Client) GetChannelHistory(channel string, params HistoryParameters) (
 			values.Add("unreads", "0")
 		}
 	}
-	response, err := channelRequest("channels.history", values, api.debug)
+	response, err := channelRequest(api.HTTPClient, "channels.history", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +118,7 @@ func (api *Client) GetChannelInfo(channel string) (*Channel, error) {
 		"token":   {api.config.token},
 		"channel": {channel},
 	}
-	response, err := channelRequest("channels.info", values, api.debug)
+	response, err := channelRequest(api.HTTPClient, "channels.info", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +132,7 @@ func (api *Client) InviteUserToChannel(channel, user string) (*Channel, error) {
 		"channel": {channel},
 		"user":    {user},
 	}
-	response, err := channelRequest("channels.invite", values, api.debug)
+	response, err := channelRequest(api.HTTPClient, "channels.invite", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +145,7 @@ func (api *Client) JoinChannel(channel string) (*Channel, error) {
 		"token": {api.config.token},
 		"name":  {channel},
 	}
-	response, err := channelRequest("channels.join", values, api.debug)
+	response, err := channelRequest(api.HTTPClient, "channels.join", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +158,7 @@ func (api *Client) LeaveChannel(channel string) (bool, error) {
 		"token":   {api.config.token},
 		"channel": {channel},
 	}
-	response, err := channelRequest("channels.leave", values, api.debug)
+	response, err := channelRequest(api.HTTPClient, "channels.leave", values, api.debug)
 	if err != nil {
 		return false, err
 	}
@@ -174,7 +175,7 @@ func (api *Client) KickUserFromChannel(channel, user string) error {
 		"channel": {channel},
 		"user":    {user},
 	}
-	_, err := channelRequest("channels.kick", values, api.debug)
+	_, err := channelRequest(api.HTTPClient, "channels.kick", values, api.debug)
 	if err != nil {
 		return err
 	}
@@ -189,7 +190,7 @@ func (api *Client) GetChannels(excludeArchived bool) ([]Channel, error) {
 	if excludeArchived {
 		values.Add("exclude_archived", "1")
 	}
-	response, err := channelRequest("channels.list", values, api.debug)
+	response, err := channelRequest(api.HTTPClient, "channels.list", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +208,7 @@ func (api *Client) SetChannelReadMark(channel, ts string) error {
 		"channel": {channel},
 		"ts":      {ts},
 	}
-	_, err := channelRequest("channels.mark", values, api.debug)
+	_, err := channelRequest(api.HTTPClient, "channels.mark", values, api.debug)
 	if err != nil {
 		return err
 	}
@@ -223,7 +224,7 @@ func (api *Client) RenameChannel(channel, name string) (*Channel, error) {
 	}
 	// XXX: the created entry in this call returns a string instead of a number
 	// so I may have to do some workaround to solve it.
-	response, err := channelRequest("channels.rename", values, api.debug)
+	response, err := channelRequest(api.HTTPClient, "channels.rename", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +240,7 @@ func (api *Client) SetChannelPurpose(channel, purpose string) (string, error) {
 		"channel": {channel},
 		"purpose": {purpose},
 	}
-	response, err := channelRequest("channels.setPurpose", values, api.debug)
+	response, err := channelRequest(api.HTTPClient, "channels.setPurpose", values, api.debug)
 	if err != nil {
 		return "", err
 	}
@@ -253,7 +254,7 @@ func (api *Client) SetChannelTopic(channel, topic string) (string, error) {
 		"channel": {channel},
 		"topic":   {topic},
 	}
-	response, err := channelRequest("channels.setTopic", values, api.debug)
+	response, err := channelRequest(api.HTTPClient, "channels.setTopic", values, api.debug)
 	if err != nil {
 		return "", err
 	}

--- a/chat.go
+++ b/chat.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
 	"net/url"
 	"strings"
 )
@@ -60,9 +61,9 @@ func NewPostMessageParameters() PostMessageParameters {
 	}
 }
 
-func chatRequest(path string, values url.Values, debug bool) (*chatResponseFull, error) {
+func chatRequest(httpcl *http.Client, path string, values url.Values, debug bool) (*chatResponseFull, error) {
 	response := &chatResponseFull{}
-	err := post(path, values, response, debug)
+	err := post(httpcl, path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +80,7 @@ func (api *Client) DeleteMessage(channel, messageTimestamp string) (string, stri
 		"channel": {channel},
 		"ts":      {messageTimestamp},
 	}
-	response, err := chatRequest("chat.delete", values, api.debug)
+	response, err := chatRequest(api.HTTPClient, "chat.delete", values, api.debug)
 	if err != nil {
 		return "", "", err
 	}
@@ -143,7 +144,7 @@ func (api *Client) PostMessage(channel, text string, params PostMessageParameter
 		values.Set("mrkdwn", "false")
 	}
 
-	response, err := chatRequest("chat.postMessage", values, api.debug)
+	response, err := chatRequest(api.HTTPClient, "chat.postMessage", values, api.debug)
 	if err != nil {
 		return "", "", err
 	}
@@ -158,7 +159,7 @@ func (api *Client) UpdateMessage(channel, timestamp, text string) (string, strin
 		"text":    {escapeMessage(text)},
 		"ts":      {timestamp},
 	}
-	response, err := chatRequest("chat.update", values, api.debug)
+	response, err := chatRequest(api.HTTPClient, "chat.update", values, api.debug)
 	if err != nil {
 		return "", "", "", err
 	}

--- a/dnd.go
+++ b/dnd.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"errors"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -35,9 +36,9 @@ type dndTeamInfoResponse struct {
 	SlackResponse
 }
 
-func dndRequest(path string, values url.Values, debug bool) (*dndResponseFull, error) {
+func dndRequest(httpcl *http.Client, path string, values url.Values, debug bool) (*dndResponseFull, error) {
 	response := &dndResponseFull{}
-	err := post(path, values, response, debug)
+	err := post(httpcl, path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +55,7 @@ func (api *Client) EndDND() error {
 	}
 
 	response := &SlackResponse{}
-	if err := post("dnd.endDnd", values, response, api.debug); err != nil {
+	if err := post(api.HTTPClient, "dnd.endDnd", values, response, api.debug); err != nil {
 		return err
 	}
 	if !response.Ok {
@@ -69,7 +70,7 @@ func (api *Client) EndSnooze() (*DNDStatus, error) {
 		"token": {api.config.token},
 	}
 
-	response, err := dndRequest("dnd.endSnooze", values, api.debug)
+	response, err := dndRequest(api.HTTPClient, "dnd.endSnooze", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +85,7 @@ func (api *Client) GetDNDInfo(user *string) (*DNDStatus, error) {
 	if user != nil {
 		values.Set("user", *user)
 	}
-	response, err := dndRequest("dnd.info", values, api.debug)
+	response, err := dndRequest(api.HTTPClient, "dnd.info", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +99,7 @@ func (api *Client) GetDNDTeamInfo(users []string) (map[string]DNDStatus, error) 
 		"users": {strings.Join(users, ",")},
 	}
 	response := &dndTeamInfoResponse{}
-	if err := post("dnd.teamInfo", values, response, api.debug); err != nil {
+	if err := post(api.HTTPClient, "dnd.teamInfo", values, response, api.debug); err != nil {
 		return nil, err
 	}
 	if !response.Ok {
@@ -115,7 +116,7 @@ func (api *Client) SetSnooze(minutes int) (*DNDStatus, error) {
 		"token":       {api.config.token},
 		"num_minutes": {strconv.Itoa(minutes)},
 	}
-	response, err := dndRequest("dnd.setSnooze", values, api.debug)
+	response, err := dndRequest(api.HTTPClient, "dnd.setSnooze", values, api.debug)
 	if err != nil {
 		return nil, err
 	}

--- a/emoji.go
+++ b/emoji.go
@@ -16,7 +16,7 @@ func (api *Client) GetEmoji() (map[string]string, error) {
 		"token": {api.config.token},
 	}
 	response := &emojiResponseFull{}
-	err := post("emoji.list", values, response, api.debug)
+	err := post(api.HTTPClient, "emoji.list", values, response, api.debug)
 	if err != nil {
 		return nil, err
 	}

--- a/files.go
+++ b/files.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"errors"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -130,9 +131,9 @@ func NewGetFilesParameters() GetFilesParameters {
 	}
 }
 
-func fileRequest(path string, values url.Values, debug bool) (*fileResponseFull, error) {
+func fileRequest(httpcl *http.Client, path string, values url.Values, debug bool) (*fileResponseFull, error) {
 	response := &fileResponseFull{}
-	err := post(path, values, response, debug)
+	err := post(httpcl, path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +151,7 @@ func (api *Client) GetFileInfo(fileID string, count, page int) (*File, []Comment
 		"count": {strconv.Itoa(count)},
 		"page":  {strconv.Itoa(page)},
 	}
-	response, err := fileRequest("files.info", values, api.debug)
+	response, err := fileRequest(api.HTTPClient, "files.info", values, api.debug)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -184,7 +185,7 @@ func (api *Client) GetFiles(params GetFilesParameters) ([]File, *Paging, error) 
 	if params.Page != DEFAULT_FILES_PAGE {
 		values.Add("page", strconv.Itoa(params.Page))
 	}
-	response, err := fileRequest("files.list", values, api.debug)
+	response, err := fileRequest(api.HTTPClient, "files.list", values, api.debug)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -220,9 +221,9 @@ func (api *Client) UploadFile(params FileUploadParameters) (file *File, err erro
 	}
 	if params.Content != "" {
 		values.Add("content", params.Content)
-		err = post("files.upload", values, response, api.debug)
+		err = post(api.HTTPClient, "files.upload", values, response, api.debug)
 	} else if params.File != "" {
-		err = postWithMultipartResponse("files.upload", params.File, values, response, api.debug)
+		err = postWithMultipartResponse(api.HTTPClient, "files.upload", params.File, values, response, api.debug)
 	}
 	if err != nil {
 		return nil, err
@@ -239,7 +240,7 @@ func (api *Client) DeleteFile(fileID string) error {
 		"token": {api.config.token},
 		"file":  {fileID},
 	}
-	_, err := fileRequest("files.delete", values, api.debug)
+	_, err := fileRequest(api.HTTPClient, "files.delete", values, api.debug)
 	if err != nil {
 		return err
 	}
@@ -253,7 +254,7 @@ func (api *Client) RevokeFilePublicURL(fileID string) (*File, error) {
 		"token": {api.config.token},
 		"file":  {fileID},
 	}
-	response, err := fileRequest("files.revokePublicURL", values, api.debug)
+	response, err := fileRequest(api.HTTPClient, "files.revokePublicURL", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -266,7 +267,7 @@ func (api *Client) ShareFilePublicURL(fileID string) (*File, []Comment, *Paging,
 		"token": {api.config.token},
 		"file":  {fileID},
 	}
-	response, err := fileRequest("files.sharedPublicURL", values, api.debug)
+	response, err := fileRequest(api.HTTPClient, "files.sharedPublicURL", values, api.debug)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/im.go
+++ b/im.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"errors"
+	"net/http"
 	"net/url"
 	"strconv"
 )
@@ -28,9 +29,9 @@ type IM struct {
 	IsUserDeleted bool   `json:"is_user_deleted"`
 }
 
-func imRequest(path string, values url.Values, debug bool) (*imResponseFull, error) {
+func imRequest(httpcl *http.Client, path string, values url.Values, debug bool) (*imResponseFull, error) {
 	response := &imResponseFull{}
-	err := post(path, values, response, debug)
+	err := post(httpcl, path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +47,7 @@ func (api *Client) CloseIMChannel(channel string) (bool, bool, error) {
 		"token":   {api.config.token},
 		"channel": {channel},
 	}
-	response, err := imRequest("im.close", values, api.debug)
+	response, err := imRequest(api.HTTPClient, "im.close", values, api.debug)
 	if err != nil {
 		return false, false, err
 	}
@@ -60,7 +61,7 @@ func (api *Client) OpenIMChannel(user string) (bool, bool, string, error) {
 		"token": {api.config.token},
 		"user":  {user},
 	}
-	response, err := imRequest("im.open", values, api.debug)
+	response, err := imRequest(api.HTTPClient, "im.open", values, api.debug)
 	if err != nil {
 		return false, false, "", err
 	}
@@ -74,7 +75,7 @@ func (api *Client) MarkIMChannel(channel, ts string) (err error) {
 		"channel": {channel},
 		"ts":      {ts},
 	}
-	_, err = imRequest("im.mark", values, api.debug)
+	_, err = imRequest(api.HTTPClient, "im.mark", values, api.debug)
 	if err != nil {
 		return err
 	}
@@ -110,7 +111,7 @@ func (api *Client) GetIMHistory(channel string, params HistoryParameters) (*Hist
 			values.Add("unreads", "0")
 		}
 	}
-	response, err := imRequest("im.history", values, api.debug)
+	response, err := imRequest(api.HTTPClient, "im.history", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +123,7 @@ func (api *Client) GetIMChannels() ([]IM, error) {
 	values := url.Values{
 		"token": {api.config.token},
 	}
-	response, err := imRequest("im.list", values, api.debug)
+	response, err := imRequest(api.HTTPClient, "im.list", values, api.debug)
 	if err != nil {
 		return nil, err
 	}

--- a/misc.go
+++ b/misc.go
@@ -15,8 +15,6 @@ import (
 	"time"
 )
 
-var HTTPClient = &http.Client{}
-
 type WebResponse struct {
 	Ok    bool      `json:"ok"`
 	Error *WebError `json:"error"`
@@ -89,9 +87,9 @@ func parseResponseBody(body io.ReadCloser, intf *interface{}, debug bool) error 
 	return nil
 }
 
-func postWithMultipartResponse(path string, filepath string, values url.Values, intf interface{}, debug bool) error {
+func postWithMultipartResponse(httpcl *http.Client, path string, filepath string, values url.Values, intf interface{}, debug bool) error {
 	req, err := fileUploadReq(SLACK_API+path, filepath, values)
-	resp, err := HTTPClient.Do(req)
+	resp, err := httpcl.Do(req)
 	if err != nil {
 		return err
 	}
@@ -99,8 +97,8 @@ func postWithMultipartResponse(path string, filepath string, values url.Values, 
 	return parseResponseBody(resp.Body, &intf, debug)
 }
 
-func postForm(endpoint string, values url.Values, intf interface{}, debug bool) error {
-	resp, err := HTTPClient.PostForm(endpoint, values)
+func postForm(httpcl *http.Client, endpoint string, values url.Values, intf interface{}, debug bool) error {
+	resp, err := httpcl.PostForm(endpoint, values)
 	if err != nil {
 		return err
 	}
@@ -109,11 +107,11 @@ func postForm(endpoint string, values url.Values, intf interface{}, debug bool) 
 	return parseResponseBody(resp.Body, &intf, debug)
 }
 
-func post(path string, values url.Values, intf interface{}, debug bool) error {
-	return postForm(SLACK_API+path, values, intf, debug)
+func post(httpcl *http.Client, path string, values url.Values, intf interface{}, debug bool) error {
+	return postForm(httpcl, SLACK_API+path, values, intf, debug)
 }
 
-func parseAdminResponse(method string, teamName string, values url.Values, intf interface{}, debug bool) error {
+func parseAdminResponse(httpcl *http.Client, method string, teamName string, values url.Values, intf interface{}, debug bool) error {
 	endpoint := fmt.Sprintf(SLACK_WEB_API_FORMAT, teamName, method, time.Now().Unix())
-	return postForm(endpoint, values, intf, debug)
+	return postForm(httpcl, endpoint, values, intf, debug)
 }

--- a/misc_test.go
+++ b/misc_test.go
@@ -40,7 +40,7 @@ func TestParseResponse(t *testing.T) {
 		"token": {validToken},
 	}
 	responsePartial := &SlackResponse{}
-	err := post("parseResponse", values, responsePartial, false)
+	err := post(http.DefaultClient, "parseResponse", values, responsePartial, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -52,7 +52,7 @@ func TestParseResponseNoToken(t *testing.T) {
 	SLACK_API = "http://" + serverAddr + "/"
 	values := url.Values{}
 	responsePartial := &SlackResponse{}
-	err := post("parseResponse", values, responsePartial, false)
+	err := post(http.DefaultClient, "parseResponse", values, responsePartial, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 		return
@@ -72,7 +72,7 @@ func TestParseResponseInvalidToken(t *testing.T) {
 		"token": {"whatever"},
 	}
 	responsePartial := &SlackResponse{}
-	err := post("parseResponse", values, responsePartial, false)
+	err := post(http.DefaultClient, "parseResponse", values, responsePartial, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 		return

--- a/oauth.go
+++ b/oauth.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"errors"
+	"net/http"
 	"net/url"
 )
 
@@ -27,15 +28,15 @@ type OAuthResponse struct {
 }
 
 // GetOAuthToken retrieves an AccessToken
-func GetOAuthToken(clientID, clientSecret, code, redirectURI string, debug bool) (accessToken string, scope string, err error) {
-	response, err := GetOAuthResponse(clientID, clientSecret, code, redirectURI, debug)
+func GetOAuthToken(httpcl *http.Client, clientID, clientSecret, code, redirectURI string, debug bool) (accessToken string, scope string, err error) {
+	response, err := GetOAuthResponse(httpcl, clientID, clientSecret, code, redirectURI, debug)
 	if err != nil {
 		return "", "", err
 	}
 	return response.AccessToken, response.Scope, nil
 }
 
-func GetOAuthResponse(clientID, clientSecret, code, redirectURI string, debug bool) (resp *OAuthResponse, err error) {
+func GetOAuthResponse(httpcl *http.Client, clientID, clientSecret, code, redirectURI string, debug bool) (resp *OAuthResponse, err error) {
 	values := url.Values{
 		"client_id":     {clientID},
 		"client_secret": {clientSecret},
@@ -43,7 +44,7 @@ func GetOAuthResponse(clientID, clientSecret, code, redirectURI string, debug bo
 		"redirect_uri":  {redirectURI},
 	}
 	response := &OAuthResponse{}
-	err = post("oauth.access", values, response, debug)
+	err = post(httpcl, "oauth.access", values, response, debug)
 	if err != nil {
 		return nil, err
 	}

--- a/pins.go
+++ b/pins.go
@@ -27,7 +27,7 @@ func (api *Client) AddPin(channel string, item ItemRef) error {
 		values.Set("file_comment", string(item.Comment))
 	}
 	response := &SlackResponse{}
-	if err := post("pins.add", values, response, api.debug); err != nil {
+	if err := post(api.HTTPClient, "pins.add", values, response, api.debug); err != nil {
 		return err
 	}
 	if !response.Ok {
@@ -52,7 +52,7 @@ func (api *Client) RemovePin(channel string, item ItemRef) error {
 		values.Set("file_comment", string(item.Comment))
 	}
 	response := &SlackResponse{}
-	if err := post("pins.remove", values, response, api.debug); err != nil {
+	if err := post(api.HTTPClient, "pins.remove", values, response, api.debug); err != nil {
 		return err
 	}
 	if !response.Ok {
@@ -68,7 +68,7 @@ func (api *Client) ListPins(channel string) ([]Item, *Paging, error) {
 		"token":   {api.config.token},
 	}
 	response := &listPinsResponseFull{}
-	err := post("pins.list", values, response, api.debug)
+	err := post(api.HTTPClient, "pins.list", values, response, api.debug)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/reactions.go
+++ b/reactions.go
@@ -148,7 +148,7 @@ func (api *Client) AddReaction(name string, item ItemRef) error {
 		values.Set("file_comment", string(item.Comment))
 	}
 	response := &SlackResponse{}
-	if err := post("reactions.add", values, response, api.debug); err != nil {
+	if err := post(api.HTTPClient, "reactions.add", values, response, api.debug); err != nil {
 		return err
 	}
 	if !response.Ok {
@@ -178,7 +178,7 @@ func (api *Client) RemoveReaction(name string, item ItemRef) error {
 		values.Set("file_comment", string(item.Comment))
 	}
 	response := &SlackResponse{}
-	if err := post("reactions.remove", values, response, api.debug); err != nil {
+	if err := post(api.HTTPClient, "reactions.remove", values, response, api.debug); err != nil {
 		return err
 	}
 	if !response.Ok {
@@ -208,7 +208,7 @@ func (api *Client) GetReactions(item ItemRef, params GetReactionsParameters) ([]
 		values.Set("full", strconv.FormatBool(params.Full))
 	}
 	response := &getReactionsResponseFull{}
-	if err := post("reactions.get", values, response, api.debug); err != nil {
+	if err := post(api.HTTPClient, "reactions.get", values, response, api.debug); err != nil {
 		return nil, err
 	}
 	if !response.Ok {
@@ -235,7 +235,7 @@ func (api *Client) ListReactions(params ListReactionsParameters) ([]ReactedItem,
 		values.Add("full", strconv.FormatBool(params.Full))
 	}
 	response := &listReactionsResponseFull{}
-	err := post("reactions.list", values, response, api.debug)
+	err := post(api.HTTPClient, "reactions.list", values, response, api.debug)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/rtm.go
+++ b/rtm.go
@@ -12,7 +12,7 @@ import (
 // on it.
 func (api *Client) StartRTM() (info *Info, websocketURL string, err error) {
 	response := &infoResponseFull{}
-	err = post("rtm.start", url.Values{"token": {api.config.token}}, response, api.debug)
+	err = post(api.HTTPClient, "rtm.start", url.Values{"token": {api.config.token}}, response, api.debug)
 	if err != nil {
 		return nil, "", fmt.Errorf("post: %s", err)
 	}

--- a/search.go
+++ b/search.go
@@ -101,7 +101,7 @@ func (api *Client) _search(path, query string, params SearchParameters, files, m
 		values.Add("page", strconv.Itoa(params.Page))
 	}
 	response = &searchResponseFull{}
-	err := post(path, values, response, api.debug)
+	err := post(api.HTTPClient, path, values, response, api.debug)
 	if err != nil {
 		return nil, err
 	}

--- a/slack.go
+++ b/slack.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"errors"
 	"log"
+	"net/http"
 	"net/url"
 	"os"
 )
@@ -36,8 +37,9 @@ type Client struct {
 	config struct {
 		token string
 	}
-	info  Info
-	debug bool
+	info       Info
+	debug      bool
+	HTTPClient *http.Client
 }
 
 // SetLogger let's library users supply a logger, so that api debugging
@@ -47,7 +49,9 @@ func SetLogger(l *log.Logger) {
 }
 
 func New(token string) *Client {
-	s := &Client{}
+	s := &Client{
+		HTTPClient: http.DefaultClient,
+	}
 	s.config.token = token
 	return s
 }
@@ -55,7 +59,7 @@ func New(token string) *Client {
 // AuthTest tests if the user is able to do authenticated requests or not
 func (api *Client) AuthTest() (response *AuthTestResponse, error error) {
 	responseFull := &authTestResponseFull{}
-	err := post("auth.test", url.Values{"token": {api.config.token}}, responseFull, api.debug)
+	err := post(api.HTTPClient, "auth.test", url.Values{"token": {api.config.token}}, responseFull, api.debug)
 	if err != nil {
 		return nil, err
 	}

--- a/stars.go
+++ b/stars.go
@@ -51,7 +51,7 @@ func (api *Client) AddStar(channel string, item ItemRef) error {
 		values.Set("file_comment", string(item.Comment))
 	}
 	response := &SlackResponse{}
-	if err := post("stars.add", values, response, api.debug); err != nil {
+	if err := post(api.HTTPClient, "stars.add", values, response, api.debug); err != nil {
 		return err
 	}
 	if !response.Ok {
@@ -76,7 +76,7 @@ func (api *Client) RemoveStar(channel string, item ItemRef) error {
 		values.Set("file_comment", string(item.Comment))
 	}
 	response := &SlackResponse{}
-	if err := post("stars.remove", values, response, api.debug); err != nil {
+	if err := post(api.HTTPClient, "stars.remove", values, response, api.debug); err != nil {
 		return err
 	}
 	if !response.Ok {
@@ -100,7 +100,7 @@ func (api *Client) ListStars(params StarsParameters) ([]Item, *Paging, error) {
 		values.Add("page", strconv.Itoa(params.Page))
 	}
 	response := &listResponseFull{}
-	err := post("stars.list", values, response, api.debug)
+	err := post(api.HTTPClient, "stars.list", values, response, api.debug)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/team.go
+++ b/team.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"errors"
+	"net/http"
 	"net/url"
 )
 
@@ -18,9 +19,9 @@ type TeamInfo struct {
 	Icon        map[string]interface{} `json:"icon"`
 }
 
-func teamRequest(path string, values url.Values, debug bool) (*TeamResponse, error) {
+func teamRequest(httpcl *http.Client, path string, values url.Values, debug bool) (*TeamResponse, error) {
 	response := &TeamResponse{}
-	err := post(path, values, response, debug)
+	err := post(httpcl, path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +39,7 @@ func (api *Client) GetTeamInfo() (*TeamInfo, error) {
 		"token": {api.config.token},
 	}
 
-	response, err := teamRequest("team.info", values, api.debug)
+	response, err := teamRequest(api.HTTPClient, "team.info", values, api.debug)
 	if err != nil {
 		return nil, err
 	}

--- a/users.go
+++ b/users.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"errors"
+	"net/http"
 	"net/url"
 )
 
@@ -62,9 +63,9 @@ type userResponseFull struct {
 	SlackResponse
 }
 
-func userRequest(path string, values url.Values, debug bool) (*userResponseFull, error) {
+func userRequest(httpcl *http.Client, path string, values url.Values, debug bool) (*userResponseFull, error) {
 	response := &userResponseFull{}
-	err := post(path, values, response, debug)
+	err := post(httpcl, path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +81,7 @@ func (api *Client) GetUserPresence(user string) (*UserPresence, error) {
 		"token": {api.config.token},
 		"user":  {user},
 	}
-	response, err := userRequest("users.getPresence", values, api.debug)
+	response, err := userRequest(api.HTTPClient, "users.getPresence", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +94,7 @@ func (api *Client) GetUserInfo(user string) (*User, error) {
 		"token": {api.config.token},
 		"user":  {user},
 	}
-	response, err := userRequest("users.info", values, api.debug)
+	response, err := userRequest(api.HTTPClient, "users.info", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +107,7 @@ func (api *Client) GetUsers() ([]User, error) {
 		"token":    {api.config.token},
 		"presence": {"1"},
 	}
-	response, err := userRequest("users.list", values, api.debug)
+	response, err := userRequest(api.HTTPClient, "users.list", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +119,7 @@ func (api *Client) SetUserAsActive() error {
 	values := url.Values{
 		"token": {api.config.token},
 	}
-	_, err := userRequest("users.setActive", values, api.debug)
+	_, err := userRequest(api.HTTPClient, "users.setActive", values, api.debug)
 	if err != nil {
 		return err
 	}
@@ -131,7 +132,7 @@ func (api *Client) SetUserPresence(presence string) error {
 		"token":    {api.config.token},
 		"presence": {presence},
 	}
-	_, err := userRequest("users.setPresence", values, api.debug)
+	_, err := userRequest(api.HTTPClient, "users.setPresence", values, api.debug)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is an expansion of my previous PR, https://github.com/nlopes/slack/pull/73.
Previously I was mucking with globals, but in many cases we need to create http.Client instances that refer to different contexts.

While the gist of the change is fairly simple, but since this is a rather big PR, I understand if you have concerns about merging.

---

Now if you want to use this in appengine, you should do:

``` go
  c := slack.New(...)
  c.HTTPClient = &http.Client{
    Transport: &urlfetch.Transport{
      Context: appengine.NewContext(r),
    },
  }
```
