### PR TITLE
Use UNIX timestamp for files.list API

### DIFF
--- a/files.go
+++ b/files.go
@@ -168,12 +168,11 @@ func (api *Client) GetFiles(params GetFilesParameters) ([]File, *Paging, error) 
 	if params.Channel != DEFAULT_FILES_CHANNEL {
 		values.Add("channel", params.Channel)
 	}
-	// XXX: this is broken. fix it with a proper unix timestamp
 	if params.TimestampFrom != DEFAULT_FILES_TS_FROM {
-		values.Add("ts_from", params.TimestampFrom.String())
+		values.Add("ts_from", strconv.FormatInt(int64(params.TimestampFrom), 10))
 	}
 	if params.TimestampTo != DEFAULT_FILES_TS_TO {
-		values.Add("ts_to", params.TimestampTo.String())
+		values.Add("ts_to", strconv.FormatInt(int64(params.TimestampTo), 10))
 	}
 	if params.Types != DEFAULT_FILES_TYPES {
 		values.Add("types", params.Types)


### PR DESCRIPTION
Parameters `ts_from` and `ts_to` should be UNIX timestamp.

See examples of https://api.slack.com/methods/files.list.