### PR TITLE
chat: support chat.command for sending a command

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -174,6 +174,7 @@ const (
 	chatUpdate      sendMode = "chat.update"
 	chatPostMessage sendMode = "chat.postMessage"
 	chatDelete      sendMode = "chat.delete"
+	chatCommand     sendMode = "chat.command"
 )
 
 type sendConfig struct {
@@ -228,6 +229,17 @@ func MsgOptionText(text string, escape bool) MsgOption {
 		if escape {
 			text = escapeMessage(text)
 		}
+		config.values.Add("text", text)
+		return nil
+	}
+}
+
+// MsgOptionCommand executes a command
+func MsgOptionCommand(command, text string) MsgOption {
+	return func(config *sendConfig) error {
+		config.mode = chatCommand
+		config.values.Del("ts")
+		config.values.Add("command", command)
 		config.values.Add("text", text)
 		return nil
 	}


### PR DESCRIPTION
The `chat.command` method allows calling internal and custom commands in a slack team. It's worth to mention that I can't see `chat.command` in the [doc for methods](https://api.slack.com/methods#chat), and I found it being used in [wee-slack](https://github.com/wee-slack/wee-slack/blob/40c937f894d2968774dab41ddff02fd6a8c0dd5f/wee_slack.py#L3025).

Tested with https://github.com/erroneousboat/slack-term/pull/57