### PR TITLE
Open websocket over HTTPS

### DIFF
--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -124,6 +124,7 @@ func (rtm *RTM) startRTMAndDial(useRTMStart bool) (*Info, *websocket.Conn, error
 		return nil, nil, err
 	}
 
+	// Only use HTTPS for connections to prevent MITM attacks on the connection.
 	conn, err := websocketProxyDial(url, "https://api.slack.com")
 	if err != nil {
 		return nil, nil, err

--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -124,7 +124,7 @@ func (rtm *RTM) startRTMAndDial(useRTMStart bool) (*Info, *websocket.Conn, error
 		return nil, nil, err
 	}
 
-	conn, err := websocketProxyDial(url, "http://api.slack.com")
+	conn, err := websocketProxyDial(url, "https://api.slack.com")
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
The websocket should be opened over HTTPS, per the Slack API documentation. The connection is currently upgraded from HTTP to HTTPS, which causes an extra connection and potential data leakage to a man in the middle. This change will prevent the automatic upgrade by doing the right thing instead.