### PR TITLE
ConnectRTM and ConnectRTMContext take an optional argument

### DIFF
--- a/rtm.go
+++ b/rtm.go
@@ -43,16 +43,26 @@ func (api *Client) StartRTMContext(ctx context.Context) (info *Info, websocketUR
 // ConnectRTM calls the "rtm.connect" endpoint and returns the provided URL and the compact Info block.
 //
 // To have a fully managed Websocket connection, use `NewRTM`, and call `ManageConnection()` on it.
-func (api *Client) ConnectRTM() (info *Info, websocketURL string, err error) {
-	return api.ConnectRTMContext(context.Background())
+func (api *Client) ConnectRTM(options ...url.Values) (info *Info, websocketURL string, err error) {
+	return api.ConnectRTMContext(context.Background(), options...)
 }
 
-// ConnectRTM calls the "rtm.connect" endpoint and returns the provided URL and the compact Info block with a custom context.
+// ConnectRTMContext calls the "rtm.connect" endpoint and returns the provided URL and the compact Info block with a custom context.
 //
 // To have a fully managed Websocket connection, use `NewRTM`, and call `ManageConnection()` on it.
-func (api *Client) ConnectRTMContext(ctx context.Context) (info *Info, websocketURL string, err error) {
+func (api *Client) ConnectRTMContext(ctx context.Context, options ...url.Values) (info *Info, websocketURL string, err error) {
 	response := &infoResponseFull{}
-	err = post(ctx, "rtm.connect", url.Values{"token": {api.config.token}}, response, api.debug)
+	var params url.Values
+
+	if len(options) > 0 {
+		params = options[0]
+		api.Debugln("Connecting with options ", options)
+	} else {
+		params = make(url.Values)
+	}
+	params["token"] = []string{api.config.token}
+
+	err = post(ctx, "rtm.connect", params, response, api.debug)
 	if err != nil {
 		return nil, "", fmt.Errorf("post: %s", err)
 	}


### PR DESCRIPTION
In view of the upcoming changes to the RTM API, make `ConnectRTM()` and `ConnectRTMContext()` methods take an `url.Values` argument with options to the `rtm.connect` call. See https://api.slack.com/changelog/2017-06-batch-presence-and-presence-subscriptions for details.

Example:

 ```go
  // Connect with presence_change events enabled
  info, wsURL, err := api.ConnectRTM(url.Values{"batch_presence_aware": {"true"}, "presence_sub": {"true"}})
```

```go
  // Connect without presence_change events (starting Nov 15 2017)
  info, wsURL, err := api.ConnectRTM()
```