### PR TITLE
Add support of channels.replies API method to channels

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -259,3 +259,17 @@ func (api *Client) SetChannelTopic(channel, topic string) (string, error) {
 	}
 	return response.Topic, nil
 }
+
+// GetChannelReplies gets an entire thread (a message plus all the messages in reply to it).
+func (api *Client) GetChannelReplies(channel, thread_ts string) ([]Message, error) {
+	values := url.Values{
+		"token":     {api.config.token},
+		"channel":   {channel},
+		"thread_ts": {thread_ts},
+	}
+	response, err := channelRequest("channels.replies", values, api.debug)
+	if err != nil {
+		return nil, err
+	}
+	return response.History.Messages, nil
+}

--- a/messages.go
+++ b/messages.go
@@ -58,6 +58,11 @@ type Msg struct {
 	// channel_archive, group_archive
 	Members []string `json:"members,omitempty"`
 
+	// channels.replies, groups.replies, im.replies, mpim.replies
+	ReplyCount   int     `json:"reply_count,omitempty"`
+	Replies      []Reply `json:"replies,omitempty"`
+	ParentUserId string  `json:"parent_user_id,omitempty"`
+
 	// file_share, file_comment, file_mention
 	File *File `json:"file,omitempty"`
 
@@ -86,6 +91,12 @@ type Icon struct {
 
 // Edited indicates that a message has been edited.
 type Edited struct {
+	User      string `json:"user,omitempty"`
+	Timestamp string `json:"ts,omitempty"`
+}
+
+// Reply contains information about a reply for a thread
+type Reply struct {
 	User      string `json:"user,omitempty"`
 	Timestamp string `json:"ts,omitempty"`
 }

--- a/messages_test.go
+++ b/messages_test.go
@@ -526,6 +526,65 @@ func TestChannelUnarchiveMessage(t *testing.T) {
 	assert.Equal(t, "U1234", message.User)
 }
 
+var channelRepliesParentMessage = `{
+    "type": "message",
+    "user": "U1234",
+    "text": "test",
+    "thread_ts": "1493305433.915644",
+    "reply_count": 2,
+    "replies": [
+        {
+            "user": "U5678",
+            "ts": "1493305444.920992"
+        },
+        {
+            "user": "U9012",
+            "ts": "1493305894.133936"
+        }
+    ],
+    "subscribed": true,
+    "last_read": "1493305894.133936",
+    "unread_count": 0,
+    "ts": "1493305433.915644"
+}`
+
+func TestChannelRepliesParentMessage(t *testing.T) {
+	message, err := unmarshalMessage(channelRepliesParentMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "U1234", message.User)
+	assert.Equal(t, "test", message.Text)
+	assert.Equal(t, "1493305433.915644", message.ThreadTimestamp)
+	assert.Equal(t, 2, message.ReplyCount)
+	assert.Equal(t, "U5678", message.Replies[0].User)
+	assert.Equal(t, "1493305444.920992", message.Replies[0].Timestamp)
+	assert.Equal(t, "U9012", message.Replies[1].User)
+	assert.Equal(t, "1493305894.133936", message.Replies[1].Timestamp)
+	assert.Equal(t, "1493305433.915644", message.Timestamp)
+}
+
+var channelRepliesChildMessage = `{
+    "type": "message",
+    "user": "U5678",
+    "text": "foo",
+    "thread_ts": "1493305433.915644",
+    "parent_user_id": "U1234",
+    "ts": "1493305444.920992"
+}`
+
+func TestChannelRepliesChildMessage(t *testing.T) {
+	message, err := unmarshalMessage(channelRepliesChildMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, "U5678", message.User)
+	assert.Equal(t, "foo", message.Text)
+	assert.Equal(t, "1493305433.915644", message.ThreadTimestamp)
+	assert.Equal(t, "U1234", message.ParentUserId)
+	assert.Equal(t, "1493305444.920992", message.Timestamp)
+}
+
 var groupJoinMessage = `{
     "type": "message",
     "subtype": "group_join",


### PR DESCRIPTION
### Overview

This PR adds support of [channels.replies](https://api.slack.com/methods/channels.replies) Web API method. 
Note that the sample response written in the above link is wrong. The correct example is shown at [here](https://api.slack.com/docs/message-threading#retrieving_message_replies).

### Demo

```golang
package main

import (
	"fmt"
	"github.com/megane42/slack"
	"github.com/k0kubun/pp"
)

func main() {
	api := slack.New("YOUR_TOKEN_HERE")
	channels, err := api.GetChannelReplies("CHANNEL_ID_HERE", "PARENT_THREAD_TS_HERE")
	if err != nil {
		fmt.Printf("%s\n", err)
		return
	}

	pp.Print(channels)
}
```

The result of the above code is [here](https://gist.github.com/megane42/5e81e009e392eb16acdc13c7e4634f38).