### PR TITLE
remove global http client requirement

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -12,9 +12,9 @@ type adminResponse struct {
 	Error string `json:"error"`
 }
 
-func adminRequest(ctx context.Context, method string, teamName string, values url.Values, debug bool) (*adminResponse, error) {
+func adminRequest(ctx context.Context, client HTTPRequester, method string, teamName string, values url.Values, debug bool) (*adminResponse, error) {
 	adminResponse := &adminResponse{}
-	err := parseAdminResponse(ctx, method, teamName, values, adminResponse, debug)
+	err := parseAdminResponse(ctx, client, method, teamName, values, adminResponse, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -35,12 +35,12 @@ func (api *Client) DisableUser(teamName string, uid string) error {
 func (api *Client) DisableUserContext(ctx context.Context, teamName string, uid string) error {
 	values := url.Values{
 		"user":       {uid},
-		"token":      {api.config.token},
+		"token":      {api.token},
 		"set_active": {"true"},
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest(ctx, "setInactive", teamName, values, api.debug)
+	_, err := adminRequest(ctx, api.httpclient, "setInactive", teamName, values, api.debug)
 	if err != nil {
 		return fmt.Errorf("Failed to disable user with id '%s': %s", uid, err)
 	}
@@ -61,12 +61,12 @@ func (api *Client) InviteGuestContext(ctx context.Context, teamName, channel, fi
 		"first_name":       {firstName},
 		"last_name":        {lastName},
 		"ultra_restricted": {"1"},
-		"token":            {api.config.token},
+		"token":            {api.token},
 		"set_active":       {"true"},
 		"_attempts":        {"1"},
 	}
 
-	_, err := adminRequest(ctx, "invite", teamName, values, api.debug)
+	_, err := adminRequest(ctx, api.httpclient, "invite", teamName, values, api.debug)
 	if err != nil {
 		return fmt.Errorf("Failed to invite single-channel guest: %s", err)
 	}
@@ -87,12 +87,12 @@ func (api *Client) InviteRestrictedContext(ctx context.Context, teamName, channe
 		"first_name": {firstName},
 		"last_name":  {lastName},
 		"restricted": {"1"},
-		"token":      {api.config.token},
+		"token":      {api.token},
 		"set_active": {"true"},
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest(ctx, "invite", teamName, values, api.debug)
+	_, err := adminRequest(ctx, api.httpclient, "invite", teamName, values, api.debug)
 	if err != nil {
 		return fmt.Errorf("Failed to restricted account: %s", err)
 	}
@@ -111,12 +111,12 @@ func (api *Client) InviteToTeamContext(ctx context.Context, teamName, firstName,
 		"email":      {emailAddress},
 		"first_name": {firstName},
 		"last_name":  {lastName},
-		"token":      {api.config.token},
+		"token":      {api.token},
 		"set_active": {"true"},
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest(ctx, "invite", teamName, values, api.debug)
+	_, err := adminRequest(ctx, api.httpclient, "invite", teamName, values, api.debug)
 	if err != nil {
 		return fmt.Errorf("Failed to invite to team: %s", err)
 	}
@@ -133,12 +133,12 @@ func (api *Client) SetRegular(teamName, user string) error {
 func (api *Client) SetRegularContext(ctx context.Context, teamName, user string) error {
 	values := url.Values{
 		"user":       {user},
-		"token":      {api.config.token},
+		"token":      {api.token},
 		"set_active": {"true"},
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest(ctx, "setRegular", teamName, values, api.debug)
+	_, err := adminRequest(ctx, api.httpclient, "setRegular", teamName, values, api.debug)
 	if err != nil {
 		return fmt.Errorf("Failed to change the user (%s) to a regular user: %s", user, err)
 	}
@@ -155,12 +155,12 @@ func (api *Client) SendSSOBindingEmail(teamName, user string) error {
 func (api *Client) SendSSOBindingEmailContext(ctx context.Context, teamName, user string) error {
 	values := url.Values{
 		"user":       {user},
-		"token":      {api.config.token},
+		"token":      {api.token},
 		"set_active": {"true"},
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest(ctx, "sendSSOBind", teamName, values, api.debug)
+	_, err := adminRequest(ctx, api.httpclient, "sendSSOBind", teamName, values, api.debug)
 	if err != nil {
 		return fmt.Errorf("Failed to send SSO binding email for user (%s): %s", user, err)
 	}
@@ -178,12 +178,12 @@ func (api *Client) SetUltraRestrictedContext(ctx context.Context, teamName, uid,
 	values := url.Values{
 		"user":       {uid},
 		"channel":    {channel},
-		"token":      {api.config.token},
+		"token":      {api.token},
 		"set_active": {"true"},
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest(ctx, "setUltraRestricted", teamName, values, api.debug)
+	_, err := adminRequest(ctx, api.httpclient, "setUltraRestricted", teamName, values, api.debug)
 	if err != nil {
 		return fmt.Errorf("Failed to ultra-restrict account: %s", err)
 	}
@@ -200,12 +200,12 @@ func (api *Client) SetRestricted(teamName, uid string) error {
 func (api *Client) SetRestrictedContext(ctx context.Context, teamName, uid string) error {
 	values := url.Values{
 		"user":       {uid},
-		"token":      {api.config.token},
+		"token":      {api.token},
 		"set_active": {"true"},
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest(ctx, "setRestricted", teamName, values, api.debug)
+	_, err := adminRequest(ctx, api.httpclient, "setRestricted", teamName, values, api.debug)
 	if err != nil {
 		return fmt.Errorf("Failed to restrict account: %s", err)
 	}

--- a/bots.go
+++ b/bots.go
@@ -19,9 +19,9 @@ type botResponseFull struct {
 	SlackResponse
 }
 
-func botRequest(ctx context.Context, path string, values url.Values, debug bool) (*botResponseFull, error) {
+func botRequest(ctx context.Context, client HTTPRequester, path string, values url.Values, debug bool) (*botResponseFull, error) {
 	response := &botResponseFull{}
-	err := post(ctx, path, values, response, debug)
+	err := post(ctx, client, path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -39,10 +39,11 @@ func (api *Client) GetBotInfo(bot string) (*Bot, error) {
 // GetBotInfoContext will retrieve the complete bot information using a custom context
 func (api *Client) GetBotInfoContext(ctx context.Context, bot string) (*Bot, error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 		"bot":   {bot},
 	}
-	response, err := botRequest(ctx, "bots.info", values, api.debug)
+
+	response, err := botRequest(ctx, api.httpclient, "bots.info", values, api.debug)
 	if err != nil {
 		return nil, err
 	}

--- a/dnd.go
+++ b/dnd.go
@@ -36,9 +36,9 @@ type dndTeamInfoResponse struct {
 	SlackResponse
 }
 
-func dndRequest(ctx context.Context, path string, values url.Values, debug bool) (*dndResponseFull, error) {
+func dndRequest(ctx context.Context, client HTTPRequester, path string, values url.Values, debug bool) (*dndResponseFull, error) {
 	response := &dndResponseFull{}
-	err := post(ctx, path, values, response, debug)
+	err := post(ctx, client, path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -56,11 +56,12 @@ func (api *Client) EndDND() error {
 // EndDNDContext ends the user's scheduled Do Not Disturb session with a custom context
 func (api *Client) EndDNDContext(ctx context.Context) error {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 	}
 
 	response := &SlackResponse{}
-	if err := post(ctx, "dnd.endDnd", values, response, api.debug); err != nil {
+
+	if err := post(ctx, api.httpclient, "dnd.endDnd", values, response, api.debug); err != nil {
 		return err
 	}
 	if !response.Ok {
@@ -77,10 +78,10 @@ func (api *Client) EndSnooze() (*DNDStatus, error) {
 // EndSnoozeContext ends the current user's snooze mode with a custom context
 func (api *Client) EndSnoozeContext(ctx context.Context) (*DNDStatus, error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 	}
 
-	response, err := dndRequest(ctx, "dnd.endSnooze", values, api.debug)
+	response, err := dndRequest(ctx, api.httpclient, "dnd.endSnooze", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -95,12 +96,13 @@ func (api *Client) GetDNDInfo(user *string) (*DNDStatus, error) {
 // GetDNDInfoContext provides information about a user's current Do Not Disturb settings with a custom context.
 func (api *Client) GetDNDInfoContext(ctx context.Context, user *string) (*DNDStatus, error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 	}
 	if user != nil {
 		values.Set("user", *user)
 	}
-	response, err := dndRequest(ctx, "dnd.info", values, api.debug)
+
+	response, err := dndRequest(ctx, api.httpclient, "dnd.info", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -115,11 +117,12 @@ func (api *Client) GetDNDTeamInfo(users []string) (map[string]DNDStatus, error) 
 // GetDNDTeamInfoContext provides information about a user's current Do Not Disturb settings with a custom context.
 func (api *Client) GetDNDTeamInfoContext(ctx context.Context, users []string) (map[string]DNDStatus, error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 		"users": {strings.Join(users, ",")},
 	}
 	response := &dndTeamInfoResponse{}
-	if err := post(ctx, "dnd.teamInfo", values, response, api.debug); err != nil {
+
+	if err := post(ctx, api.httpclient, "dnd.teamInfo", values, response, api.debug); err != nil {
 		return nil, err
 	}
 	if !response.Ok {
@@ -139,10 +142,11 @@ func (api *Client) SetSnooze(minutes int) (*DNDStatus, error) {
 // For more information see the SetSnooze docs
 func (api *Client) SetSnoozeContext(ctx context.Context, minutes int) (*DNDStatus, error) {
 	values := url.Values{
-		"token":       {api.config.token},
+		"token":       {api.token},
 		"num_minutes": {strconv.Itoa(minutes)},
 	}
-	response, err := dndRequest(ctx, "dnd.setSnooze", values, api.debug)
+
+	response, err := dndRequest(ctx, api.httpclient, "dnd.setSnooze", values, api.debug)
 	if err != nil {
 		return nil, err
 	}

--- a/emoji.go
+++ b/emoji.go
@@ -19,10 +19,11 @@ func (api *Client) GetEmoji() (map[string]string, error) {
 // GetEmojiContext retrieves all the emojis with a custom context
 func (api *Client) GetEmojiContext(ctx context.Context) (map[string]string, error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 	}
 	response := &emojiResponseFull{}
-	err := post(ctx, "emoji.list", values, response, api.debug)
+
+	err := post(ctx, api.httpclient, "emoji.list", values, response, api.debug)
 	if err != nil {
 		return nil, err
 	}

--- a/files.go
+++ b/files.go
@@ -136,9 +136,9 @@ func NewGetFilesParameters() GetFilesParameters {
 	}
 }
 
-func fileRequest(ctx context.Context, path string, values url.Values, debug bool) (*fileResponseFull, error) {
+func fileRequest(ctx context.Context, client HTTPRequester, path string, values url.Values, debug bool) (*fileResponseFull, error) {
 	response := &fileResponseFull{}
-	err := post(ctx, path, values, response, debug)
+	err := postForm(ctx, client, SLACK_API+path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -156,12 +156,13 @@ func (api *Client) GetFileInfo(fileID string, count, page int) (*File, []Comment
 // GetFileInfoContext retrieves a file and related comments with a custom context
 func (api *Client) GetFileInfoContext(ctx context.Context, fileID string, count, page int) (*File, []Comment, *Paging, error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 		"file":  {fileID},
 		"count": {strconv.Itoa(count)},
 		"page":  {strconv.Itoa(page)},
 	}
-	response, err := fileRequest(ctx, "files.info", values, api.debug)
+
+	response, err := fileRequest(ctx, api.httpclient, "files.info", values, api.debug)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -176,7 +177,7 @@ func (api *Client) GetFiles(params GetFilesParameters) ([]File, *Paging, error) 
 // GetFilesContext retrieves all files according to the parameters given with a custom context
 func (api *Client) GetFilesContext(ctx context.Context, params GetFilesParameters) ([]File, *Paging, error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 	}
 	if params.User != DEFAULT_FILES_USER {
 		values.Add("user", params.User)
@@ -199,7 +200,8 @@ func (api *Client) GetFilesContext(ctx context.Context, params GetFilesParameter
 	if params.Page != DEFAULT_FILES_PAGE {
 		values.Add("page", strconv.Itoa(params.Page))
 	}
-	response, err := fileRequest(ctx, "files.list", values, api.debug)
+
+	response, err := fileRequest(ctx, api.httpclient, "files.list", values, api.debug)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -221,7 +223,7 @@ func (api *Client) UploadFileContext(ctx context.Context, params FileUploadParam
 	}
 	response := &fileResponseFull{}
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 	}
 	if params.Filetype != "" {
 		values.Add("filetype", params.Filetype)
@@ -240,11 +242,11 @@ func (api *Client) UploadFileContext(ctx context.Context, params FileUploadParam
 	}
 	if params.Content != "" {
 		values.Add("content", params.Content)
-		err = post(ctx, "files.upload", values, response, api.debug)
+		err = postForm(ctx, api.httpclient, SLACK_API+"files.upload", values, response, api.debug)
 	} else if params.File != "" {
-		err = postLocalWithMultipartResponse(ctx, "files.upload", params.File, "file", values, response, api.debug)
+		err = postLocalWithMultipartResponse(ctx, api.httpclient, SLACK_API+"files.upload", params.File, "file", values, response, api.debug)
 	} else if params.Reader != nil {
-		err = postWithMultipartResponse(ctx, "files.upload", params.Filename, "file", values, params.Reader, response, api.debug)
+		err = postWithMultipartResponse(ctx, api.httpclient, SLACK_API+"files.upload", params.Filename, "file", values, params.Reader, response, api.debug)
 	}
 	if err != nil {
 		return nil, err
@@ -261,14 +263,17 @@ func (api *Client) DeleteFile(fileID string) error {
 }
 
 // DeleteFileContext deletes a file with a custom context
-func (api *Client) DeleteFileContext(ctx context.Context, fileID string) error {
+func (api *Client) DeleteFileContext(ctx context.Context, fileID string) (err error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 		"file":  {fileID},
 	}
-	_, err := fileRequest(ctx, "files.delete", values, api.debug)
-	return err
 
+	if _, err = fileRequest(ctx, api.httpclient, "files.delete", values, api.debug); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // RevokeFilePublicURL disables public/external sharing for a file
@@ -279,10 +284,11 @@ func (api *Client) RevokeFilePublicURL(fileID string) (*File, error) {
 // RevokeFilePublicURLContext disables public/external sharing for a file with a custom context
 func (api *Client) RevokeFilePublicURLContext(ctx context.Context, fileID string) (*File, error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 		"file":  {fileID},
 	}
-	response, err := fileRequest(ctx, "files.revokePublicURL", values, api.debug)
+
+	response, err := fileRequest(ctx, api.httpclient, "files.revokePublicURL", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -297,10 +303,11 @@ func (api *Client) ShareFilePublicURL(fileID string) (*File, []Comment, *Paging,
 // ShareFilePublicURLContext enabled public/external sharing for a file with a custom context
 func (api *Client) ShareFilePublicURLContext(ctx context.Context, fileID string) (*File, []Comment, *Paging, error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 		"file":  {fileID},
 	}
-	response, err := fileRequest(ctx, "files.sharedPublicURL", values, api.debug)
+
+	response, err := fileRequest(ctx, api.httpclient, "files.sharedPublicURL", values, api.debug)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/groups.go
+++ b/groups.go
@@ -28,9 +28,9 @@ type groupResponseFull struct {
 	SlackResponse
 }
 
-func groupRequest(ctx context.Context, path string, values url.Values, debug bool) (*groupResponseFull, error) {
+func groupRequest(ctx context.Context, client HTTPRequester, path string, values url.Values, debug bool) (*groupResponseFull, error) {
 	response := &groupResponseFull{}
-	err := post(ctx, path, values, response, debug)
+	err := postForm(ctx, client, SLACK_API+path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -45,17 +45,18 @@ func (api *Client) ArchiveGroup(group string) error {
 	return api.ArchiveGroupContext(context.Background(), group)
 }
 
-// ArchiveGroup archives a private group
+// ArchiveGroupContext archives a private group
 func (api *Client) ArchiveGroupContext(ctx context.Context, group string) error {
 	values := url.Values{
-		"token":   {api.config.token},
+		"token":   {api.token},
 		"channel": {group},
 	}
-	_, err := groupRequest(ctx, "groups.archive", values, api.debug)
+
+	_, err := groupRequest(ctx, api.httpclient, "groups.archive", values, api.debug)
 	if err != nil {
 		return err
 	}
-	return nil
+	return err
 }
 
 // UnarchiveGroup unarchives a private group
@@ -63,13 +64,14 @@ func (api *Client) UnarchiveGroup(group string) error {
 	return api.UnarchiveGroupContext(context.Background(), group)
 }
 
-// UnarchiveGroup unarchives a private group
+// UnarchiveGroupContext unarchives a private group
 func (api *Client) UnarchiveGroupContext(ctx context.Context, group string) error {
 	values := url.Values{
-		"token":   {api.config.token},
+		"token":   {api.token},
 		"channel": {group},
 	}
-	_, err := groupRequest(ctx, "groups.unarchive", values, api.debug)
+
+	_, err := groupRequest(ctx, api.httpclient, "groups.unarchive", values, api.debug)
 	if err != nil {
 		return err
 	}
@@ -81,13 +83,14 @@ func (api *Client) CreateGroup(group string) (*Group, error) {
 	return api.CreateGroupContext(context.Background(), group)
 }
 
-// CreateGroup creates a private group
+// CreateGroupContext creates a private group
 func (api *Client) CreateGroupContext(ctx context.Context, group string) (*Group, error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 		"name":  {group},
 	}
-	response, err := groupRequest(ctx, "groups.create", values, api.debug)
+
+	response, err := groupRequest(ctx, api.httpclient, "groups.create", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -104,14 +107,15 @@ func (api *Client) CreateChildGroup(group string) (*Group, error) {
 	return api.CreateChildGroupContext(context.Background(), group)
 }
 
-// CreateChildGroup creates a new private group archiving the old one with a custom context
+// CreateChildGroupContext creates a new private group archiving the old one with a custom context
 // For more information see CreateChildGroup
 func (api *Client) CreateChildGroupContext(ctx context.Context, group string) (*Group, error) {
 	values := url.Values{
-		"token":   {api.config.token},
+		"token":   {api.token},
 		"channel": {group},
 	}
-	response, err := groupRequest(ctx, "groups.createChild", values, api.debug)
+
+	response, err := groupRequest(ctx, api.httpclient, "groups.createChild", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -126,10 +130,11 @@ func (api *Client) CloseGroup(group string) (bool, bool, error) {
 // CloseGroupContext closes a private group with a custom context
 func (api *Client) CloseGroupContext(ctx context.Context, group string) (bool, bool, error) {
 	values := url.Values{
-		"token":   {api.config.token},
+		"token":   {api.token},
 		"channel": {group},
 	}
-	response, err := imRequest(ctx, "groups.close", values, api.debug)
+
+	response, err := imRequest(ctx, api.httpclient, "groups.close", values, api.debug)
 	if err != nil {
 		return false, false, err
 	}
@@ -144,7 +149,7 @@ func (api *Client) GetGroupHistory(group string, params HistoryParameters) (*His
 // GetGroupHistoryContext fetches all the history for a private group with a custom context
 func (api *Client) GetGroupHistoryContext(ctx context.Context, group string, params HistoryParameters) (*History, error) {
 	values := url.Values{
-		"token":   {api.config.token},
+		"token":   {api.token},
 		"channel": {group},
 	}
 	if params.Latest != DEFAULT_HISTORY_LATEST {
@@ -170,7 +175,8 @@ func (api *Client) GetGroupHistoryContext(ctx context.Context, group string, par
 			values.Add("unreads", "0")
 		}
 	}
-	response, err := groupRequest(ctx, "groups.history", values, api.debug)
+
+	response, err := groupRequest(ctx, api.httpclient, "groups.history", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -185,11 +191,12 @@ func (api *Client) InviteUserToGroup(group, user string) (*Group, bool, error) {
 // InviteUserToGroupContext invites a specific user to a private group with a custom context
 func (api *Client) InviteUserToGroupContext(ctx context.Context, group, user string) (*Group, bool, error) {
 	values := url.Values{
-		"token":   {api.config.token},
+		"token":   {api.token},
 		"channel": {group},
 		"user":    {user},
 	}
-	response, err := groupRequest(ctx, "groups.invite", values, api.debug)
+
+	response, err := groupRequest(ctx, api.httpclient, "groups.invite", values, api.debug)
 	if err != nil {
 		return nil, false, err
 	}
@@ -202,13 +209,17 @@ func (api *Client) LeaveGroup(group string) error {
 }
 
 // LeaveGroupContext makes authenticated user leave the group with a custom context
-func (api *Client) LeaveGroupContext(ctx context.Context, group string) error {
+func (api *Client) LeaveGroupContext(ctx context.Context, group string) (err error) {
 	values := url.Values{
-		"token":   {api.config.token},
+		"token":   {api.token},
 		"channel": {group},
 	}
-	_, err := groupRequest(ctx, "groups.leave", values, api.debug)
-	return err
+
+	if _, err = groupRequest(ctx, api.httpclient, "groups.leave", values, api.debug); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // KickUserFromGroup kicks a user from a group
@@ -217,14 +228,18 @@ func (api *Client) KickUserFromGroup(group, user string) error {
 }
 
 // KickUserFromGroupContext kicks a user from a group with a custom context
-func (api *Client) KickUserFromGroupContext(ctx context.Context, group, user string) error {
+func (api *Client) KickUserFromGroupContext(ctx context.Context, group, user string) (err error) {
 	values := url.Values{
-		"token":   {api.config.token},
+		"token":   {api.token},
 		"channel": {group},
 		"user":    {user},
 	}
-	_, err := groupRequest(ctx, "groups.kick", values, api.debug)
-	return err
+
+	if _, err = groupRequest(ctx, api.httpclient, "groups.kick", values, api.debug); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // GetGroups retrieves all groups
@@ -235,12 +250,13 @@ func (api *Client) GetGroups(excludeArchived bool) ([]Group, error) {
 // GetGroupsContext retrieves all groups with a custom context
 func (api *Client) GetGroupsContext(ctx context.Context, excludeArchived bool) ([]Group, error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 	}
 	if excludeArchived {
 		values.Add("exclude_archived", "1")
 	}
-	response, err := groupRequest(ctx, "groups.list", values, api.debug)
+
+	response, err := groupRequest(ctx, api.httpclient, "groups.list", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -255,10 +271,11 @@ func (api *Client) GetGroupInfo(group string) (*Group, error) {
 // GetGroupInfoContext retrieves the given group with a custom context
 func (api *Client) GetGroupInfoContext(ctx context.Context, group string) (*Group, error) {
 	values := url.Values{
-		"token":   {api.config.token},
+		"token":   {api.token},
 		"channel": {group},
 	}
-	response, err := groupRequest(ctx, "groups.info", values, api.debug)
+
+	response, err := groupRequest(ctx, api.httpclient, "groups.info", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -276,14 +293,18 @@ func (api *Client) SetGroupReadMark(group, ts string) error {
 
 // SetGroupReadMarkContext sets the read mark on a private group with a custom context
 // For more details see SetGroupReadMark
-func (api *Client) SetGroupReadMarkContext(ctx context.Context, group, ts string) error {
+func (api *Client) SetGroupReadMarkContext(ctx context.Context, group, ts string) (err error) {
 	values := url.Values{
-		"token":   {api.config.token},
+		"token":   {api.token},
 		"channel": {group},
 		"ts":      {ts},
 	}
-	_, err := groupRequest(ctx, "groups.mark", values, api.debug)
-	return err
+
+	if _, err = groupRequest(ctx, api.httpclient, "groups.mark", values, api.debug); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // OpenGroup opens a private group
@@ -294,10 +315,11 @@ func (api *Client) OpenGroup(group string) (bool, bool, error) {
 // OpenGroupContext opens a private group with a custom context
 func (api *Client) OpenGroupContext(ctx context.Context, group string) (bool, bool, error) {
 	values := url.Values{
-		"token":   {api.config.token},
+		"token":   {api.token},
 		"channel": {group},
 	}
-	response, err := groupRequest(ctx, "groups.open", values, api.debug)
+
+	response, err := groupRequest(ctx, api.httpclient, "groups.open", values, api.debug)
 	if err != nil {
 		return false, false, err
 	}
@@ -314,13 +336,14 @@ func (api *Client) RenameGroup(group, name string) (*Channel, error) {
 // RenameGroupContext renames a group with a custom context
 func (api *Client) RenameGroupContext(ctx context.Context, group, name string) (*Channel, error) {
 	values := url.Values{
-		"token":   {api.config.token},
+		"token":   {api.token},
 		"channel": {group},
 		"name":    {name},
 	}
+
 	// XXX: the created entry in this call returns a string instead of a number
 	// so I may have to do some workaround to solve it.
-	response, err := groupRequest(ctx, "groups.rename", values, api.debug)
+	response, err := groupRequest(ctx, api.httpclient, "groups.rename", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -335,11 +358,12 @@ func (api *Client) SetGroupPurpose(group, purpose string) (string, error) {
 // SetGroupPurposeContext sets the group purpose with a custom context
 func (api *Client) SetGroupPurposeContext(ctx context.Context, group, purpose string) (string, error) {
 	values := url.Values{
-		"token":   {api.config.token},
+		"token":   {api.token},
 		"channel": {group},
 		"purpose": {purpose},
 	}
-	response, err := groupRequest(ctx, "groups.setPurpose", values, api.debug)
+
+	response, err := groupRequest(ctx, api.httpclient, "groups.setPurpose", values, api.debug)
 	if err != nil {
 		return "", err
 	}
@@ -354,11 +378,12 @@ func (api *Client) SetGroupTopic(group, topic string) (string, error) {
 // SetGroupTopicContext sets the group topic with a custom context
 func (api *Client) SetGroupTopicContext(ctx context.Context, group, topic string) (string, error) {
 	values := url.Values{
-		"token":   {api.config.token},
+		"token":   {api.token},
 		"channel": {group},
 		"topic":   {topic},
 	}
-	response, err := groupRequest(ctx, "groups.setTopic", values, api.debug)
+
+	response, err := groupRequest(ctx, api.httpclient, "groups.setTopic", values, api.debug)
 	if err != nil {
 		return "", err
 	}

--- a/im.go
+++ b/im.go
@@ -29,9 +29,9 @@ type IM struct {
 	IsUserDeleted bool   `json:"is_user_deleted"`
 }
 
-func imRequest(ctx context.Context, path string, values url.Values, debug bool) (*imResponseFull, error) {
+func imRequest(ctx context.Context, client HTTPRequester, path string, values url.Values, debug bool) (*imResponseFull, error) {
 	response := &imResponseFull{}
-	err := post(ctx, path, values, response, debug)
+	err := post(ctx, client, path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -49,10 +49,11 @@ func (api *Client) CloseIMChannel(channel string) (bool, bool, error) {
 // CloseIMChannelContext closes the direct message channel with a custom context
 func (api *Client) CloseIMChannelContext(ctx context.Context, channel string) (bool, bool, error) {
 	values := url.Values{
-		"token":   {api.config.token},
+		"token":   {api.token},
 		"channel": {channel},
 	}
-	response, err := imRequest(ctx, "im.close", values, api.debug)
+
+	response, err := imRequest(ctx, api.httpclient, "im.close", values, api.debug)
 	if err != nil {
 		return false, false, err
 	}
@@ -69,10 +70,11 @@ func (api *Client) OpenIMChannel(user string) (bool, bool, string, error) {
 // Returns some status and the channel ID
 func (api *Client) OpenIMChannelContext(ctx context.Context, user string) (bool, bool, string, error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 		"user":  {user},
 	}
-	response, err := imRequest(ctx, "im.open", values, api.debug)
+
+	response, err := imRequest(ctx, api.httpclient, "im.open", values, api.debug)
 	if err != nil {
 		return false, false, "", err
 	}
@@ -87,11 +89,12 @@ func (api *Client) MarkIMChannel(channel, ts string) (err error) {
 // MarkIMChannelContext sets the read mark of a direct message channel to a specific point with a custom context
 func (api *Client) MarkIMChannelContext(ctx context.Context, channel, ts string) (err error) {
 	values := url.Values{
-		"token":   {api.config.token},
+		"token":   {api.token},
 		"channel": {channel},
 		"ts":      {ts},
 	}
-	_, err = imRequest(ctx, "im.mark", values, api.debug)
+
+	_, err = imRequest(ctx, api.httpclient, "im.mark", values, api.debug)
 	if err != nil {
 		return err
 	}
@@ -106,7 +109,7 @@ func (api *Client) GetIMHistory(channel string, params HistoryParameters) (*Hist
 // GetIMHistoryContext retrieves the direct message channel history with a custom context
 func (api *Client) GetIMHistoryContext(ctx context.Context, channel string, params HistoryParameters) (*History, error) {
 	values := url.Values{
-		"token":   {api.config.token},
+		"token":   {api.token},
 		"channel": {channel},
 	}
 	if params.Latest != DEFAULT_HISTORY_LATEST {
@@ -132,7 +135,8 @@ func (api *Client) GetIMHistoryContext(ctx context.Context, channel string, para
 			values.Add("unreads", "0")
 		}
 	}
-	response, err := imRequest(ctx, "im.history", values, api.debug)
+
+	response, err := imRequest(ctx, api.httpclient, "im.history", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -147,9 +151,10 @@ func (api *Client) GetIMChannels() ([]IM, error) {
 // GetIMChannelsContext returns the list of direct message channels with a custom context
 func (api *Client) GetIMChannelsContext(ctx context.Context) ([]IM, error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 	}
-	response, err := imRequest(ctx, "im.list", values, api.debug)
+
+	response, err := imRequest(ctx, api.httpclient, "im.list", values, api.debug)
 	if err != nil {
 		return nil, err
 	}

--- a/misc_test.go
+++ b/misc_test.go
@@ -41,7 +41,7 @@ func TestParseResponse(t *testing.T) {
 		"token": {validToken},
 	}
 	responsePartial := &SlackResponse{}
-	err := post(context.Background(), "parseResponse", values, responsePartial, false)
+	err := post(context.Background(), http.DefaultClient, "parseResponse", values, responsePartial, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -53,7 +53,7 @@ func TestParseResponseNoToken(t *testing.T) {
 	SLACK_API = "http://" + serverAddr + "/"
 	values := url.Values{}
 	responsePartial := &SlackResponse{}
-	err := post(context.Background(), "parseResponse", values, responsePartial, false)
+	err := post(context.Background(), http.DefaultClient, "parseResponse", values, responsePartial, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 		return
@@ -73,7 +73,7 @@ func TestParseResponseInvalidToken(t *testing.T) {
 		"token": {"whatever"},
 	}
 	responsePartial := &SlackResponse{}
-	err := post(context.Background(), "parseResponse", values, responsePartial, false)
+	err := post(context.Background(), http.DefaultClient, "parseResponse", values, responsePartial, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 		return

--- a/oauth.go
+++ b/oauth.go
@@ -55,7 +55,7 @@ func GetOAuthResponseContext(ctx context.Context, clientID, clientSecret, code, 
 		"redirect_uri":  {redirectURI},
 	}
 	response := &OAuthResponse{}
-	err = post(ctx, "oauth.access", values, response, debug)
+	err = post(ctx, customHTTPClient, "oauth.access", values, response, debug)
 	if err != nil {
 		return nil, err
 	}

--- a/pins.go
+++ b/pins.go
@@ -21,7 +21,7 @@ func (api *Client) AddPin(channel string, item ItemRef) error {
 func (api *Client) AddPinContext(ctx context.Context, channel string, item ItemRef) error {
 	values := url.Values{
 		"channel": {channel},
-		"token":   {api.config.token},
+		"token":   {api.token},
 	}
 	if item.Timestamp != "" {
 		values.Set("timestamp", string(item.Timestamp))
@@ -32,8 +32,9 @@ func (api *Client) AddPinContext(ctx context.Context, channel string, item ItemR
 	if item.Comment != "" {
 		values.Set("file_comment", string(item.Comment))
 	}
+
 	response := &SlackResponse{}
-	if err := post(ctx, "pins.add", values, response, api.debug); err != nil {
+	if err := post(ctx, api.httpclient, "pins.add", values, response, api.debug); err != nil {
 		return err
 	}
 	if !response.Ok {
@@ -51,7 +52,7 @@ func (api *Client) RemovePin(channel string, item ItemRef) error {
 func (api *Client) RemovePinContext(ctx context.Context, channel string, item ItemRef) error {
 	values := url.Values{
 		"channel": {channel},
-		"token":   {api.config.token},
+		"token":   {api.token},
 	}
 	if item.Timestamp != "" {
 		values.Set("timestamp", string(item.Timestamp))
@@ -62,8 +63,9 @@ func (api *Client) RemovePinContext(ctx context.Context, channel string, item It
 	if item.Comment != "" {
 		values.Set("file_comment", string(item.Comment))
 	}
+
 	response := &SlackResponse{}
-	if err := post(ctx, "pins.remove", values, response, api.debug); err != nil {
+	if err := post(ctx, api.httpclient, "pins.remove", values, response, api.debug); err != nil {
 		return err
 	}
 	if !response.Ok {
@@ -81,10 +83,11 @@ func (api *Client) ListPins(channel string) ([]Item, *Paging, error) {
 func (api *Client) ListPinsContext(ctx context.Context, channel string) ([]Item, *Paging, error) {
 	values := url.Values{
 		"channel": {channel},
-		"token":   {api.config.token},
+		"token":   {api.token},
 	}
+
 	response := &listPinsResponseFull{}
-	err := post(ctx, "pins.list", values, response, api.debug)
+	err := post(ctx, api.httpclient, "pins.list", values, response, api.debug)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/reactions.go
+++ b/reactions.go
@@ -136,7 +136,7 @@ func (api *Client) AddReaction(name string, item ItemRef) error {
 // AddReactionContext adds a reaction emoji to a message, file or file comment with a custom context.
 func (api *Client) AddReactionContext(ctx context.Context, name string, item ItemRef) error {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 	}
 	if name != "" {
 		values.Set("name", name)
@@ -153,8 +153,9 @@ func (api *Client) AddReactionContext(ctx context.Context, name string, item Ite
 	if item.Comment != "" {
 		values.Set("file_comment", string(item.Comment))
 	}
+
 	response := &SlackResponse{}
-	if err := post(ctx, "reactions.add", values, response, api.debug); err != nil {
+	if err := post(ctx, api.httpclient, "reactions.add", values, response, api.debug); err != nil {
 		return err
 	}
 	if !response.Ok {
@@ -171,7 +172,7 @@ func (api *Client) RemoveReaction(name string, item ItemRef) error {
 // RemoveReactionContext removes a reaction emoji from a message, file or file comment with a custom context.
 func (api *Client) RemoveReactionContext(ctx context.Context, name string, item ItemRef) error {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 	}
 	if name != "" {
 		values.Set("name", name)
@@ -188,8 +189,9 @@ func (api *Client) RemoveReactionContext(ctx context.Context, name string, item 
 	if item.Comment != "" {
 		values.Set("file_comment", string(item.Comment))
 	}
+
 	response := &SlackResponse{}
-	if err := post(ctx, "reactions.remove", values, response, api.debug); err != nil {
+	if err := post(ctx, api.httpclient, "reactions.remove", values, response, api.debug); err != nil {
 		return err
 	}
 	if !response.Ok {
@@ -206,7 +208,7 @@ func (api *Client) GetReactions(item ItemRef, params GetReactionsParameters) ([]
 // GetReactionsContext returns details about the reactions on an item with a custom context
 func (api *Client) GetReactionsContext(ctx context.Context, item ItemRef, params GetReactionsParameters) ([]ItemReaction, error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 	}
 	if item.Channel != "" {
 		values.Set("channel", string(item.Channel))
@@ -223,8 +225,9 @@ func (api *Client) GetReactionsContext(ctx context.Context, item ItemRef, params
 	if params.Full != DEFAULT_REACTIONS_FULL {
 		values.Set("full", strconv.FormatBool(params.Full))
 	}
+
 	response := &getReactionsResponseFull{}
-	if err := post(ctx, "reactions.get", values, response, api.debug); err != nil {
+	if err := post(ctx, api.httpclient, "reactions.get", values, response, api.debug); err != nil {
 		return nil, err
 	}
 	if !response.Ok {
@@ -241,7 +244,7 @@ func (api *Client) ListReactions(params ListReactionsParameters) ([]ReactedItem,
 // ListReactionsContext returns information about the items a user reacted to with a custom context.
 func (api *Client) ListReactionsContext(ctx context.Context, params ListReactionsParameters) ([]ReactedItem, *Paging, error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 	}
 	if params.User != DEFAULT_REACTIONS_USER {
 		values.Add("user", params.User)
@@ -255,8 +258,9 @@ func (api *Client) ListReactionsContext(ctx context.Context, params ListReaction
 	if params.Full != DEFAULT_REACTIONS_FULL {
 		values.Add("full", strconv.FormatBool(params.Full))
 	}
+
 	response := &listReactionsResponseFull{}
-	err := post(ctx, "reactions.list", values, response, api.debug)
+	err := post(ctx, api.httpclient, "reactions.list", values, response, api.debug)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/rtm.go
+++ b/rtm.go
@@ -20,7 +20,7 @@ func (api *Client) StartRTM() (info *Info, websocketURL string, err error) {
 // To have a fully managed Websocket connection, use `NewRTM`, and call `ManageConnection()` on it.
 func (api *Client) StartRTMContext(ctx context.Context) (info *Info, websocketURL string, err error) {
 	response := &infoResponseFull{}
-	err = post(ctx, "rtm.start", url.Values{"token": {api.config.token}}, response, api.debug)
+	err = post(ctx, api.httpclient, "rtm.start", url.Values{"token": {api.token}}, response, api.debug)
 	if err != nil {
 		return nil, "", fmt.Errorf("post: %s", err)
 	}
@@ -43,7 +43,7 @@ func (api *Client) ConnectRTM() (info *Info, websocketURL string, err error) {
 // To have a fully managed Websocket connection, use `NewRTM`, and call `ManageConnection()` on it.
 func (api *Client) ConnectRTMContext(ctx context.Context) (info *Info, websocketURL string, err error) {
 	response := &infoResponseFull{}
-	err = post(ctx, "rtm.connect", url.Values{"token": {api.config.token}}, response, api.debug)
+	err = post(ctx, api.httpclient, "rtm.connect", url.Values{"token": {api.token}}, response, api.debug)
 	if err != nil {
 		return nil, "", fmt.Errorf("post: %s", err)
 	}

--- a/search.go
+++ b/search.go
@@ -83,7 +83,7 @@ func NewSearchParameters() SearchParameters {
 
 func (api *Client) _search(ctx context.Context, path, query string, params SearchParameters, files, messages bool) (response *searchResponseFull, error error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 		"query": {query},
 	}
 	if params.Sort != DEFAULT_SEARCH_SORT {
@@ -101,8 +101,9 @@ func (api *Client) _search(ctx context.Context, path, query string, params Searc
 	if params.Page != DEFAULT_SEARCH_PAGE {
 		values.Add("page", strconv.Itoa(params.Page))
 	}
+
 	response = &searchResponseFull{}
-	err := post(ctx, path, values, response, api.debug)
+	err := post(ctx, api.httpclient, path, values, response, api.debug)
 	if err != nil {
 		return nil, err
 	}

--- a/slack.go
+++ b/slack.go
@@ -4,17 +4,42 @@ import (
 	"context"
 	"errors"
 	"log"
+	"net/http"
 	"net/url"
 	"os"
 	"fmt"
 )
 
-var logger *log.Logger // A logger that can be set by consumers
+var (
+	logger *log.Logger // A logger that can be set by consumers
+)
+
 /*
   Added as a var so that we can change this for testing purposes
 */
 var SLACK_API string = "https://slack.com/api/"
 var SLACK_WEB_API_FORMAT string = "https://%s.slack.com/api/users.admin.%s?t=%s"
+
+// HTTPClient sets a custom http.Client
+// deprecated: in favor of SetHTTPClient()
+var HTTPClient = &http.Client{}
+
+var customHTTPClient HTTPRequester = HTTPClient
+
+// HTTPRequester defines the minimal interface needed for an http.Client to be implemented.
+//
+// Use it in conjunction with the SetHTTPClient function to allow for other capabilities
+// like a tracing http.Client
+type HTTPRequester interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// SetHTTPClient allows you to specify a custom http.Client
+// Use this instead of the package level HTTPClient variable if you want to use a custom client like the
+// Stackdriver Trace HTTPClient https://godoc.org/cloud.google.com/go/trace#HTTPClient
+func SetHTTPClient(client HTTPRequester) {
+	customHTTPClient = client
+}
 
 type SlackResponse struct {
 	Ok    bool   `json:"ok"`
@@ -35,11 +60,10 @@ type authTestResponseFull struct {
 }
 
 type Client struct {
-	config struct {
-		token string
-	}
-	info  Info
-	debug bool
+	token      string
+	info       Info
+	debug      bool
+	httpclient HTTPRequester
 }
 
 // SetLogger let's library users supply a logger, so that api debugging
@@ -48,9 +72,27 @@ func SetLogger(l *log.Logger) {
 	logger = l
 }
 
-func New(token string) *Client {
-	s := &Client{}
-	s.config.token = token
+// Option defines an option for a Client
+type Option func(*Client)
+
+// OptionHTTPClient - provide a custom http client to the slack client.
+func OptionHTTPClient(c HTTPRequester) func(*Client) {
+	return func(s *Client) {
+		s.httpclient = c
+	}
+}
+
+// New builds a slack client from the provided token and options.
+func New(token string, options ...Option) *Client {
+	s := &Client{
+		token:      token,
+		httpclient: customHTTPClient,
+	}
+
+	for _, opt := range options {
+		opt(s)
+	}
+
 	return s
 }
 
@@ -62,7 +104,7 @@ func (api *Client) AuthTest() (response *AuthTestResponse, error error) {
 // AuthTestContext tests if the user is able to do authenticated requests or not with a custom context
 func (api *Client) AuthTestContext(ctx context.Context) (response *AuthTestResponse, error error) {
 	responseFull := &authTestResponseFull{}
-	err := post(ctx, "auth.test", url.Values{"token": {api.config.token}}, responseFull, api.debug)
+	err := post(ctx, api.httpclient, "auth.test", url.Values{"token": {api.token}}, responseFull, api.debug)
 	if err != nil {
 		return nil, err
 	}

--- a/stars.go
+++ b/stars.go
@@ -45,7 +45,7 @@ func (api *Client) AddStar(channel string, item ItemRef) error {
 func (api *Client) AddStarContext(ctx context.Context, channel string, item ItemRef) error {
 	values := url.Values{
 		"channel": {channel},
-		"token":   {api.config.token},
+		"token":   {api.token},
 	}
 	if item.Timestamp != "" {
 		values.Set("timestamp", string(item.Timestamp))
@@ -56,8 +56,9 @@ func (api *Client) AddStarContext(ctx context.Context, channel string, item Item
 	if item.Comment != "" {
 		values.Set("file_comment", string(item.Comment))
 	}
+
 	response := &SlackResponse{}
-	if err := post(ctx, "stars.add", values, response, api.debug); err != nil {
+	if err := post(ctx, api.httpclient, "stars.add", values, response, api.debug); err != nil {
 		return err
 	}
 	if !response.Ok {
@@ -75,7 +76,7 @@ func (api *Client) RemoveStar(channel string, item ItemRef) error {
 func (api *Client) RemoveStarContext(ctx context.Context, channel string, item ItemRef) error {
 	values := url.Values{
 		"channel": {channel},
-		"token":   {api.config.token},
+		"token":   {api.token},
 	}
 	if item.Timestamp != "" {
 		values.Set("timestamp", string(item.Timestamp))
@@ -86,8 +87,9 @@ func (api *Client) RemoveStarContext(ctx context.Context, channel string, item I
 	if item.Comment != "" {
 		values.Set("file_comment", string(item.Comment))
 	}
+
 	response := &SlackResponse{}
-	if err := post(ctx, "stars.remove", values, response, api.debug); err != nil {
+	if err := post(ctx, api.httpclient, "stars.remove", values, response, api.debug); err != nil {
 		return err
 	}
 	if !response.Ok {
@@ -104,7 +106,7 @@ func (api *Client) ListStars(params StarsParameters) ([]Item, *Paging, error) {
 // ListStarsContext returns information about the stars a user added with a custom context
 func (api *Client) ListStarsContext(ctx context.Context, params StarsParameters) ([]Item, *Paging, error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 	}
 	if params.User != DEFAULT_STARS_USER {
 		values.Add("user", params.User)
@@ -115,8 +117,9 @@ func (api *Client) ListStarsContext(ctx context.Context, params StarsParameters)
 	if params.Page != DEFAULT_STARS_PAGE {
 		values.Add("page", strconv.Itoa(params.Page))
 	}
+
 	response := &listResponseFull{}
-	err := post(ctx, "stars.list", values, response, api.debug)
+	err := post(ctx, api.httpclient, "stars.list", values, response, api.debug)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/team.go
+++ b/team.go
@@ -67,9 +67,9 @@ func NewAccessLogParameters() AccessLogParameters {
 	}
 }
 
-func teamRequest(ctx context.Context, path string, values url.Values, debug bool) (*TeamResponse, error) {
+func teamRequest(ctx context.Context, client HTTPRequester, path string, values url.Values, debug bool) (*TeamResponse, error) {
 	response := &TeamResponse{}
-	err := post(ctx, path, values, response, debug)
+	err := post(ctx, client, path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -81,9 +81,9 @@ func teamRequest(ctx context.Context, path string, values url.Values, debug bool
 	return response, nil
 }
 
-func billableInfoRequest(ctx context.Context, path string, values url.Values, debug bool) (map[string]BillingActive, error) {
+func billableInfoRequest(ctx context.Context, client HTTPRequester, path string, values url.Values, debug bool) (map[string]BillingActive, error) {
 	response := &BillableInfoResponse{}
-	err := post(ctx, path, values, response, debug)
+	err := post(ctx, client, path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -95,9 +95,9 @@ func billableInfoRequest(ctx context.Context, path string, values url.Values, de
 	return response.BillableInfo, nil
 }
 
-func accessLogsRequest(ctx context.Context, path string, values url.Values, debug bool) (*LoginResponse, error) {
+func accessLogsRequest(ctx context.Context, client HTTPRequester, path string, values url.Values, debug bool) (*LoginResponse, error) {
 	response := &LoginResponse{}
-	err := post(ctx, path, values, response, debug)
+	err := post(ctx, client, path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -115,10 +115,10 @@ func (api *Client) GetTeamInfo() (*TeamInfo, error) {
 // GetTeamInfoContext gets the Team Information of the user with a custom context
 func (api *Client) GetTeamInfoContext(ctx context.Context) (*TeamInfo, error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 	}
 
-	response, err := teamRequest(ctx, "team.info", values, api.debug)
+	response, err := teamRequest(ctx, api.httpclient, "team.info", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func (api *Client) GetAccessLogs(params AccessLogParameters) ([]Login, *Paging, 
 // GetAccessLogsContext retrieves a page of logins according to the parameters given with a custom context
 func (api *Client) GetAccessLogsContext(ctx context.Context, params AccessLogParameters) ([]Login, *Paging, error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 	}
 	if params.Count != DEFAULT_LOGINS_COUNT {
 		values.Add("count", strconv.Itoa(params.Count))
@@ -141,7 +141,8 @@ func (api *Client) GetAccessLogsContext(ctx context.Context, params AccessLogPar
 	if params.Page != DEFAULT_LOGINS_PAGE {
 		values.Add("page", strconv.Itoa(params.Page))
 	}
-	response, err := accessLogsRequest(ctx, "team.accessLogs", values, api.debug)
+
+	response, err := accessLogsRequest(ctx, api.httpclient, "team.accessLogs", values, api.debug)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -154,11 +155,11 @@ func (api *Client) GetBillableInfo(user string) (map[string]BillingActive, error
 
 func (api *Client) GetBillableInfoContext(ctx context.Context, user string) (map[string]BillingActive, error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 		"user":  {user},
 	}
 
-	return billableInfoRequest(ctx, "team.billableInfo", values, api.debug)
+	return billableInfoRequest(ctx, api.httpclient, "team.billableInfo", values, api.debug)
 }
 
 // GetBillableInfoForTeam returns the billing_active status of all users on the team.
@@ -169,8 +170,8 @@ func (api *Client) GetBillableInfoForTeam() (map[string]BillingActive, error) {
 // GetBillableInfoForTeamContext returns the billing_active status of all users on the team with a custom context
 func (api *Client) GetBillableInfoForTeamContext(ctx context.Context) (map[string]BillingActive, error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 	}
 
-	return billableInfoRequest(ctx, "team.billableInfo", values, api.debug)
+	return billableInfoRequest(ctx, api.httpclient, "team.billableInfo", values, api.debug)
 }

--- a/usergroups.go
+++ b/usergroups.go
@@ -40,9 +40,9 @@ type userGroupResponseFull struct {
 	SlackResponse
 }
 
-func userGroupRequest(ctx context.Context, path string, values url.Values, debug bool) (*userGroupResponseFull, error) {
+func userGroupRequest(ctx context.Context, client HTTPRequester, path string, values url.Values, debug bool) (*userGroupResponseFull, error) {
 	response := &userGroupResponseFull{}
-	err := post(ctx, path, values, response, debug)
+	err := post(ctx, client, path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (api *Client) CreateUserGroup(userGroup UserGroup) (UserGroup, error) {
 // CreateUserGroupContext creates a new user group with a custom context
 func (api *Client) CreateUserGroupContext(ctx context.Context, userGroup UserGroup) (UserGroup, error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 		"name":  {userGroup.Name},
 	}
 
@@ -76,7 +76,7 @@ func (api *Client) CreateUserGroupContext(ctx context.Context, userGroup UserGro
 		values["channels"] = []string{strings.Join(userGroup.Prefs.Channels, ",")}
 	}
 
-	response, err := userGroupRequest(ctx, "usergroups.create", values, api.debug)
+	response, err := userGroupRequest(ctx, api.httpclient, "usergroups.create", values, api.debug)
 	if err != nil {
 		return UserGroup{}, err
 	}
@@ -91,11 +91,11 @@ func (api *Client) DisableUserGroup(userGroup string) (UserGroup, error) {
 // DisableUserGroupContext disables an existing user group with a custom context
 func (api *Client) DisableUserGroupContext(ctx context.Context, userGroup string) (UserGroup, error) {
 	values := url.Values{
-		"token":     {api.config.token},
+		"token":     {api.token},
 		"usergroup": {userGroup},
 	}
 
-	response, err := userGroupRequest(ctx, "usergroups.disable", values, api.debug)
+	response, err := userGroupRequest(ctx, api.httpclient, "usergroups.disable", values, api.debug)
 	if err != nil {
 		return UserGroup{}, err
 	}
@@ -110,11 +110,11 @@ func (api *Client) EnableUserGroup(userGroup string) (UserGroup, error) {
 // EnableUserGroupContext enables an existing user group with a custom context
 func (api *Client) EnableUserGroupContext(ctx context.Context, userGroup string) (UserGroup, error) {
 	values := url.Values{
-		"token":     {api.config.token},
+		"token":     {api.token},
 		"usergroup": {userGroup},
 	}
 
-	response, err := userGroupRequest(ctx, "usergroups.enable", values, api.debug)
+	response, err := userGroupRequest(ctx, api.httpclient, "usergroups.enable", values, api.debug)
 	if err != nil {
 		return UserGroup{}, err
 	}
@@ -129,10 +129,10 @@ func (api *Client) GetUserGroups() ([]UserGroup, error) {
 // GetUserGroupsContext returns a list of user groups for the team with a custom context
 func (api *Client) GetUserGroupsContext(ctx context.Context) ([]UserGroup, error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 	}
 
-	response, err := userGroupRequest(ctx, "usergroups.list", values, api.debug)
+	response, err := userGroupRequest(ctx, api.httpclient, "usergroups.list", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +147,7 @@ func (api *Client) UpdateUserGroup(userGroup UserGroup) (UserGroup, error) {
 // UpdateUserGroupContext will update an existing user group with a custom context
 func (api *Client) UpdateUserGroupContext(ctx context.Context, userGroup UserGroup) (UserGroup, error) {
 	values := url.Values{
-		"token":     {api.config.token},
+		"token":     {api.token},
 		"usergroup": {userGroup.ID},
 	}
 
@@ -163,7 +163,7 @@ func (api *Client) UpdateUserGroupContext(ctx context.Context, userGroup UserGro
 		values["description"] = []string{userGroup.Description}
 	}
 
-	response, err := userGroupRequest(ctx, "usergroups.update", values, api.debug)
+	response, err := userGroupRequest(ctx, api.httpclient, "usergroups.update", values, api.debug)
 	if err != nil {
 		return UserGroup{}, err
 	}
@@ -178,11 +178,11 @@ func (api *Client) GetUserGroupMembers(userGroup string) ([]string, error) {
 // GetUserGroupMembersContext will retrieve the current list of users in a group with a custom context
 func (api *Client) GetUserGroupMembersContext(ctx context.Context, userGroup string) ([]string, error) {
 	values := url.Values{
-		"token":     {api.config.token},
+		"token":     {api.token},
 		"usergroup": {userGroup},
 	}
 
-	response, err := userGroupRequest(ctx, "usergroups.users.list", values, api.debug)
+	response, err := userGroupRequest(ctx, api.httpclient, "usergroups.users.list", values, api.debug)
 	if err != nil {
 		return []string{}, err
 	}
@@ -197,12 +197,12 @@ func (api *Client) UpdateUserGroupMembers(userGroup string, members string) (Use
 // UpdateUserGroupMembersContext will update the members of an existing user group with a custom context
 func (api *Client) UpdateUserGroupMembersContext(ctx context.Context, userGroup string, members string) (UserGroup, error) {
 	values := url.Values{
-		"token":     {api.config.token},
+		"token":     {api.token},
 		"usergroup": {userGroup},
 		"users":     {members},
 	}
 
-	response, err := userGroupRequest(ctx, "usergroups.users.update", values, api.debug)
+	response, err := userGroupRequest(ctx, api.httpclient, "usergroups.users.update", values, api.debug)
 	if err != nil {
 		return UserGroup{}, err
 	}

--- a/users.go
+++ b/users.go
@@ -121,9 +121,9 @@ func NewUserSetPhotoParams() UserSetPhotoParams {
 	}
 }
 
-func userRequest(ctx context.Context, path string, values url.Values, debug bool) (*userResponseFull, error) {
+func userRequest(ctx context.Context, client HTTPRequester, path string, values url.Values, debug bool) (*userResponseFull, error) {
 	response := &userResponseFull{}
-	err := post(ctx, path, values, response, debug)
+	err := postForm(ctx, client, SLACK_API+path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -141,10 +141,11 @@ func (api *Client) GetUserPresence(user string) (*UserPresence, error) {
 // GetUserPresenceContext will retrieve the current presence status of given user with a custom context.
 func (api *Client) GetUserPresenceContext(ctx context.Context, user string) (*UserPresence, error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 		"user":  {user},
 	}
-	response, err := userRequest(ctx, "users.getPresence", values, api.debug)
+
+	response, err := userRequest(ctx, api.httpclient, "users.getPresence", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -159,10 +160,11 @@ func (api *Client) GetUserInfo(user string) (*User, error) {
 // GetUserInfoContext will retrieve the complete user information with a custom context
 func (api *Client) GetUserInfoContext(ctx context.Context, user string) (*User, error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 		"user":  {user},
 	}
-	response, err := userRequest(ctx, "users.info", values, api.debug)
+
+	response, err := userRequest(ctx, api.httpclient, "users.info", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -177,10 +179,11 @@ func (api *Client) GetUsers() ([]User, error) {
 // GetUsersContext returns the list of users (with their detailed information) with a custom context
 func (api *Client) GetUsersContext(ctx context.Context) ([]User, error) {
 	values := url.Values{
-		"token":    {api.config.token},
+		"token":    {api.token},
 		"presence": {"1"},
 	}
-	response, err := userRequest(ctx, "users.list", values, api.debug)
+
+	response, err := userRequest(ctx, api.httpclient, "users.list", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -193,12 +196,16 @@ func (api *Client) SetUserAsActive() error {
 }
 
 // SetUserAsActiveContext marks the currently authenticated user as active with a custom context
-func (api *Client) SetUserAsActiveContext(ctx context.Context) error {
+func (api *Client) SetUserAsActiveContext(ctx context.Context) (err error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 	}
-	_, err := userRequest(ctx, "users.setActive", values, api.debug)
-	return err
+
+	if _, err := userRequest(ctx, api.httpclient, "users.setActive", values, api.debug); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // SetUserPresence changes the currently authenticated user presence
@@ -209,10 +216,11 @@ func (api *Client) SetUserPresence(presence string) error {
 // SetUserPresenceContext changes the currently authenticated user presence with a custom context
 func (api *Client) SetUserPresenceContext(ctx context.Context, presence string) error {
 	values := url.Values{
-		"token":    {api.config.token},
+		"token":    {api.token},
 		"presence": {presence},
 	}
-	_, err := userRequest(ctx, "users.setPresence", values, api.debug)
+
+	_, err := userRequest(ctx, api.httpclient, "users.setPresence", values, api.debug)
 	if err != nil {
 		return err
 	}
@@ -228,10 +236,11 @@ func (api *Client) GetUserIdentity() (*UserIdentityResponse, error) {
 // GetUserIdentityContext will retrieve user info available per identity scopes with a custom context
 func (api *Client) GetUserIdentityContext(ctx context.Context) (*UserIdentityResponse, error) {
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 	}
 	response := &UserIdentityResponse{}
-	err := post(ctx, "users.identity", values, response, api.debug)
+
+	err := postForm(ctx, api.httpclient, SLACK_API+"users.identity", values, response, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +259,7 @@ func (api *Client) SetUserPhoto(image string, params UserSetPhotoParams) error {
 func (api *Client) SetUserPhotoContext(ctx context.Context, image string, params UserSetPhotoParams) error {
 	response := &SlackResponse{}
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 	}
 	if params.CropX != DEFAULT_USER_PHOTO_CROP_X {
 		values.Add("crop_x", string(params.CropX))
@@ -261,7 +270,8 @@ func (api *Client) SetUserPhotoContext(ctx context.Context, image string, params
 	if params.CropW != DEFAULT_USER_PHOTO_CROP_W {
 		values.Add("crop_w", string(params.CropW))
 	}
-	err := postLocalWithMultipartResponse(ctx, "users.setPhoto", image, "image", values, response, api.debug)
+
+	err := postLocalWithMultipartResponse(ctx, api.httpclient, SLACK_API+"users.setPhoto", image, "image", values, response, api.debug)
 	if err != nil {
 		return err
 	}
@@ -280,9 +290,10 @@ func (api *Client) DeleteUserPhoto() error {
 func (api *Client) DeleteUserPhotoContext(ctx context.Context) error {
 	response := &SlackResponse{}
 	values := url.Values{
-		"token": {api.config.token},
+		"token": {api.token},
 	}
-	err := post(ctx, "users.deletePhoto", values, response, api.debug)
+
+	err := postForm(ctx, api.httpclient, SLACK_API+"users.deletePhoto", values, response, api.debug)
 	if err != nil {
 		return err
 	}
@@ -329,13 +340,12 @@ func (api *Client) SetUserCustomStatusContext(ctx context.Context, statusText, s
 	}
 
 	values := url.Values{
-		"token":   {api.config.token},
+		"token":   {api.token},
 		"profile": {string(profile)},
 	}
 
 	response := &userResponseFull{}
-
-	if err = post(ctx, "users.profile.set", values, response, api.debug); err != nil {
+	if err = postForm(ctx, api.httpclient, SLACK_API+"users.profile.set", values, response, api.debug); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
cleaned up version of #68 and #85 for #27. the package level scope isn't enough. we run a number of clients simultaneously and sometimes need to enable debugging of the http req/resp on a per client basis.

- allows for per instance http client configuration, useful for setting a client with a customized transport/timeouts etc.
- backwards compatible.