### PR TITLE
Add example for direct messaging a user

### DIFF
--- a/examples/ims/ims.go
+++ b/examples/ims/ims.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/nlopes/slack"
+)
+
+func main() {
+	api := slack.New("YOUR_TOKEN_HERE")
+
+	userID := "USER_ID"
+
+	_, _, channelID, err := api.OpenIMChannel(userID)
+
+	if err != nil {
+		fmt.Printf("%s\n", err)
+	}
+
+	api.PostMessage(channelID, "Hello World!", slack.PostMessageParameters{})
+}


### PR DESCRIPTION
This PR will add an example under `examples/ims`. The example shows how to send a message directly to a user.

![image](https://user-images.githubusercontent.com/427379/31643171-fe1389e8-b2bc-11e7-86a1-5a328caaa396.png)
