### PR TITLE
Add AuthorID to Attachment struct

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -78,6 +78,7 @@ type Attachment struct {
 	CallbackID string `json:"callback_id,omitempty"`
 	ID         int    `json:"id,omitempty"`
 
+	AuthorID      string `json:"author_id,omitempty"`
 	AuthorName    string `json:"author_name,omitempty"`
 	AuthorSubname string `json:"author_subname,omitempty"`
 	AuthorLink    string `json:"author_link,omitempty"`


### PR DESCRIPTION
For Slack archive message unfurls, there is a AuthorID field which gives the Slack ID of the author of the linked message:

```json
{
  "from_url":"https:\/\/yourworkspace.slack.com\/archives\/C12345678\/p1234567890123456",
  "fallback":"...",
  "ts":"1521611847.000156",
  "author_id":"U12345678",
  "author_subname":"",
  "channel_id":"C12345678",
  "channel_name":"",
  "is_msg_unfurl":true,
  "text":"",
  "author_name":"",
  "author_link":"",
  "author_icon":"",
  "mrkdwn_in":[
    "text"
  ],
  "id":1,
  "footer":""
}
```