### PR TITLE
Add ConnectRTM call to use the rtm.connect endpoint

### DIFF
--- a/rtm.go
+++ b/rtm.go
@@ -1,8 +1,10 @@
 package slack
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
+	"time"
 )
 
 // StartRTM calls the "rtm.start" endpoint and returns the provided URL and the full Info
@@ -37,14 +39,14 @@ func (api *Client) StartRTM() (info *Info, websocketURL string, err error) {
 //
 // To have a fully managed Websocket connection, use `NewRTM`, and call `ManageConnection()`
 // on it.
-func (api *Client) ConnectRTM() (info *Info, websocketURL string, slackResponse WebResponse, err error) {
+func (api *Client) ConnectRTM() (info *Info, websocketURL string, err error) {
 	response := &infoResponseFull{}
 	err = post("rtm.connect", url.Values{"token": {api.config.token}}, response, api.debug)
 	if err != nil {
-		return nil, "", response.WebResponse, fmt.Errorf("post: %s", err)
+		return nil, "", fmt.Errorf("post: %s", err)
 	}
 	if !response.Ok {
-		return nil, "", response.WebResponse, response.Error
+		return nil, "", response.Error
 	}
 
 	// websocket.Dial does not accept url without the port (yet)
@@ -53,14 +55,40 @@ func (api *Client) ConnectRTM() (info *Info, websocketURL string, slackResponse 
 	api.Debugln("Using URL:", response.Info.URL)
 	websocketURL, err = websocketizeURLPort(response.Info.URL)
 	if err != nil {
-		return nil, "", response.WebResponse, fmt.Errorf("parsing response URL: %s", err)
+		return nil, "", fmt.Errorf("parsing response URL: %s", err)
 	}
 
-	return &response.Info, websocketURL, response.WebResponse, nil
+	return &response.Info, websocketURL, nil
 }
 
 // NewRTM returns a RTM, which provides a fully managed connection to
-// Slack's websocket-based Real-Time Messaging protocol./
+// Slack's websocket-based Real-Time Messaging protocol.
 func (api *Client) NewRTM() *RTM {
-	return newRTM(api)
+	return api.NewRTMWithOptions(nil)
+}
+
+// NewRTMWithOptions returns a RTM, which provides a fully managed connection to
+// Slack's websocket-based Real-Time Messaging protocol.
+// This also allows to configure various options available for RTM API.
+func (api *Client) NewRTMWithOptions(options *RTMOptions) *RTM {
+	result := &RTM{
+		Client:           *api,
+		IncomingEvents:   make(chan RTMEvent, 50),
+		outgoingMessages: make(chan OutgoingMessage, 20),
+		pings:            make(map[int]time.Time),
+		isConnected:      false,
+		wasIntentional:   true,
+		killChannel:      make(chan bool),
+		forcePing:        make(chan bool),
+		rawEvents:        make(chan json.RawMessage),
+		idGen:            NewSafeID(1),
+	}
+
+	if options != nil {
+		result.useRTMStart = options.UseRTMStart
+	} else {
+		result.useRTMStart = true
+	}
+
+	return result
 }

--- a/rtm.go
+++ b/rtm.go
@@ -32,6 +32,33 @@ func (api *Client) StartRTM() (info *Info, websocketURL string, err error) {
 	return &response.Info, websocketURL, nil
 }
 
+// ConnectRTM calls the "rtm.connect" endpoint and returns the provided URL and the compact Info
+// block.
+//
+// To have a fully managed Websocket connection, use `NewRTM`, and call `ManageConnection()`
+// on it.
+func (api *Client) ConnectRTM() (info *Info, websocketURL string, slackResponse WebResponse, err error) {
+	response := &infoResponseFull{}
+	err = post("rtm.connect", url.Values{"token": {api.config.token}}, response, api.debug)
+	if err != nil {
+		return nil, "", response.WebResponse, fmt.Errorf("post: %s", err)
+	}
+	if !response.Ok {
+		return nil, "", response.WebResponse, response.Error
+	}
+
+	// websocket.Dial does not accept url without the port (yet)
+	// Fixed by: https://github.com/golang/net/commit/5058c78c3627b31e484a81463acd51c7cecc06f3
+	// but slack returns the address with no port, so we have to fix it
+	api.Debugln("Using URL:", response.Info.URL)
+	websocketURL, err = websocketizeURLPort(response.Info.URL)
+	if err != nil {
+		return nil, "", response.WebResponse, fmt.Errorf("parsing response URL: %s", err)
+	}
+
+	return &response.Info, websocketURL, response.WebResponse, nil
+}
+
 // NewRTM returns a RTM, which provides a fully managed connection to
 // Slack's websocket-based Real-Time Messaging protocol./
 func (api *Client) NewRTM() *RTM {

--- a/websocket.go
+++ b/websocket.go
@@ -17,7 +17,7 @@ const (
 // RTM represents a managed websocket connection. It also supports
 // all the methods of the `Client` type.
 //
-// Create this element with Client's NewRTM().
+// Create this element with Client's NewRTM() or NewRTMWithOptions(*RTMOptions)
 type RTM struct {
 	idGen IDGenerator
 	pings map[int]time.Time
@@ -38,23 +38,23 @@ type RTM struct {
 
 	// UserDetails upon connection
 	info *Info
+
+	// useRTMStart should be set to true if you want to use
+	// rtm.start to connect to Slack, otherwise it will use
+	// rtm.connect
+	useRTMStart bool
 }
 
-// NewRTM returns a RTM, which provides a fully managed connection to
-// Slack's websocket-based Real-Time Messaging protocol.
-func newRTM(api *Client) *RTM {
-	return &RTM{
-		Client:           *api,
-		IncomingEvents:   make(chan RTMEvent, 50),
-		outgoingMessages: make(chan OutgoingMessage, 20),
-		pings:            make(map[int]time.Time),
-		isConnected:      false,
-		wasIntentional:   true,
-		killChannel:      make(chan bool),
-		forcePing:        make(chan bool),
-		rawEvents:        make(chan json.RawMessage),
-		idGen:            NewSafeID(1),
-	}
+// RTMOptions allows configuration of various options available for RTM messaging
+//
+// This structure will evolve in time so please make sure you are always using the
+// named keys for every entry available as per Go 1 compatibility promise adding fields
+// to this structure should not be considered a breaking change.
+type RTMOptions struct {
+	// UseRTMStart set to true in order to use rtm.start or false to use rtm.connect
+	// As of 11th July 2017 you should prefer setting this to false, see:
+	// https://api.slack.com/changelog/2017-04-start-using-rtm-connect-and-stop-using-rtm-start
+	UseRTMStart bool
 }
 
 // Disconnect and wait, blocking until a successful disconnection.


### PR DESCRIPTION
This is a subset of the PR from #157.

As that branch was updated I'll merge this one instead.
Closes #157.