### PR TITLE
Fix errors reported by staticcheck

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -49,10 +49,7 @@ func (api *Client) ArchiveChannelContext(ctx context.Context, channel string) er
 		"channel": {channel},
 	}
 	_, err := channelRequest(ctx, "channels.archive", values, api.debug)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // UnarchiveChannel unarchives the given channel
@@ -67,10 +64,7 @@ func (api *Client) UnarchiveChannelContext(ctx context.Context, channel string) 
 		"channel": {channel},
 	}
 	_, err := channelRequest(ctx, "channels.unarchive", values, api.debug)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // CreateChannel creates a channel with the given name and returns a *Channel
@@ -221,10 +215,7 @@ func (api *Client) KickUserFromChannelContext(ctx context.Context, channel, user
 		"user":    {user},
 	}
 	_, err := channelRequest(ctx, "channels.kick", values, api.debug)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // GetChannels retrieves all the channels
@@ -265,10 +256,7 @@ func (api *Client) SetChannelReadMarkContext(ctx context.Context, channel, ts st
 		"ts":      {ts},
 	}
 	_, err := channelRequest(ctx, "channels.mark", values, api.debug)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // RenameChannel renames a given channel

--- a/examples/team/team.go
+++ b/examples/team/team.go
@@ -8,7 +8,7 @@ import (
 
 func main() {
 	api := slack.New("YOUR_TOKEN_HERE")
-  //Example for single user
+	//Example for single user
 	billingActive, err := api.GetBillableInfo("U023BECGF")
 	if err != nil {
 		fmt.Printf("%s\n", err)
@@ -16,10 +16,10 @@ func main() {
 	}
 	fmt.Printf("ID: U023BECGF, BillingActive: %v\n\n\n", billingActive["U023BECGF"])
 
-  //Example for team
-  billingActiveForTeam, err := api.GetBillableInfoForTeam()
-  for id, value := range billingActiveForTeam {
-    fmt.Printf("ID: %v, BillingActive: %v\n", id, value)
-  }
+	//Example for team
+	billingActiveForTeam, _ := api.GetBillableInfoForTeam()
+	for id, value := range billingActiveForTeam {
+		fmt.Printf("ID: %v, BillingActive: %v\n", id, value)
+	}
 
 }

--- a/files.go
+++ b/files.go
@@ -267,10 +267,7 @@ func (api *Client) DeleteFileContext(ctx context.Context, fileID string) error {
 		"file":  {fileID},
 	}
 	_, err := fileRequest(ctx, "files.delete", values, api.debug)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 
 }
 

--- a/groups.go
+++ b/groups.go
@@ -208,10 +208,7 @@ func (api *Client) LeaveGroupContext(ctx context.Context, group string) error {
 		"channel": {group},
 	}
 	_, err := groupRequest(ctx, "groups.leave", values, api.debug)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // KickUserFromGroup kicks a user from a group
@@ -227,10 +224,7 @@ func (api *Client) KickUserFromGroupContext(ctx context.Context, group, user str
 		"user":    {user},
 	}
 	_, err := groupRequest(ctx, "groups.kick", values, api.debug)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // GetGroups retrieves all groups
@@ -289,10 +283,7 @@ func (api *Client) SetGroupReadMarkContext(ctx context.Context, group, ts string
 		"ts":      {ts},
 	}
 	_, err := groupRequest(ctx, "groups.mark", values, api.debug)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // OpenGroup opens a private group

--- a/misc.go
+++ b/misc.go
@@ -79,12 +79,7 @@ func parseResponseBody(body io.ReadCloser, intf *interface{}, debug bool) error 
 		logger.Printf("parseResponseBody: %s\n", string(response))
 	}
 
-	err = json.Unmarshal(response, &intf)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return json.Unmarshal(response, &intf)
 }
 
 func postLocalWithMultipartResponse(ctx context.Context, path, fpath, fieldname string, values url.Values, intf interface{}, debug bool) error {

--- a/users.go
+++ b/users.go
@@ -198,10 +198,7 @@ func (api *Client) SetUserAsActiveContext(ctx context.Context) error {
 		"token": {api.config.token},
 	}
 	_, err := userRequest(ctx, "users.setActive", values, api.debug)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // SetUserPresence changes the currently authenticated user presence
@@ -245,7 +242,7 @@ func (api *Client) GetUserIdentityContext(ctx context.Context) (*UserIdentityRes
 }
 
 // SetUserPhoto changes the currently authenticated user's profile image
-func (api *Client) SetUserPhoto(ctx context.Context, image string, params UserSetPhotoParams) error {
+func (api *Client) SetUserPhoto(image string, params UserSetPhotoParams) error {
 	return api.SetUserPhotoContext(context.Background(), image, params)
 }
 

--- a/websocket_proxy.go
+++ b/websocket_proxy.go
@@ -32,8 +32,7 @@ func websocketHTTPConnect(proxy, urlString string) (net.Conn, error) {
 	}
 
 	cc := httputil.NewProxyClientConn(p, nil)
-	cc.Do(&req)
-	if err != nil && err != httputil.ErrPersistEOF {
+	if _, err := cc.Do(&req); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Specifically:

examples/team/team.go:20:25: this value of err is never used (SA4006)
misc.go:94:7: this value of err is never used (SA4006)
websocket_proxy.go:34:8: httputil.NewProxyClientConn is deprecated: Use the Client or Transport in package net/http instead.  (SA1019)
websocket_proxy.go:36:26: httputil.ErrPersistEOF is deprecated: No longer used.  (SA1019)

I wasn't sure how to replace the NewProxyClientConn so I left it
alone. It's possible we can just call http.NewRequest and then use
a Transport that implements http.ProxyURL.