### PR TITLE
Add users.setPhoto and users.deletePhoto

### DIFF
--- a/files.go
+++ b/files.go
@@ -222,7 +222,7 @@ func (api *Client) UploadFile(params FileUploadParameters) (file *File, err erro
 		values.Add("content", params.Content)
 		err = post("files.upload", values, response, api.debug)
 	} else if params.File != "" {
-		err = postWithMultipartResponse("files.upload", params.File, values, response, api.debug)
+		err = postWithMultipartResponse("files.upload", params.File, "file", values, response, api.debug)
 	}
 	if err != nil {
 		return nil, err

--- a/misc.go
+++ b/misc.go
@@ -29,7 +29,7 @@ func (s WebError) Error() string {
 	return string(s)
 }
 
-func fileUploadReq(path, fpath string, values url.Values) (*http.Request, error) {
+func fileUploadReq(path, fpath, fieldname string, values url.Values) (*http.Request, error) {
 	fullpath, err := filepath.Abs(fpath)
 	if err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func fileUploadReq(path, fpath string, values url.Values) (*http.Request, error)
 	body := &bytes.Buffer{}
 	wr := multipart.NewWriter(body)
 
-	ioWriter, err := wr.CreateFormFile("file", filepath.Base(fullpath))
+	ioWriter, err := wr.CreateFormFile(fieldname, filepath.Base(fullpath))
 	if err != nil {
 		wr.Close()
 		return nil, err
@@ -90,8 +90,8 @@ func parseResponseBody(body io.ReadCloser, intf *interface{}, debug bool) error 
 	return nil
 }
 
-func postWithMultipartResponse(path string, filepath string, values url.Values, intf interface{}, debug bool) error {
-	req, err := fileUploadReq(SLACK_API+path, filepath, values)
+func postWithMultipartResponse(path, filepath, fieldname string, values url.Values, intf interface{}, debug bool) error {
+	req, err := fileUploadReq(SLACK_API+path, filepath, fieldname, values)
 	resp, err := HTTPClient.Do(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
This adds basic support for users.setPhoto and users.deletePhoto. I was debating whether the image should be provided as a file path or an [image.Image](https://golang.org/pkg/image/#Image). A file path has the benefit of being more agnostic. I don't think that we should be responsible for how the image an gets encoded before being uploaded.