### PR TITLE
Add fields to the EmojiChangedEvent

### DIFF
--- a/websocket_misc.go
+++ b/websocket_misc.go
@@ -80,6 +80,7 @@ type EmojiChangedEvent struct {
 	SubType        string   `json:"subtype"`
 	Name           string   `json:"name"`
 	Names          []string `json:"names"`
+	Value          string   `json:"value"` 
 	EventTimestamp string   `json:"event_ts"`
 }
 

--- a/websocket_misc.go
+++ b/websocket_misc.go
@@ -76,8 +76,11 @@ type UserChangeEvent struct {
 
 // EmojiChangedEvent represents the emoji changed event
 type EmojiChangedEvent struct {
-	Type           string `json:"type"`
-	EventTimestamp string `json:"event_ts"`
+	Type           string   `json:"type"`
+	SubType        string   `json:"subtype"`
+	Name           string   `json:"name"`
+	Names          []string `json:"names"`
+	EventTimestamp string   `json:"event_ts"`
 }
 
 // CommandsChangedEvent represents the commands changed event


### PR DESCRIPTION
As seen in the API documents of the emoji_changed event, we should be able to distinguish whether or not it is an `add` or a `remove`. Also, we should be able to know which emojis are added/removed.
https://api.slack.com/events/emoji_changed

The `EmojiChangedEvent` struct did not have these fields ( `subtype` , `name` , `names` ) so I added them.