### PR TITLE
Added new fields from latest version of API to UserProfile struct

### DIFF
--- a/users.go
+++ b/users.go
@@ -15,6 +15,7 @@ const (
 
 // UserProfile contains all the information details of a given user
 type UserProfile struct {
+	AvatarHash            string `json:"avatar_hash"`
 	FirstName             string `json:"first_name"`
 	LastName              string `json:"last_name"`
 	DisplayName           string `json:"display_name"`

--- a/users.go
+++ b/users.go
@@ -15,24 +15,26 @@ const (
 
 // UserProfile contains all the information details of a given user
 type UserProfile struct {
-	FirstName          string `json:"first_name"`
-	LastName           string `json:"last_name"`
-	RealName           string `json:"real_name"`
-	RealNameNormalized string `json:"real_name_normalized"`
-	Email              string `json:"email"`
-	Skype              string `json:"skype"`
-	Phone              string `json:"phone"`
-	Image24            string `json:"image_24"`
-	Image32            string `json:"image_32"`
-	Image48            string `json:"image_48"`
-	Image72            string `json:"image_72"`
-	Image192           string `json:"image_192"`
-	ImageOriginal      string `json:"image_original"`
-	Title              string `json:"title"`
-	BotID              string `json:"bot_id,omitempty"`
-	ApiAppID           string `json:"api_app_id,omitempty"`
-	StatusText         string `json:"status_text,omitempty"`
-	StatusEmoji        string `json:"status_emoji,omitempty"`
+	FirstName             string `json:"first_name"`
+	LastName              string `json:"last_name"`
+	DisplayName           string `json:"display_name"`
+	DisplayNameNormalized string `json:"display_name_normalized"`
+	RealName              string `json:"real_name"`
+	RealNameNormalized    string `json:"real_name_normalized"`
+	Email                 string `json:"email"`
+	Skype                 string `json:"skype"`
+	Phone                 string `json:"phone"`
+	Image24               string `json:"image_24"`
+	Image32               string `json:"image_32"`
+	Image48               string `json:"image_48"`
+	Image72               string `json:"image_72"`
+	Image192              string `json:"image_192"`
+	ImageOriginal         string `json:"image_original"`
+	Title                 string `json:"title"`
+	BotID                 string `json:"bot_id,omitempty"`
+	ApiAppID              string `json:"api_app_id,omitempty"`
+	StatusText            string `json:"status_text,omitempty"`
+	StatusEmoji           string `json:"status_emoji,omitempty"`
 }
 
 // User contains all the information of a user


### PR DESCRIPTION
Hi! 

In the latest version of API Slack added three new fields to a user (`avatar_hash`, `display_name` and `display_name_normalized` fields in [response example](https://api.slack.com/methods/users.profile.get)).