### PR TITLE
Add timeout to the websocket connection

### DIFF
--- a/rtm.go
+++ b/rtm.go
@@ -9,14 +9,14 @@ import (
 )
 
 const (
-	WEBSOCKET_TIMEOUT_SECONDS = 10 * time.Second
+	websocketDefaultTimeout = 10 * time.Second
 )
 
 // StartRTM calls the "rtm.start" endpoint and returns the provided URL and the full Info block.
 //
 // To have a fully managed Websocket connection, use `NewRTM`, and call `ManageConnection()` on it.
 func (api *Client) StartRTM() (info *Info, websocketURL string, err error) {
-	ctx, cancel := context.WithTimeout(context.Background(), WEBSOCKET_TIMEOUT_SECONDS)
+	ctx, cancel := context.WithTimeout(context.Background(), websocketDefaultTimeout)
 	defer cancel()
 
 	return api.StartRTMContext(ctx)
@@ -42,7 +42,7 @@ func (api *Client) StartRTMContext(ctx context.Context) (info *Info, websocketUR
 //
 // To have a fully managed Websocket connection, use `NewRTM`, and call `ManageConnection()` on it.
 func (api *Client) ConnectRTM() (info *Info, websocketURL string, err error) {
-	ctx, cancel := context.WithTimeout(context.Background(), WEBSOCKET_TIMEOUT_SECONDS)
+	ctx, cancel := context.WithTimeout(context.Background(), websocketDefaultTimeout)
 	defer cancel()
 
 	return api.ConnectRTMContext(ctx)

--- a/rtm.go
+++ b/rtm.go
@@ -12,7 +12,10 @@ import (
 //
 // To have a fully managed Websocket connection, use `NewRTM`, and call `ManageConnection()` on it.
 func (api *Client) StartRTM() (info *Info, websocketURL string, err error) {
-	return api.StartRTMContext(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	return api.StartRTMContext(ctx)
 }
 
 // StartRTMContext calls the "rtm.start" endpoint and returns the provided URL and the full Info block with a custom context.
@@ -35,7 +38,10 @@ func (api *Client) StartRTMContext(ctx context.Context) (info *Info, websocketUR
 //
 // To have a fully managed Websocket connection, use `NewRTM`, and call `ManageConnection()` on it.
 func (api *Client) ConnectRTM() (info *Info, websocketURL string, err error) {
-	return api.ConnectRTMContext(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	return api.ConnectRTMContext(ctx)
 }
 
 // ConnectRTM calls the "rtm.connect" endpoint and returns the provided URL and the compact Info block with a custom context.
@@ -45,6 +51,7 @@ func (api *Client) ConnectRTMContext(ctx context.Context) (info *Info, websocket
 	response := &infoResponseFull{}
 	err = post(ctx, "rtm.connect", url.Values{"token": {api.config.token}}, response, api.debug)
 	if err != nil {
+		api.Debugf("Failed to connect to RTM: %s", err)
 		return nil, "", fmt.Errorf("post: %s", err)
 	}
 	if !response.Ok {

--- a/rtm.go
+++ b/rtm.go
@@ -8,11 +8,15 @@ import (
 	"time"
 )
 
+const (
+	WEBSOCKET_TIMEOUT_SECONDS = 10
+)
+
 // StartRTM calls the "rtm.start" endpoint and returns the provided URL and the full Info block.
 //
 // To have a fully managed Websocket connection, use `NewRTM`, and call `ManageConnection()` on it.
 func (api *Client) StartRTM() (info *Info, websocketURL string, err error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), WEBSOCKET_TIMEOUT_SECONDS*time.Second)
 	defer cancel()
 
 	return api.StartRTMContext(ctx)
@@ -38,7 +42,7 @@ func (api *Client) StartRTMContext(ctx context.Context) (info *Info, websocketUR
 //
 // To have a fully managed Websocket connection, use `NewRTM`, and call `ManageConnection()` on it.
 func (api *Client) ConnectRTM() (info *Info, websocketURL string, err error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), WEBSOCKET_TIMEOUT_SECONDS*time.Second)
 	defer cancel()
 
 	return api.ConnectRTMContext(ctx)

--- a/rtm.go
+++ b/rtm.go
@@ -9,14 +9,14 @@ import (
 )
 
 const (
-	WEBSOCKET_TIMEOUT_SECONDS = 10
+	WEBSOCKET_TIMEOUT_SECONDS = 10 * time.Second
 )
 
 // StartRTM calls the "rtm.start" endpoint and returns the provided URL and the full Info block.
 //
 // To have a fully managed Websocket connection, use `NewRTM`, and call `ManageConnection()` on it.
 func (api *Client) StartRTM() (info *Info, websocketURL string, err error) {
-	ctx, cancel := context.WithTimeout(context.Background(), WEBSOCKET_TIMEOUT_SECONDS*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), WEBSOCKET_TIMEOUT_SECONDS)
 	defer cancel()
 
 	return api.StartRTMContext(ctx)
@@ -42,7 +42,7 @@ func (api *Client) StartRTMContext(ctx context.Context) (info *Info, websocketUR
 //
 // To have a fully managed Websocket connection, use `NewRTM`, and call `ManageConnection()` on it.
 func (api *Client) ConnectRTM() (info *Info, websocketURL string, err error) {
-	ctx, cancel := context.WithTimeout(context.Background(), WEBSOCKET_TIMEOUT_SECONDS*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), WEBSOCKET_TIMEOUT_SECONDS)
 	defer cancel()
 
 	return api.ConnectRTMContext(ctx)

--- a/slack.go
+++ b/slack.go
@@ -80,14 +80,19 @@ func (api *Client) AuthTest() (response *AuthTestResponse, error error) {
 
 // AuthTestContext tests if the user is able to do authenticated requests or not with a custom context
 func (api *Client) AuthTestContext(ctx context.Context) (response *AuthTestResponse, error error) {
+	api.Debugf("Challenging auth...")
 	responseFull := &authTestResponseFull{}
 	err := post(ctx, "auth.test", url.Values{"token": {api.config.token}}, responseFull, api.debug)
 	if err != nil {
+		api.Debugf("failed to test for auth: %s", err)
 		return nil, err
 	}
 	if !responseFull.Ok {
+		api.Debugf("auth response was not Ok: %s", responseFull.Error)
 		return nil, errors.New(responseFull.Error)
 	}
+
+	api.Debugf("Auth challenge was successful with response %+v", responseFull.AuthTestResponse)
 	return &responseFull.AuthTestResponse, nil
 }
 

--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -141,6 +141,7 @@ func (rtm *RTM) startRTMAndDial(useRTMStart bool) (*Info, *websocket.Conn, error
 	}
 
 	rtm.Debugf("Dialing to websocket on url %s", url)
+	// Only use HTTPS for connections to prevent MITM attacks on the connection.
 	conn, err := websocketProxyDial(url, "https://api.slack.com")
 	if err != nil {
 		rtm.Debugf("Failed to dial to the websocket: %s", err)

--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -33,6 +33,7 @@ func (rtm *RTM) ManageConnection() {
 		// if err != nil then the connection is sucessful - otherwise it is
 		// fatal
 		if err != nil {
+			rtm.Debugf("Failed to connect with RTM on try %d: %s", connectionCount, err)
 			return
 		}
 		rtm.info = info
@@ -43,6 +44,8 @@ func (rtm *RTM) ManageConnection() {
 
 		rtm.conn = conn
 		rtm.isConnected = true
+
+		rtm.Debugf("RTM connection succeeded on try %d", connectionCount)
 
 		keepRunning := make(chan bool)
 		// we're now connected (or have failed fatally) so we can set up
@@ -89,6 +92,7 @@ func (rtm *RTM) connect(connectionCount int, useRTMStart bool) (*Info, *websocke
 		}
 		// check for fatal errors - currently only invalid_auth
 		if sErr, ok := err.(*WebError); ok && (sErr.Error() == "invalid_auth" || sErr.Error() == "account_inactive") {
+			rtm.Debugf("Invalid auth when connecting with RTM: %s", err)
 			rtm.IncomingEvents <- RTMEvent{"invalid_auth", &InvalidAuthEvent{}}
 			return nil, nil, sErr
 		}
@@ -125,17 +129,21 @@ func (rtm *RTM) startRTMAndDial(useRTMStart bool) (*Info, *websocket.Conn, error
 	var err error
 
 	if useRTMStart {
+		rtm.Debugf("Starting RTM")
 		info, url, err = rtm.StartRTM()
 	} else {
+		rtm.Debugf("Connecting to RTM")
 		info, url, err = rtm.ConnectRTM()
 	}
 	if err != nil {
+		rtm.Debugf("Failed to start or connect to RTM: %s", err)
 		return nil, nil, err
 	}
 
-	// Only use HTTPS for connections to prevent MITM attacks on the connection.
+	rtm.Debugf("Dialing to websocket on url %s", url)
 	conn, err := websocketProxyDial(url, "https://api.slack.com")
 	if err != nil {
+		rtm.Debugf("Failed to dial to the websocket: %s", err)
 		return nil, nil, err
 	}
 	return info, conn, err


### PR DESCRIPTION
When the Websocket connection locks for network reasons the whole thing just locks and provides no further output than

```
nlopes/slack2017/12/27 09:00:54 slack.go:91: Dialing to websocket on url wss://mpmulti-8ba0.lb.slack-msgs.com/websocket/KyN3bSd_30LXwzzJptxDwSH7ueeXerZuHa0qIX9IVmQpvepYC136bNxZfrEQiLCAreT6dtohZimnvM0q6H4GvkrSb3higukMj7iLJAwi9n0J_iEkhphlNo9Y4FyoPVhQeonNOVJC5KKQm-vgVypo_ifflS5IqSX-cLk5gp7GwRc=
```

With this PR the logs now continues with

```
2017/12/27 09:01:04 Received Slack Event &slack.ConnectionErrorEvent{Attempt:18, ErrorObj:(*websocket.DialError)(0x11664200)}
nlopes/slack2017/12/27 09:01:04 slack.go:91: Failed to dial to the websocket: websocket.Dial wss://mpmulti-8ba0.lb.slack-msgs.com/websocket/KyN3bSd_30LXwzzJptxDwSH7ueeXerZuHa0qIX9IVmQpvepYC136bNxZfrEQiLCAreT6dtohZimnvM0q6H4GvkrSb3higukMj7iLJAwi9n0J_iEkhphlNo9Y4FyoPVhQeonNOVJC5KKQm-vgVypo_ifflS5IqSX-cLk5gp7GwRc=: tls: DialWithDialer timed out
nlopes/slack2017/12/27 09:01:04 slack.go:91: reconnection 19 failed: websocket.Dial wss://mpmulti-8ba0.lb.slack-msgs.com/websocket/KyN3bSd_30LXwzzJptxDwSH7ueeXerZuHa0qIX9IVmQpvepYC136bNxZfrEQiLCAreT6dtohZimnvM0q6H4GvkrSb3higukMj7iLJAwi9n0J_iEkhphlNo9Y4FyoPVhQeonNOVJC5KKQm-vgVypo_ifflS5IqSX-cLk5gp7GwRc=: tls: DialWithDialer timed out
nlopes/slack2017/12/27 09:01:04 slack.go:97:  -> reconnecting in 5m0s
```

Which can be useful when running things on flaky connections, as connections can simply block forever for network weather reasons.

I also added a couple of debug log lines that helped me to troubleshoot the path to reach the websocket lockup from https://github.com/nlopes/slack/issues/226