### PR TITLE
Add threaded timestamp to messages

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -74,6 +74,9 @@ type Msg struct {
 
 	// reactions
 	Reactions []ItemReaction `json:"reactions,omitempty"`
+
+	// Thread timestamp
+	ThreadTimestamp string `json:"thread_ts"`
 }
 
 // Icon is used for bot messages


### PR DESCRIPTION
Correct me if I'm mistaken but there didn't appear to be a way to determine if a received message was within a thread or not without this.