### PR TITLE
Added exclude_members option to channel list

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -228,17 +228,20 @@ func (api *Client) KickUserFromChannelContext(ctx context.Context, channel, user
 }
 
 // GetChannels retrieves all the channels
-func (api *Client) GetChannels(excludeArchived bool) ([]Channel, error) {
-	return api.GetChannelsContext(context.Background(), excludeArchived)
+func (api *Client) GetChannels(excludeArchived bool, excludeMembers bool) ([]Channel, error) {
+	return api.GetChannelsContext(context.Background(), excludeArchived, excludeMembers)
 }
 
 // GetChannelsContext retrieves all the channels with a custom context
-func (api *Client) GetChannelsContext(ctx context.Context, excludeArchived bool) ([]Channel, error) {
+func (api *Client) GetChannelsContext(ctx context.Context, excludeArchived bool, excludeMembers bool) ([]Channel, error) {
 	values := url.Values{
 		"token": {api.config.token},
 	}
 	if excludeArchived {
 		values.Add("exclude_archived", "1")
+	}
+	if excludeMembers {
+		values.Add("exclude_members", "1")
 	}
 	response, err := channelRequest(ctx, "channels.list", values, api.debug)
 	if err != nil {

--- a/examples/channels/channels.go
+++ b/examples/channels/channels.go
@@ -8,7 +8,7 @@ import (
 
 func main() {
 	api := slack.New("YOUR_TOKEN_HERE")
-	channels, err := api.GetChannels(false)
+	channels, err := api.GetChannels(false, false)
 	if err != nil {
 		fmt.Printf("%s\n", err)
 		return

--- a/examples/pins/pins.go
+++ b/examples/pins/pins.go
@@ -51,7 +51,7 @@ func main() {
 		// If the channel exists, that means we just need to unarchive it
 		if err.Error() == "name_taken" {
 			err = nil
-			channels, err := api.GetChannels(false)
+			channels, err := api.GetChannels(false, false)
 			if err != nil {
 				fmt.Println("Could not retrieve channels")
 				return


### PR DESCRIPTION
As slack teams grow to large levels of channels and members the api call to get the list of channels is getting slower and slower. A very large part of this slow down is it returns the list of members for each channel. 

In order to prevent timeouts from the slack api we have to use exclude_members in the channels.list call to cut down on the large response.

**It should be noted that this change will break any existing use of slack.Channels.GetChannels()**
