### PR TITLE
Add UnmarshalJSON to Message and params to UpdateMessage

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -29,18 +29,18 @@ type chatResponseFull struct {
 
 // PostMessageParameters contains all the parameters necessary (including the optional ones) for a PostMessage() request
 type PostMessageParameters struct {
-	Text        string
-	Username    string
-	AsUser      bool
-	Parse       string
-	LinkNames   int
-	Attachments []Attachment
-	UnfurlLinks bool
-	UnfurlMedia bool
-	IconURL     string
-	IconEmoji   string
-	Markdown    bool `json:"mrkdwn,omitempty"`
-	EscapeText  bool
+	Text        string       `json:"text"`
+	Username    string       `json:"username"`
+	AsUser      bool         `json:"as_user"`
+	Parse       string       `json:"parse"`
+	LinkNames   int          `json:"link_names"`
+	Attachments []Attachment `json:"attachments"`
+	UnfurlLinks bool         `json:"unfurl_links"`
+	UnfurlMedia bool         `json:"unfurl_media"`
+	IconURL     string       `json:"icon_url"`
+	IconEmoji   string       `json:"icon_emoji"`
+	Markdown    bool         `json:"mrkdwn,omitempty"`
+	EscapeText  bool         `json:"-"`
 }
 
 // NewPostMessageParameters provides an instance of PostMessageParameters with all the sane default values set

--- a/messages.go
+++ b/messages.go
@@ -1,5 +1,10 @@
 package slack
 
+import (
+	"encoding/json"
+	"strconv"
+)
+
 // OutgoingMessage is used for the realtime API, and seems incomplete.
 type OutgoingMessage struct {
 	ID      int    `json:"id"`
@@ -12,6 +17,29 @@ type OutgoingMessage struct {
 type Message struct {
 	Msg
 	SubMessage *Msg `json:"message,omitempty"`
+}
+
+func (m *Message) UnmarshalJSON(bytes []byte) error {
+	var msg struct {
+		Msg
+		SubMessage *Msg `json:"message,omitempty"`
+	}
+
+	t, err := strconv.Unquote(string(bytes))
+	if err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal([]byte(t), &msg); err != nil {
+		return err
+	}
+
+	m = &Message{
+		Msg:        msg.Msg,
+		SubMessage: msg.SubMessage,
+	}
+
+	return nil
 }
 
 // Msg contains information about a slack message

--- a/messages.go
+++ b/messages.go
@@ -27,17 +27,15 @@ func (m *Message) UnmarshalJSON(bytes []byte) error {
 
 	t, err := strconv.Unquote(string(bytes))
 	if err != nil {
-		return err
+		t = string(bytes)
 	}
 
 	if err := json.Unmarshal([]byte(t), &msg); err != nil {
 		return err
 	}
 
-	m = &Message{
-		Msg:        msg.Msg,
-		SubMessage: msg.SubMessage,
-	}
+	m.Msg = msg.Msg
+	m.SubMessage = msg.SubMessage
 
 	return nil
 }

--- a/messages_test.go
+++ b/messages_test.go
@@ -753,3 +753,39 @@ func TestFileShareMessage(t *testing.T) {
 	assert.True(t, message.Upload)
 	assert.NotNil(t, message.File)
 }
+
+var testCallback = `{
+  "actions": [
+    {
+      "name": "recommend",
+      "value": "yes"
+    }
+  ],
+  "callback_id": "test_callback",
+  "team": {
+    "id": "T47563693",
+    "domain": "watermelonsugar"
+  },
+  "channel": {
+    "id": "C065W1189",
+    "name": "forgotten-works"
+  },
+  "user": {
+    "id": "U045VRZFT",
+    "name": "brautigan"
+  },
+  "action_ts": "1458170917.164398",
+  "message_ts": "1458170866.000004",
+  "attachment_id": "1",
+  "token": "xAB3yVzGS4BQ3O9FACTa8Ho4",
+  "original_message": "{\"text\":\"New comic book alert!\",\"attachments\":[{\"title\":\"The Further Adventures of Slackbot\",\"fields\":[{\"title\":\"Volume\",\"value\":\"1\",\"short\":true},{\"title\":\"Issue\",\"value\":\"3\",\"short\":true}],\"author_name\":\"Stanford S. Strickland\",\"author_icon\":\"https://api.slack.com/img/api/homepage_custom_integrations-2x.png\",\"image_url\":\"http://i.imgur.com/OJkaVOI.jpg?1\"},{\"title\":\"Synopsis\",\"text\":\"After @episod pushed exciting changes to a devious new branch back in Issue 1, Slackbot notifies @don about an unexpected deploy...\"},{\"fallback\":\"Would you recommend it to customers?\",\"title\":\"Would you recommend it to customers?\",\"callback_id\":\"comic_1234_xyz\",\"color\":\"#3AA3E3\",\"attachment_type\":\"default\",\"actions\":[{\"name\":\"recommend\",\"text\":\"Recommend\",\"type\":\"button\",\"value\":\"recommend\"},{\"name\":\"no\",\"text\":\"No\",\"type\":\"button\",\"value\":\"bad\"}]}]}",
+  "response_url": "https://hooks.slack.com/actions/T47563693/6204672533/x7ZLaiVMoECAW50Gw1ZYAXEM"
+}`
+
+func TestUnmarshalJSONAttachmentActionCallback(t *testing.T) {
+	var callback AttachmentActionCallback
+	err := json.Unmarshal([]byte(testCallback), &callback)
+	assert.Nil(t, err)
+	fmt.Printf("%#v", callback.OriginalMessage)
+	assert.Equal(t, "New comic book alert!", callback.OriginalMessage.Text)
+}


### PR DESCRIPTION
This PR adds `UnmarshalJSON` to Message so you can unmarshal an attachment action callback directly. Otherwise it fails due it having the original message as a quoted string and a string can be unmarshalled in `Message` struct.

It also adds parameters to `UpdateMessage` so more complex messages can be used.
