### PR TITLE
added app user access token response struct

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -8,6 +8,7 @@ import (
 type OAuthResponseIncomingWebhook struct {
 	URL              string `json:"url"`
 	Channel          string `json:"channel"`
+	ChannelID        string `json:"channel_id,omitempty"`
 	ConfigurationURL string `json:"configuration_url"`
 }
 
@@ -23,6 +24,7 @@ type OAuthResponse struct {
 	TeamID          string                       `json:"team_id"`
 	IncomingWebhook OAuthResponseIncomingWebhook `json:"incoming_webhook"`
 	Bot             OAuthResponseBot             `json:"bot"`
+	UserID          string                       `json:"user_id,omitempty"`
 	SlackResponse
 }
 


### PR DESCRIPTION
if using 'app user', oauth.access response struct has "user_id" and "incoming_webhook.channel_id". added them.
