### PR TITLE
Support slash commands

### DIFF
--- a/examples/slash/slash.go
+++ b/examples/slash/slash.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"net/http"
+
+	"github.com/nlopes/slack"
+)
+
+func main() {
+	var (
+		verificationToken string
+	)
+
+	flag.StringVar(&verificationToken, "token", "YOUR_VERIFICATION_TOKEN_HERE", "Your Slash Verification Token")
+	flag.Parse()
+
+	// Example 1 (very simple)
+	http.HandleFunc("/slash", slack.SlashHandler(verificationToken, slash))
+
+	// Example 2 (customize)
+	http.HandleFunc("/slash2", func(w http.ResponseWriter, r *http.Request) {
+		s := &slack.Slash{}
+		s.Parse(r)
+
+		if s.Token != verificationToken {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		switch s.Command {
+		case "/echo":
+			params := &slack.PostMessageParameters{Text: s.Text}
+			b, err := json.Marshal(params)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(b)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	})
+	fmt.Println("[INFO] Server listening")
+	http.ListenAndServe(":3000", nil)
+}
+
+func slash(s *slack.Slash) (params *slack.PostMessageParameters, err error) {
+	switch s.Command {
+	case "/echo":
+		params = &slack.PostMessageParameters{Text: s.Text}
+	default:
+		return nil, errors.New("Invalid command")
+	}
+	return params, nil
+}

--- a/slash.go
+++ b/slash.go
@@ -1,0 +1,76 @@
+package slack
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Slash contains information about a request of the slash command
+type Slash struct {
+	Token       string `json:"token"`
+	TeamID      string `json:"team_id"`
+	TeamDomain  string `json:"team_domain"`
+	ChannelID   string `json:"channel_id"`
+	ChannelName string `json:"channel_name"`
+	UserID      string `json:"user_id"`
+	UserName    string `json:"user_name"`
+	Command     string `json:"command"`
+	Text        string `json:"text"`
+	ResponseURL string `json:"response_url"`
+	TriggerID   string `json:"trigger_id"`
+}
+
+// Parse will parse the request of the slash command
+func (s *Slash) Parse(r *http.Request) error {
+	if err := r.ParseForm(); err != nil {
+		return err
+	}
+	s.Token = r.PostForm.Get("token")
+	s.TeamID = r.PostForm.Get("team_id")
+	s.TeamDomain = r.PostForm.Get("team_domain")
+	s.ChannelID = r.PostForm.Get("channel_id")
+	s.ChannelName = r.PostForm.Get("channel_name")
+	s.UserID = r.PostForm.Get("user_id")
+	s.UserName = r.PostForm.Get("user_name")
+	s.Command = r.PostForm.Get("command")
+	s.Text = r.PostForm.Get("text")
+	s.ResponseURL = r.PostForm.Get("response_url")
+	s.TriggerID = r.PostForm.Get("trigger_id")
+	return nil
+}
+
+// SlashHandler returns func for http.Handler
+func SlashHandler(verificationToken string,
+	handler func(*Slash) (*PostMessageParameters, error)) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+
+		s := &Slash{}
+		if err := s.Parse(r); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		if s.Token != verificationToken {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		params, err := handler(s)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		b, err := json.Marshal(params)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(b)
+	}
+}

--- a/slash_test.go
+++ b/slash_test.go
@@ -1,0 +1,100 @@
+package slack
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type slashHandler struct {
+	gotParams *Slash
+}
+
+func newSlashHandler() *slashHandler {
+	return &slashHandler{
+		gotParams: &Slash{},
+	}
+}
+func (sh *slashHandler) handler(s *Slash) (*PostMessageParameters, error) {
+	sh.gotParams = s
+	response := &PostMessageParameters{Text: "success"}
+	return response, nil
+}
+
+func TestSlash_ServeHTTP(t *testing.T) {
+	once.Do(startServer)
+	serverURL := fmt.Sprintf("http://%s/slash", serverAddr)
+
+	tests := []struct {
+		body           url.Values
+		wantParams     *Slash
+		wantStatusCode int
+	}{
+		{
+			body: url.Values{
+				"command":      []string{"/command"},
+				"team_domain":  []string{"team"},
+				"channel_id":   []string{"C1234ABCD"},
+				"text":         []string{"text"},
+				"team_id":      []string{"T1234ABCD"},
+				"user_id":      []string{"U1234ABCD"},
+				"user_name":    []string{"username"},
+				"response_url": []string{"https://hooks.slack.com/commands/XXXXXXXX/00000000000/YYYYYYYYYYYYYY"},
+				"token":        []string{"valid"},
+				"channel_name": []string{"channel"},
+				"trigger_id":   []string{"0000000000.1111111111.222222222222aaaaaaaaaaaaaa"},
+			},
+			wantParams: &Slash{
+				Command:     "/command",
+				TeamDomain:  "team",
+				ChannelID:   "C1234ABCD",
+				Text:        "text",
+				TeamID:      "T1234ABCD",
+				UserID:      "U1234ABCD",
+				UserName:    "username",
+				ResponseURL: "https://hooks.slack.com/commands/XXXXXXXX/00000000000/YYYYYYYYYYYYYY",
+				Token:       "valid",
+				ChannelName: "channel",
+				TriggerID:   "0000000000.1111111111.222222222222aaaaaaaaaaaaaa",
+			},
+			wantStatusCode: http.StatusOK,
+		},
+		{
+			body: url.Values{
+				"token": []string{"invalid"},
+			},
+			wantParams:     &Slash{},
+			wantStatusCode: http.StatusUnauthorized,
+		},
+	}
+
+	client := &http.Client{}
+	h := newSlashHandler()
+	verificationToken := "valid"
+	http.HandleFunc("/slash", SlashHandler(verificationToken, h.handler))
+
+	for i, test := range tests {
+		req, err := http.NewRequest(http.MethodPost, serverURL, strings.NewReader(test.body.Encode()))
+		if err != nil {
+			t.Fatalf("%d: Unexpected error: %s", i, err)
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("%d: Unexpected error: %s", i, err)
+		}
+
+		if resp.StatusCode != test.wantStatusCode {
+			t.Errorf("%d: Got status code %d, want %d", i, resp.StatusCode, test.wantStatusCode)
+		}
+		if !reflect.DeepEqual(h.gotParams, test.wantParams) {
+			t.Errorf("%d: Got params %#v, want %#v", i, h.gotParams, test.wantParams)
+		}
+		resp.Body.Close()
+		h = newSlashHandler()
+	}
+}


### PR DESCRIPTION
I support `slash` commands.
https://api.slack.com/slash-commands

This PR mainly offer parse HTTP requests of `slash` commands
In addition, it also provides a convenient wrapper for use with http.HandlerFunc.

Please see an example.
Example 1: It's a very easy way to write a bot. You only need to write command handling.
Example 2: It's a flexible way. This example only use `parse` method.

I wrote the test code with reference to the following test code.
https://github.com/nlopes/slack/blob/master/stars_test.go

Please point out that if there are strange points!