### PR TITLE
adds users.identity api call and tests

### DIFF
--- a/users.go
+++ b/users.go
@@ -57,6 +57,39 @@ type UserPresence struct {
 	LastActivity    JSONTime `json:"last_activity,omitempty"`
 }
 
+type UserIdentityResponse struct {
+	User UserIdentity `json:"user"`
+	Team TeamIdentity `json:"team"`
+	SlackResponse
+}
+
+type UserIdentity struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Email    string `json:"email"`
+	Image24  string `json:"image_24"`
+	Image32  string `json:"image_32"`
+	Image48  string `json:"image_48"`
+	Image72  string `json:"image_72"`
+	Image192 string `json:"image_192"`
+	Image512 string `json:"image_512"`
+}
+
+type TeamIdentity struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	Domain        string `json:"domain"`
+	Image34       string `json:"image_34"`
+	Image44       string `json:"image_44"`
+	Image68       string `json:"image_68"`
+	Image88       string `json:"image_88"`
+	Image102      string `json:"image_102"`
+	Image132      string `json:"image_132"`
+	Image230      string `json:"image_230"`
+	ImageDefault  bool   `json:"image_default"`
+	ImageOriginal string `json:"image_original"`
+}
+
 type userResponseFull struct {
 	Members      []User                  `json:"members,omitempty"` // ListUsers
 	User         `json:"user,omitempty"` // GetUserInfo
@@ -139,4 +172,20 @@ func (api *Client) SetUserPresence(presence string) error {
 	}
 	return nil
 
+}
+
+// GetUserIdentity will retrieve user info available per identity scopes
+func (api *Client) GetUserIdentity() (*UserIdentityResponse, error) {
+	values := url.Values{
+		"token": {api.config.token},
+	}
+	response := &UserIdentityResponse{}
+	err := post("users.identity", values, response, api.debug)
+	if err != nil {
+		return nil, err
+	}
+	if !response.Ok {
+		return nil, errors.New(response.Error)
+	}
+	return response, nil
 }

--- a/users_test.go
+++ b/users_test.go
@@ -1,0 +1,83 @@
+package slack
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+var (
+	ErrIncorrectResponse = errors.New("Response is incorrect")
+)
+
+func getUserIdentity(rw http.ResponseWriter, r *http.Request) {
+	rw.Header().Set("Content-Type", "application/json")
+	response := []byte(`{
+  "ok": true,
+  "user": {
+    "id": "UXXXXXXXX",
+    "name": "Test User",
+    "email": "test@test.com",
+    "image_24": "https:\/\/s3-us-west-2.amazonaws.com\/slack-files2\/avatars\/2016-10-18\/92962080834_ef14c1469fc0741caea1_24.jpg",
+    "image_32": "https:\/\/s3-us-west-2.amazonaws.com\/slack-files2\/avatars\/2016-10-18\/92962080834_ef14c1469fc0741caea1_32.jpg",
+    "image_48": "https:\/\/s3-us-west-2.amazonaws.com\/slack-files2\/avatars\/2016-10-18\/92962080834_ef14c1469fc0741caea1_48.jpg",
+    "image_72": "https:\/\/s3-us-west-2.amazonaws.com\/slack-files2\/avatars\/2016-10-18\/92962080834_ef14c1469fc0741caea1_72.jpg",
+    "image_192": "https:\/\/s3-us-west-2.amazonaws.com\/slack-files2\/avatars\/2016-10-18\/92962080834_ef14c1469fc0741caea1_192.jpg",
+    "image_512": "https:\/\/s3-us-west-2.amazonaws.com\/slack-files2\/avatars\/2016-10-18\/92962080834_ef14c1469fc0741caea1_512.jpg"
+  },
+  "team": {
+    "id": "TXXXXXXXX",
+    "name": "team-name",
+    "domain": "team-domain",
+    "image_34": "https:\/\/s3-us-west-2.amazonaws.com\/slack-files2\/avatars\/2016-10-18\/92962080834_ef14c1469fc0741caea1_34.jpg",
+    "image_44": "https:\/\/s3-us-west-2.amazonaws.com\/slack-files2\/avatars\/2016-10-18\/92962080834_ef14c1469fc0741caea1_44.jpg",
+    "image_68": "https:\/\/s3-us-west-2.amazonaws.com\/slack-files2\/avatars\/2016-10-18\/92962080834_ef14c1469fc0741caea1_68.jpg",
+    "image_88": "https:\/\/s3-us-west-2.amazonaws.com\/slack-files2\/avatars\/2016-10-18\/92962080834_ef14c1469fc0741caea1_88.jpg",
+    "image_102": "https:\/\/s3-us-west-2.amazonaws.com\/slack-files2\/avatars\/2016-10-18\/92962080834_ef14c1469fc0741caea1_102.jpg",
+    "image_132": "https:\/\/s3-us-west-2.amazonaws.com\/slack-files2\/avatars\/2016-10-18\/92962080834_ef14c1469fc0741caea1_132.jpg",
+    "image_230": "https:\/\/s3-us-west-2.amazonaws.com\/slack-files2\/avatars\/2016-10-18\/92962080834_ef14c1469fc0741caea1_230.jpg",
+    "image_original": "https:\/\/s3-us-west-2.amazonaws.com\/slack-files2\/avatars\/2016-10-18\/92962080834_ef14c1469fc0741caea1_original.jpg"
+  }
+}`)
+	rw.Write(response)
+}
+
+func TestGetUserIdentity(t *testing.T) {
+	http.HandleFunc("/users.identity", getUserIdentity)
+
+	once.Do(startServer)
+	SLACK_API = "http://" + serverAddr + "/"
+	api := New("testing-token")
+
+	identity, err := api.GetUserIdentity()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	// t.Fatal refers to -> t.Errorf & return
+	if identity.User.ID != "UXXXXXXXX" {
+		t.Fatal(ErrIncorrectResponse)
+	}
+	if identity.User.Name != "Test User" {
+		t.Fatal(ErrIncorrectResponse)
+	}
+	if identity.User.Email != "test@test.com" {
+		t.Fatal(ErrIncorrectResponse)
+	}
+	if identity.Team.ID != "TXXXXXXXX" {
+		t.Fatal(ErrIncorrectResponse)
+	}
+	if identity.Team.Name != "team-name" {
+		t.Fatal(ErrIncorrectResponse)
+	}
+	if identity.Team.Domain != "team-domain" {
+		t.Fatal(ErrIncorrectResponse)
+	}
+	if identity.User.Image24 == "" {
+		t.Fatal(ErrIncorrectResponse)
+	}
+	if identity.Team.Image34 == "" {
+		t.Fatal(ErrIncorrectResponse)
+	}
+}

--- a/users_test.go
+++ b/users_test.go
@@ -1,13 +1,8 @@
 package slack
 
 import (
-	"errors"
 	"net/http"
 	"testing"
-)
-
-var (
-	ErrIncorrectResponse = errors.New("Response is incorrect")
 )
 
 func getUserIdentity(rw http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This adds support for the Slack `users.identity` api method: 

https://api.slack.com/methods/users.identity

It ends up being a pretty different response structure than other `user.*` methods, so I went the route of using dedicated structs.  You can request a few different `identity.*` scopes, and the fields I added to the structs encompass everything you could possibly get if you have all of the `identity` related scopes.

I also added a basic test for it.

This addresses #80 as well I believe.
