### PR TITLE
Parse ts as json.Number not string

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -1,5 +1,7 @@
 package slack
 
+import "encoding/json"
+
 // AttachmentField contains information for an attachment field
 // An Attachment can contain multiple of these
 type AttachmentField struct {
@@ -72,5 +74,5 @@ type Attachment struct {
 	Footer     string `json:"footer,omitempty"`
 	FooterIcon string `json:"footer_icon,omitempty"`
 
-	Ts string `json:"ts,omitempty"`
+	Ts json.Number `json:"ts,omitempty"`
 }


### PR DESCRIPTION
See discussion of the issue #92 . 
- Slack api returns `ts` field as `String` or `Number` 
