### PR TITLE
reduces required logger scope to only require an Output function.

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,53 @@
+package slack
+
+import (
+	"fmt"
+	"sync"
+)
+
+// SetLogger let's library users supply a logger, so that api debugging
+// can be logged along with the application's debugging info.
+func SetLogger(l logProvider) {
+	loggerMutex.Lock()
+	logger = ilogger{logProvider: l}
+	loggerMutex.Unlock()
+}
+
+var (
+	loggerMutex = new(sync.Mutex)
+	logger      logInternal // A logger that can be set by consumers
+)
+
+// logProvider is a logger interface compatible with both stdlib and some
+// 3rd party loggers such as logrus.
+type logProvider interface {
+	Output(int, string) error
+}
+
+// logInternal represents the internal logging api we use.
+type logInternal interface {
+	Print(...interface{})
+	Printf(string, ...interface{})
+	Println(...interface{})
+	Output(int, string) error
+}
+
+// ilogger implements the additional methods used by our internal logging.
+type ilogger struct {
+	logProvider
+}
+
+// Println replicates the behaviour of the standard logger.
+func (t ilogger) Println(v ...interface{}) {
+	t.Output(2, fmt.Sprintln(v...))
+}
+
+// Printf replicates the behaviour of the standard logger.
+func (t ilogger) Printf(format string, v ...interface{}) {
+	t.Output(2, fmt.Sprintf(format, v...))
+}
+
+// Print replicates the behaviour of the standard logger.
+func (t ilogger) Print(v ...interface{}) {
+	t.Output(2, fmt.Sprint(v...))
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,26 @@
+package slack
+
+import (
+	"bytes"
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogging(t *testing.T) {
+	buf := bytes.NewBufferString("")
+	logger := ilogger{logProvider: log.New(buf, "", 0|log.Lshortfile)}
+	logger.Println("test line 123")
+	assert.Equal(t, buf.String(), "logger_test.go:14: test line 123\n")
+	buf.Truncate(0)
+	logger.Print("test line 123")
+	assert.Equal(t, buf.String(), "logger_test.go:17: test line 123\n")
+	buf.Truncate(0)
+	logger.Printf("test line 123\n")
+	assert.Equal(t, buf.String(), "logger_test.go:20: test line 123\n")
+	buf.Truncate(0)
+	logger.Output(1, "test line 123\n")
+	assert.Equal(t, buf.String(), "logger_test.go:23: test line 123\n")
+	buf.Truncate(0)
+}

--- a/slack.go
+++ b/slack.go
@@ -9,10 +9,7 @@ import (
 	"os"
 )
 
-var logger stdLogger // A logger that can be set by consumers
-/*
-  Added as a var so that we can change this for testing purposes
-*/
+// Added as a var so that we can change this for testing purposes
 var SLACK_API string = "https://slack.com/api/"
 var SLACK_WEB_API_FORMAT string = "https://%s.slack.com/api/users.admin.%s?t=%s"
 
@@ -40,30 +37,6 @@ type Client struct {
 	}
 	info  Info
 	debug bool
-}
-
-// stdLogger is a logger interface compatible with both stdlib and some
-// 3rd party loggers such as logrus.
-type stdLogger interface {
-	Print(...interface{})
-	Printf(string, ...interface{})
-	Println(...interface{})
-
-	Fatal(...interface{})
-	Fatalf(string, ...interface{})
-	Fatalln(...interface{})
-
-	Panic(...interface{})
-	Panicf(string, ...interface{})
-	Panicln(...interface{})
-
-	Output(int, string) error
-}
-
-// SetLogger let's library users supply a logger, so that api debugging
-// can be logged along with the application's debugging info.
-func SetLogger(l stdLogger) {
-	logger = l
 }
 
 // New creates new Client.
@@ -97,16 +70,18 @@ func (api *Client) AuthTestContext(ctx context.Context) (response *AuthTestRespo
 func (api *Client) SetDebug(debug bool) {
 	api.debug = debug
 	if debug && logger == nil {
-		logger = log.New(os.Stdout, "nlopes/slack", log.LstdFlags|log.Lshortfile)
+		SetLogger(log.New(os.Stdout, "nlopes/slack", log.LstdFlags|log.Lshortfile))
 	}
 }
 
+// Debugf print a formatted debug line.
 func (api *Client) Debugf(format string, v ...interface{}) {
 	if api.debug {
 		logger.Output(2, fmt.Sprintf(format, v...))
 	}
 }
 
+// Debugln print a debug line.
 func (api *Client) Debugln(v ...interface{}) {
 	if api.debug {
 		logger.Output(2, fmt.Sprintln(v...))


### PR DESCRIPTION
as mentioned in in #233, reduces the required interface for logging to be satisfied just the Output method.