### PR TITLE
Add missing bot_id and api_app_id to UserProfile

### DIFF
--- a/users.go
+++ b/users.go
@@ -21,6 +21,8 @@ type UserProfile struct {
 	Image192           string `json:"image_192"`
 	ImageOriginal      string `json:"image_original"`
 	Title              string `json:"title"`
+	BotID              string `json:"bot_id,omitempty"`
+	ApiAppID           string `json:"api_app_id,omitempty"`
 }
 
 // User contains all the information of a user


### PR DESCRIPTION
This is important to know whether the message originated from a bot user that is yourself.

An abbreviated copy of the payload looks like this:

```
{
  "ok": true,
  "user": {
    "profile": {
      "bot_id": "B0TGXXXXX",
      "api_app_id": "A0TFXXXXX",
    }
  }
}
```
