### PR TITLE
rtm: add RTM options, and gorilla websocket Dialer

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -44,6 +44,10 @@ type RTM struct {
 	// rtm.start to connect to Slack, otherwise it will use
 	// rtm.connect
 	useRTMStart bool
+
+	// dialer is a gorilla/websocket Dialer. If nil, use the default
+	// Dialer.
+	dialer *websocket.Dialer
 }
 
 // RTMOptions allows configuration of various options available for RTM messaging

--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -145,7 +145,11 @@ func (rtm *RTM) startRTMAndDial(useRTMStart bool) (*Info, *websocket.Conn, error
 	// Only use HTTPS for connections to prevent MITM attacks on the connection.
 	upgradeHeader := http.Header{}
 	upgradeHeader.Add("Origin", "https://api.slack.com")
-	conn, _, err := websocket.DefaultDialer.Dial(url, upgradeHeader)
+	dialer := websocket.DefaultDialer
+	if rtm.dialer != nil {
+		dialer = rtm.dialer
+	}
+	conn, _, err := dialer.Dial(url, upgradeHeader)
 	if err != nil {
 		rtm.Debugf("Failed to dial to the websocket: %s", err)
 		return nil, nil, err

--- a/websocket_managed_conn_test.go
+++ b/websocket_managed_conn_test.go
@@ -21,7 +21,7 @@ func TestRTMSingleConnect(t *testing.T) {
 	// Setup and start the RTM.
 	slack.SLACK_API = testServer.GetAPIURL()
 	api := slack.New(testToken)
-	rtm := api.NewRTM()
+	rtm := api.NewRTM(slack.RTMOptionUseStart(true))
 	go rtm.ManageConnection()
 
 	// Observe incoming messages.


### PR DESCRIPTION
This is a combination of #244 and #263, with a test fix of #244 to `UseRTMStart(true)` in the test.

This allows NewRTM to accept options: RTMOptionUseStart mimics the
existing RTMOptions.UseRTMStart, and RTMOptionDialer allows passing in
a gorilla websocket Dialer. The various Dialer fields are generally
useful; as an example, this will allow callers to specify
per-connection proxy settings without mutating environment variables.