### PR TITLE
Update Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: go
 
 go:
-    - 1.7
-    - 1.8
-    - 1.x
+    - 1.7.x
+    - 1.8.x
+    - 1.9.x
     - tip
 
 before_install:


### PR DESCRIPTION
- Use the latest version of Go 1.7 and 1.8, not 1.7.0 and 1.8.0
- Explicitly specify Go 1.9.x and test for it