### PR TITLE
Add function that returns rtm.IncomingEvents for external testing

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -91,3 +91,9 @@ func (rtm *RTM) SendMessage(msg *OutgoingMessage) {
 
 	rtm.outgoingMessages <- *msg
 }
+
+// Events returns the internal event channel (can also be accessed directly
+// with `rtm.IncomingEvents``). Mainly for testing purposes.
+func (rtm *RTM) Events() chan RTMEvent {
+	return rtm.IncomingEvents
+}


### PR DESCRIPTION
- When writing some tests that utilize this library, I need to mock
  out slack to test message handling.
- To create my testing interface I need a function to return the
  `IncomingEvents` channel