### PR TITLE
Extra options for menu callback (aka Options Load URL payload)

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -48,6 +48,9 @@ type AttachmentActionCallback struct {
 	Channel    Channel            `json:"channel"`
 	User       User               `json:"user"`
 
+	Name  string `json:"name"`
+	Value string `json:"value"`
+
 	OriginalMessage Message `json:"original_message"`
 
 	ActionTs     string `json:"action_ts"`


### PR DESCRIPTION
Add extra fields to AttachmentActionCallback to decode Slack callback when message menus dynamically populated

https://api.slack.com/docs/interactive-message-field-guide#options_load_url