### PR TITLE
Attachment action confirm field is a hash not an array

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -12,12 +12,12 @@ type AttachmentField struct {
 // using message buttons and otherwise not useful. A maximum of 5 actions may be
 // provided per attachment.
 type AttachmentAction struct {
-	Name    string              `json:"name"`              // Required.
-	Text    string              `json:"text"`              // Required.
-	Style   string              `json:"style,omitempty"`   // Optional. Allowed values: "default", "primary", "danger"
-	Type    string              `json:"type"`              // Required. Must be set to "button"
-	Value   string              `json:"value,omitempty"`   // Optional.
-	Confirm []ConfirmationField `json:"confirm,omitempty"` // Optional.
+	Name    string             `json:"name"`              // Required.
+	Text    string             `json:"text"`              // Required.
+	Style   string             `json:"style,omitempty"`   // Optional. Allowed values: "default", "primary", "danger"
+	Type    string             `json:"type"`              // Required. Must be set to "button"
+	Value   string             `json:"value,omitempty"`   // Optional.
+	Confirm *ConfirmationField `json:"confirm,omitempty"` // Optional.
 }
 
 // AttachmentActionCallback is sent from Slack when a user clicks a button in an interactive message (aka AttachmentAction)


### PR DESCRIPTION
Hi, according to [slack doc](https://api.slack.com/docs/message-buttons#action_fields) `confirm` field for attachment action is a hash not an array. This causes 2 problems:
1. Unmarshalling of button webhook payload is falling with error `cannot unmarshal object into Go value of type []slack.ConfirmationField`.
2. Slack ignores provided `confirm` field and uses default values for confirmation window instead.
