### PR TITLE
Fixed "invalid_limit" error occurs.

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -393,7 +393,7 @@ func (api *Client) GetConversationRepliesContext(ctx context.Context, params *Ge
 		values.Add("latest", params.Latest)
 	}
 	if params.Limit != 0 {
-		values.Add("limit", string(params.Limit))
+		values.Add("limit", strconv.Itoa(params.Limit))
 	}
 	if params.Oldest != "" {
 		values.Add("oldest", params.Oldest)

--- a/conversation.go
+++ b/conversation.go
@@ -83,7 +83,7 @@ func (api *Client) GetUsersInConversationContext(ctx context.Context, params *Ge
 		values.Add("cursor", params.Cursor)
 	}
 	if params.Limit != 0 {
-		values.Add("limit", string(params.Limit))
+		values.Add("limit", strconv.Itoa(params.Limit))
 	}
 	response := struct {
 		Members          []string         `json:"members"`
@@ -444,7 +444,7 @@ func (api *Client) GetConversationsContext(ctx context.Context, params *GetConve
 		values.Add("cursor", params.Cursor)
 	}
 	if params.Limit != 0 {
-		values.Add("limit", string(params.Limit))
+		values.Add("limit", strconv.Itoa(params.Limit))
 	}
 	if params.Types != nil {
 		values.Add("types", strings.Join(params.Types, ","))
@@ -573,7 +573,7 @@ func (api *Client) GetConversationHistoryContext(ctx context.Context, params *Ge
 		values.Add("latest", params.Latest)
 	}
 	if params.Limit != 0 {
-		values.Add("limit", string(params.Limit))
+		values.Add("limit", strconv.Itoa(params.Limit))
 	}
 	if params.Oldest != "" {
 		values.Add("oldest", params.Oldest)


### PR DESCRIPTION
The part that was not correctly converted from a character string to a numerical value with the following code. We corrected this to be converted correctly.

```
if params.Limit != 0 {
	values.Add("limit", string(params.Limit))
}
```

fixes #271 