### PR TITLE
fix memory leak in managed connection

### DIFF
--- a/rtm.go
+++ b/rtm.go
@@ -72,6 +72,7 @@ func (api *Client) NewRTMWithOptions(options *RTMOptions) *RTM {
 		isConnected:      false,
 		wasIntentional:   true,
 		killChannel:      make(chan bool),
+		disconnected:     make(chan struct{}),
 		forcePing:        make(chan bool),
 		rawEvents:        make(chan json.RawMessage),
 		idGen:            NewSafeID(1),

--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -99,6 +99,15 @@ func (rtm *RTM) connect(connectionCount int, useRTMStart bool) (*Info, *websocke
 			Attempt:  boff.attempts,
 			ErrorObj: err,
 		}}
+
+		// check if Disconnect() has been invoked.
+		select {
+		case _ = <-rtm.disconnected:
+			rtm.IncomingEvents <- RTMEvent{"disconnected", &DisconnectedEvent{Intentional: true}}
+			return nil, nil, fmt.Errorf("disconnect received while trying to connect")
+		default:
+		}
+
 		// get time we should wait before attempting to connect again
 		dur := boff.Duration()
 		rtm.Debugf("reconnection %d failed: %s", boff.attempts+1, err)
@@ -317,10 +326,13 @@ func (rtm *RTM) handleAck(event json.RawMessage) {
 		rtm.Debugln(" -> Erroneous 'ack' event:", string(event))
 		return
 	}
+
 	if ack.Ok {
 		rtm.IncomingEvents <- RTMEvent{"ack", ack}
-	} else {
+	} else if ack.RTMResponse.Error != nil {
 		rtm.IncomingEvents <- RTMEvent{"ack_error", &AckErrorEvent{ack.Error}}
+	} else {
+		rtm.IncomingEvents <- RTMEvent{"ack_error", &AckErrorEvent{fmt.Errorf("ack decode failure")}}
 	}
 }
 


### PR DESCRIPTION
there is a go routine leak if disconnect is invoked on a managed connection that is not connected.
```
func printEvents(wg *sync.WaitGroup, id int, t *slack.RTM) {
	defer wg.Done()
	for msg := range t.IncomingEvents {
		log.Printf("id(%d): %+v", id, msg.Data)
		switch msg.Data.(type) {
		case *slack.DisconnectedEvent:
			return
		default:
		}
		time.Sleep(time.Second)
	}
}

func main() {
	wg := &sync.WaitGroup{}
	for i := 0; i < 10; i++ {
		wg.Add(1)
		c := slack.New("token")
		// c.SetDebug(true)
		rtm := c.NewRTMWithOptions(&slack.RTMOptions{})
		go rtm.ManageConnection()
		if err := rtm.Disconnect(); err != nil {
			log.Println("disconnect error", err)
		}
		log.Println("disconnect completed")
		go printEvents(wg, i, rtm)
	}
	wg.Wait()
}
```