### PR TITLE
fix deadlock

### DIFF
--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -227,6 +227,12 @@ func (rtm *RTM) ping() error {
 	rtm.pings[id] = time.Now()
 
 	msg := &Ping{ID: id, Type: "ping"}
+
+	if err := rtm.conn.SetWriteDeadline(time.Now().Add(1 * time.Second)); err != nil {
+		rtm.Debugf("RTM Error setting deadline 'PING %d': %s", id, err.Error())
+		return err
+	}
+
 	err := websocket.JSON.Send(rtm.conn, msg)
 	if err != nil {
 		rtm.Debugf("RTM Error sending 'PING %d': %s", id, err.Error())


### PR DESCRIPTION
fix https://github.com/nlopes/slack/issues/87

The bug is actually upstream in x/websocket. https://github.com/golang/go/issues/16298

Current: breaks because codec.Send can't write into the buffer because the connection is closed.
and the handler.WriteClose method can't run because Codec.Send is holding the lock on the connection.

```
2016/07/08 10:01:30 websocket_managed_conn.go:232: PING invoked
2016/07/08 10:01:30 websocket_managed_conn.go:244: Invoking JSON Send
2016/07/08 10:01:30 websocket.go:291: Codec Send
2016/07/08 10:01:30 websocket.go:293: Codec Marshal Completed <nil>
2016/07/08 10:01:30 websocket.go:298: Codec Send: locking {0 0}
2016/07/08 10:01:30 websocket.go:302: Codec Send: Locked {1 0}
```

This fix: fixes the problem by timing out the connection. may cause the connection to completely die if ping fails to send due to network latency.

```
2016/07/08 10:03:41 websocket_managed_conn.go:232: PING invoked
2016/07/08 10:03:41 websocket_managed_conn.go:244: Invoking JSON Send
2016/07/08 10:03:41 websocket.go:291: Codec Send
2016/07/08 10:03:41 websocket.go:293: Codec Marshal Completed <nil>
2016/07/08 10:03:41 websocket.go:298: Codec Send: locking {0 0}
2016/07/08 10:03:41 websocket.go:302: Codec Send: Locked {1 0}
2016/07/08 10:03:42 websocket.go:311: Codec Send: write failure write tcp 10.0.2.15:50564->52.90.163.180:443: i/o timeout
2016/07/08 10:03:42 websocket.go:313: Codec Send: unlocked {0 0}
2016/07/08 10:03:42 websocket_managed_conn.go:247: Send Failure write tcp 10.0.2.15:50564->52.90.163.180:443: i/o timeout
2016/07/08 10:03:42 websocket_managed_conn.go:249: PING done
2016/07/08 10:03:42 hybi.go:313: handler WriteClose locking: {0 0}
2016/07/08 10:03:42 hybi.go:325: handler WriteClose unlocked: {0 0}
```
