### PR TITLE
Ignoring desktop_notification (fixes #125)

### DIFF
--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -302,6 +302,8 @@ func (rtm *RTM) handleRawEvent(rawEvent json.RawMessage) {
 		rtm.IncomingEvents <- RTMEvent{"hello", &HelloEvent{}}
 	case "pong":
 		rtm.handlePong(rawEvent)
+	case "desktop_notification":
+		rtm.Debugln("Recieved desktop notification, ignoring")
 	default:
 		rtm.handleEvent(event.Type, rawEvent)
 	}

--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -303,7 +303,7 @@ func (rtm *RTM) handleRawEvent(rawEvent json.RawMessage) {
 	case "pong":
 		rtm.handlePong(rawEvent)
 	case "desktop_notification":
-		rtm.Debugln("Recieved desktop notification, ignoring")
+		rtm.Debugln("Received desktop notification, ignoring")
 	default:
 		rtm.handleEvent(event.Type, rawEvent)
 	}


### PR DESCRIPTION
There is no documentation on `desktop_notification` event (at least I could not find it) and it spams log with unmarshal errors.
I do not see any use for this event now, so I propose to ignore it instead of creating a new mapping.