### PR TITLE
JSON error when trying to parse plain text response body

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -114,6 +114,11 @@ func postForm(endpoint string, values url.Values, intf interface{}, debug bool) 
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != 200 {
+		logResponse(resp, debug)
+		return fmt.Errorf("Slack server error: %s.", resp.Status)
+	}
+
 	return parseResponseBody(resp.Body, &intf, debug)
 }
 


### PR DESCRIPTION
I was hitting rate limits with api requests to getUsers and getting back the following:
`invalid character 'Y' looking for beginning of value` as the error message.

Since we can't rely on a JSON response in all cases this bugs out if we see anything but a 200 and returns a more useful status code instead `Slack server error: 429 Too Many Requests.`