### PR TITLE
use pagination for users.list

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -145,7 +145,13 @@ func postForm(ctx context.Context, endpoint string, values url.Values, intf inte
 	if resp.StatusCode != 200 {
 		retryAfter := 0
 		if resp.StatusCode == 429 {
-			retryAfter, _ = strconv.Atoi(resp.Header.Get("retry-after"))
+			retryAfter, err = strconv.Atoi(resp.Header.Get("retry-after"))
+			if err != nil {
+				if debug {
+					logger.Printf("Got a 429 without a retry-after: %s", err)
+				}
+				retryAfter = 10
+			}
 		}
 		logResponse(resp, debug)
 		return WebError{

--- a/users.go
+++ b/users.go
@@ -199,7 +199,10 @@ pagination:
 			response, err = userRequest(ctx, "users.list", values, api.debug)
 			if err != nil {
 				if e, ok := err.(WebError); ok && e.Status == 429 {
-					time.Sleep(time.Duration(e.RetryAfter+1) * time.Second)
+					if api.debug {
+						logger.Printf("GetUsersContext: users.list rate limited, sleeping for %d seconds", e.RetryAfter)
+					}
+					time.Sleep(time.Duration(e.RetryAfter) * time.Second)
 					continue retry
 				}
 				return nil, err
@@ -207,6 +210,9 @@ pagination:
 			break retry
 		}
 		users = append(users, response.Members...)
+		if api.debug {
+			logger.Printf("GetUsersContext: got %d users; now %d total", len(response.Members), len(users))
+		}
 		if next_token, ok := response.ResponseMetadata["next_cursor"]; ok && next_token != "" {
 			values["cursor"] = []string{next_token}
 		} else {

--- a/users.go
+++ b/users.go
@@ -208,9 +208,7 @@ pagination:
 			break retry
 		}
 		users = append(users, response.Members...)
-		if api.debug {
-			logger.Printf("GetUsersContext: got %d users; now %d total", len(response.Members), len(users))
-		}
+		api.Debugf("GetUsersContext: got %d users; now %d total", len(response.Members), len(users))
 		if next_cursor, ok := response.ResponseMetadata["next_cursor"]; ok && next_cursor != "" {
 			values["cursor"] = []string{next_cursor}
 		} else {

--- a/users.go
+++ b/users.go
@@ -199,9 +199,7 @@ pagination:
 			response, err = userRequest(ctx, "users.list", values, api.debug)
 			if err != nil {
 				if e, ok := err.(WebError); ok && e.Status == 429 {
-					if api.debug {
-						logger.Printf("GetUsersContext: users.list rate limited, sleeping for %d seconds", e.RetryAfter)
-					}
+					api.Debugf("GetUsersContext: users.list rate limited, sleeping for %d seconds\n", e.RetryAfter)
 					time.Sleep(time.Duration(e.RetryAfter) * time.Second)
 					continue retry
 				}
@@ -213,8 +211,8 @@ pagination:
 		if api.debug {
 			logger.Printf("GetUsersContext: got %d users; now %d total", len(response.Members), len(users))
 		}
-		if next_token, ok := response.ResponseMetadata["next_cursor"]; ok && next_token != "" {
-			values["cursor"] = []string{next_token}
+		if next_cursor, ok := response.ResponseMetadata["next_cursor"]; ok && next_cursor != "" {
+			values["cursor"] = []string{next_cursor}
 		} else {
 			break pagination
 		}

--- a/users.go
+++ b/users.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/url"
 	"time"
 )
@@ -208,7 +207,7 @@ pagination:
 			break retry
 		}
 		users = append(users, response.Members...)
-		if next_token, ok := response.ResponseMetadata["next_cursor"]; ok {
+		if next_token, ok := response.ResponseMetadata["next_cursor"]; ok && next_token != "" {
 			values["cursor"] = []string{next_token}
 		} else {
 			break pagination

--- a/users.go
+++ b/users.go
@@ -186,7 +186,7 @@ func (api *Client) GetUsersContext(ctx context.Context) (users []User, err error
 		// quickly, so we'll have to be bad little citizens and
 		// use the max. :-/
 		"limit":    {"1000"},
-		"presence": {"false"},
+		"presence": {"true"},
 		"token":    {api.config.token},
 	}
 


### PR DESCRIPTION
Issue #196

Use pagination to try to get all users.
The API docs recommend to request 200 users each time, but it
there is also rate-limiting in effect, so if we loop too often
too quickly, we'll never get all users.  We try to work around
that by sleeping for 2 seconds in between each iteration (API
docs say "send no more than one message per second", so we
want to play it safe), but even then we get rate-limited when
trying to fetch several K users, so we try to get as many as
we can on each call (i.e. 999).

This is all very suboptimal, but getting, say, 8K users out of
20K is better than getting 0, so I suppose it's a start.