### PR TITLE
correctly apply the AsUser parameter

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -249,7 +249,7 @@ func MsgOptionPostMessageParameters(params PostMessageParameters) MsgOption {
 		}
 
 		// never generates an error.
-		_ = MsgOptionAsUser(params.AsUser)
+		MsgOptionAsUser(params.AsUser)(config)
 
 		if params.Parse != DEFAULT_MESSAGE_PARSE {
 			config.values.Set("parse", string(params.Parse))


### PR DESCRIPTION
This correctly applies the AsUser MsgOption.

I noticed this because my bot always appeared in slack as "bot" without an icon, despite AsUser being set. I added some log and saw that `as_user` was never set in the `config.values` map.

I believe #142 is the same bug too.