### PR TITLE
add missing interactive/slash-command msg fields

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -85,6 +85,10 @@ type Msg struct {
 
 	// reactions
 	Reactions []ItemReaction `json:"reactions,omitempty"`
+
+	// slash commands and interactive messages
+	ResponseType    string `json:"response_type,omitempty"`
+	ReplaceOriginal bool   `json:"replace_original,omitempty"`
 }
 
 // Icon is used for bot messages


### PR DESCRIPTION
Only ones that I noticed that were missing so far.

-----

https://api.slack.com/interactive-messages
 * Responding with an error message: "replace_original"

https://api.slack.com/slash-commands
 * "In Channel" vs "Ephemeral" responses: "response_type"