### PR TITLE
Return a special error when rate limited.

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -121,7 +121,7 @@ func postWithMultipartResponse(ctx context.Context, path, name, fieldname string
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == 429 {
+	if resp.StatusCode == http.StatusTooManyRequests {
 		retry, err := strconv.ParseUint(resp.Header.Get("Retry-After"), 10, 64)
 		if err != nil {
 			retry = 1
@@ -153,7 +153,7 @@ func postForm(ctx context.Context, endpoint string, values url.Values, intf inte
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == 429 {
+	if resp.StatusCode == http.StatusTooManyRequests {
 		retry, err := strconv.ParseUint(resp.Header.Get("Retry-After"), 10, 64)
 		if err != nil {
 			retry = 1

--- a/misc.go
+++ b/misc.go
@@ -130,7 +130,7 @@ func postWithMultipartResponse(ctx context.Context, path, name, fieldname string
 	}
 
 	// Slack seems to send an HTML body along with 5xx error codes. Don't parse it.
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		logResponse(resp, debug)
 		return fmt.Errorf("Slack server error: %s.", resp.Status)
 	}
@@ -162,7 +162,7 @@ func postForm(ctx context.Context, endpoint string, values url.Values, intf inte
 	}
 
 	// Slack seems to send an HTML body along with 5xx error codes. Don't parse it.
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		logResponse(resp, debug)
 		return fmt.Errorf("Slack server error: %s.", resp.Status)
 	}

--- a/misc.go
+++ b/misc.go
@@ -28,9 +28,6 @@ type HTTPRequester interface {
 
 var customHTTPClient HTTPRequester
 
-// Default duration for rate limiting if Retry-After header does not exist/parse
-const defaultRetrySeconds int64 = 60
-
 // HTTPClient sets a custom http.Client
 // deprecated: in favor of SetHTTPClient()
 var HTTPClient = &http.Client{}
@@ -127,7 +124,7 @@ func postWithMultipartResponse(ctx context.Context, path, name, fieldname string
 	if resp.StatusCode == http.StatusTooManyRequests {
 		retry, err := strconv.ParseInt(resp.Header.Get("Retry-After"), 10, 64)
 		if err != nil {
-			retry = defaultRetrySeconds
+			return err
 		}
 		return &RateLimitedError{time.Duration(retry) * time.Second}
 	}
@@ -159,7 +156,7 @@ func postForm(ctx context.Context, endpoint string, values url.Values, intf inte
 	if resp.StatusCode == http.StatusTooManyRequests {
 		retry, err := strconv.ParseInt(resp.Header.Get("Retry-After"), 10, 64)
 		if err != nil {
-			retry = defaultRetrySeconds
+			return err
 		}
 		return &RateLimitedError{time.Duration(retry) * time.Second}
 	}

--- a/misc.go
+++ b/misc.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -40,6 +41,14 @@ type WebError string
 
 func (s WebError) Error() string {
 	return string(s)
+}
+
+type RateLimitedError struct {
+	RetryAfter uint64
+}
+
+func (e *RateLimitedError) Error() string {
+	return fmt.Sprintf("Slack rate limit exceeded, retry after %d seconds", e.RetryAfter)
 }
 
 func fileUploadReq(ctx context.Context, path, fieldname, filename string, values url.Values, r io.Reader) (*http.Request, error) {
@@ -112,6 +121,14 @@ func postWithMultipartResponse(ctx context.Context, path, name, fieldname string
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == 429 {
+		retry, err := strconv.ParseUint(resp.Header.Get("Retry-After"), 10, 64)
+		if err != nil {
+			retry = 1
+		}
+		return &RateLimitedError{retry}
+	}
+
 	// Slack seems to send an HTML body along with 5xx error codes. Don't parse it.
 	if resp.StatusCode != 200 {
 		logResponse(resp, debug)
@@ -135,6 +152,14 @@ func postForm(ctx context.Context, endpoint string, values url.Values, intf inte
 		return err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode == 429 {
+		retry, err := strconv.ParseUint(resp.Header.Get("Retry-After"), 10, 64)
+		if err != nil {
+			retry = 1
+		}
+		return &RateLimitedError{retry}
+	}
 
 	// Slack seems to send an HTML body along with 5xx error codes. Don't parse it.
 	if resp.StatusCode != 200 {


### PR DESCRIPTION
Instead of having to parse the error string provided, for the special case of status code 429, we can return a different error type to allow for intelligent retry.

See also: https://api.slack.com/docs/rate-limits