### PR TITLE
add support for setting and unsetting Custom Status/Emoji

### DIFF
--- a/users_test.go
+++ b/users_test.go
@@ -1,6 +1,8 @@
 package slack
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 )
@@ -35,6 +37,57 @@ func getUserIdentity(rw http.ResponseWriter, r *http.Request) {
   }
 }`)
 	rw.Write(response)
+}
+
+func httpTestErrReply(w http.ResponseWriter, clientErr bool, msg string) {
+	if clientErr {
+		w.WriteHeader(http.StatusBadRequest)
+	} else {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	body, _ := json.Marshal(&SlackResponse{
+		Ok: false, Error: msg,
+	})
+
+	w.Write(body)
+}
+
+func newProfileHandler(up *UserProfile) (setter func(http.ResponseWriter, *http.Request)) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if up == nil {
+			httpTestErrReply(w, false, "err: UserProfile is nil")
+			return
+		}
+
+		if err := r.ParseForm(); err != nil {
+			httpTestErrReply(w, true, fmt.Sprintf("err parsing form: %s", err.Error()))
+			return
+		}
+
+		values := r.Form
+
+		if len(values["profile"]) == 0 {
+			httpTestErrReply(w, true, `POST data must include a "profile" field`)
+			return
+		}
+
+		profile := []byte(values["profile"][0])
+
+		userProfile := UserProfile{}
+
+		if err := json.Unmarshal(profile, &userProfile); err != nil {
+			httpTestErrReply(w, true, fmt.Sprintf("err parsing JSON: %s\n\njson: `%s`", err.Error(), profile))
+			return
+		}
+
+		*up = userProfile
+
+		// TODO(theckman): enhance this to return a full User object
+		fmt.Fprint(w, `{"ok":true}`)
+	}
 }
 
 func TestGetUserIdentity(t *testing.T) {
@@ -74,5 +127,53 @@ func TestGetUserIdentity(t *testing.T) {
 	}
 	if identity.Team.Image34 == "" {
 		t.Fatal(ErrIncorrectResponse)
+	}
+}
+
+func TestUserCustomStatus(t *testing.T) {
+	up := &UserProfile{}
+
+	setUserProfile := newProfileHandler(up)
+
+	http.HandleFunc("/users.profile.set", setUserProfile)
+
+	once.Do(startServer)
+	SLACK_API = "http://" + serverAddr + "/"
+	api := New("testing-token")
+
+	testSetUserCustomStatus(api, up, t)
+	testUnsetUserCustomStatus(api, up, t)
+}
+
+func testSetUserCustomStatus(api *Client, up *UserProfile, t *testing.T) {
+	const (
+		statusText  = "testStatus"
+		statusEmoji = ":construction:"
+	)
+
+	if err := api.SetUserCustomStatus(statusText, statusEmoji); err != nil {
+		t.Fatalf(`SetUserCustomStatus(%q, %q) = %#v, want <nil>`, statusText, statusEmoji, err)
+	}
+
+	if up.StatusText != statusText {
+		t.Fatalf(`UserProfile.StatusText = %q, want %q`, up.StatusText, statusText)
+	}
+
+	if up.StatusEmoji != statusEmoji {
+		t.Fatalf(`UserProfile.StatusEmoji = %q, want %q`, up.StatusEmoji, statusEmoji)
+	}
+}
+
+func testUnsetUserCustomStatus(api *Client, up *UserProfile, t *testing.T) {
+	if err := api.UnsetUserCustomStatus(); err != nil {
+		t.Fatalf(`UnsetUserCustomStatus() = %#v, want <nil>`, err)
+	}
+
+	if up.StatusText != "" {
+		t.Fatalf(`UserProfile.StatusText = %q, want %q`, up.StatusText, "")
+	}
+
+	if up.StatusEmoji != "" {
+		t.Fatalf(`UserProfile.StatusEmoji = %q, want %q`, up.StatusEmoji, "")
 	}
 }


### PR DESCRIPTION
This change introduces two new methods on *Client for setting and unsetting the
Custom Status and Status Emoji for the currently authenticated User. This also
adds `StatusText` and `StatusEmoji` fields to the `UserProfile` struct. The
Custom Status and Status Emoji functionality was recently added as part of the
User's profile[1].

The first method added is `SetUserCustomStatus()` which takes two string
arguments. This method uses an anonymous struct to generate the JSON required to
update a User's Custom Status and Status Emoji. If both arguments are set to
empty-string (`""`) the Slack API will unset the Custom Status/Emoji.

The second method is `UnsetUserCustomStatus()`, which is a convenience method
that takes zero arguments and wraps `SetUserCustomStatus()`. It unsets the
custom status.

Integration tests were added to ensure that that setting and unsetting the
Custom Status should work as-expected.

Closes #153.

[1] https://slackhq.com/set-your-status-in-slack-28a793914b98

Signed-off-by: Tim Heckman <t@heckman.io>