### PR TITLE
check the HTTP status code and content type headers

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"mime/multipart"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -96,6 +97,13 @@ func postWithMultipartResponse(path string, filepath string, values url.Values, 
 		return err
 	}
 	defer resp.Body.Close()
+
+	// Slack seems to send an HTML body along with 5xx error codes. Don't parse it.
+	if resp.StatusCode != 200 {
+		logResponse(resp, debug)
+		return fmt.Errorf("Slack server error: %s.", resp.Status)
+	}
+
 	return parseResponseBody(resp.Body, &intf, debug)
 }
 
@@ -116,4 +124,17 @@ func post(path string, values url.Values, intf interface{}, debug bool) error {
 func parseAdminResponse(method string, teamName string, values url.Values, intf interface{}, debug bool) error {
 	endpoint := fmt.Sprintf(SLACK_WEB_API_FORMAT, teamName, method, time.Now().Unix())
 	return postForm(endpoint, values, intf, debug)
+}
+
+func logResponse(resp *http.Response, debug bool) error {
+	if debug {
+		text, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return err
+		}
+
+		logger.Print(text)
+	}
+
+	return nil
 }


### PR DESCRIPTION
This change checks the response code to make sure the server returned
a 200. When Slack returns a non-200 response code, the body might be
HTML, which causes JSON parsing to fail with:

```
invalid character '<' looking for beginning of value
```

This is misleading since the real problem is the server error which is now
reported in the error.

I saw this locally with file uploads timing out with a 504 Gateway
Timeout that was invisible until I added some debug logs and then this
code.

In a previous patch, I checked the Content-Type as well, but that
quickly proved to be fragile and unnecessary.

Also added a logResponse() function that uses net/http/httputil to dump
the response when in debug mode. net/http/httputil is already used in
websocket_proxy.go so it does not create a new dependency.
