### PR TITLE
Add an explicit event type for RTM rate-limit errors.

### DIFF
--- a/websocket_internals.go
+++ b/websocket_internals.go
@@ -63,6 +63,13 @@ func (m *MessageTooLongEvent) Error() string {
 	return fmt.Sprintf("Message too long (max %d characters)", m.MaxLength)
 }
 
+// RateLimitEvent is used when Slack warns that rate-limits are being hit.
+type RateLimitEvent struct{}
+
+func (e *RateLimitEvent) Error() string {
+	return "Messages are being sent too fast."
+}
+
 // OutgoingErrorEvent contains information in case there were errors sending messages
 type OutgoingErrorEvent struct {
 	Message  OutgoingMessage

--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -340,7 +340,13 @@ func (rtm *RTM) handleAck(event json.RawMessage) {
 	if ack.Ok {
 		rtm.IncomingEvents <- RTMEvent{"ack", ack}
 	} else if ack.RTMResponse.Error != nil {
-		rtm.IncomingEvents <- RTMEvent{"ack_error", &AckErrorEvent{ack.Error}}
+		// As there is no documentation for RTM error-codes, this
+		// identification of a rate-limit warning is very brittle.
+		if ack.RTMResponse.Error.Code == -1 && ack.RTMResponse.Error.Msg == "slow down, too many messages..." {
+			rtm.IncomingEvents <- RTMEvent{"ack_error", &RateLimitEvent{}}
+		} else {
+			rtm.IncomingEvents <- RTMEvent{"ack_error", &AckErrorEvent{ack.Error}}
+		}
 	} else {
 		rtm.IncomingEvents <- RTMEvent{"ack_error", &AckErrorEvent{fmt.Errorf("ack decode failure")}}
 	}


### PR DESCRIPTION
Proposal for #240. The chosen implementation attempts to remain as much as possible in line with existing code-structure. It requires users to take action themselves on rate-limiting errors as the library remains transparent to them but it does provide them with an easier way to filter for such errors.

As the added comment in the code explains the identification of rate-limiting errors in the RTM API is brittle as there is no proper documentation of errors in that API. The values that are filtered against were retrieved experimentally by forcing a rate-limit on a private Slack workspace (screenshot below):

<img width="888" alt="screen shot 2018-01-14 at 18 45 29" src="https://user-images.githubusercontent.com/896592/34919412-7f605384-f95b-11e7-9b9e-fba9a374c504.png">
