### PR TITLE
Add Events API helper middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ func main() {
 
 See https://github.com/nlopes/slack/blob/master/examples/websocket/websocket.go
 
+## Events API
+
+While there aren't any helpers (yet) for processing events from the Events API. This library does 
+provide HTTP middleware for you to register an endpoint to receive events from Slack. Check the docs 
+for usage examples.
 
 ## Contributing
 

--- a/webhook.go
+++ b/webhook.go
@@ -1,0 +1,102 @@
+package slack
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+type ChallengeHandlerOptions struct {
+	// Set to 'true' if you want to process events synchronously. This means the supplied
+	// http.Handler is responsible for sending a 200 back to Slack within 3 seconds of recieving
+	// the request. By default, your http.Handler will be called in a new goroutine with a mocked
+	// ResponseWriter and Request object.
+	SyncProcessing bool
+}
+
+type challengeEvent struct {
+	Token     string `json:"token"`
+	Challenge []byte `json:"challenge"`
+	Type      string `json:"type"`
+}
+
+const challengeEventType = "url_verification"
+
+// fakeResponseWriter is mocking the http.ResponseWriter interface
+// so we can send slack a 200 as soon as possible, and pass off
+// this mock to the user-supplied HTTP handler. It's got a lower memory
+// overhead than the httptest Recorder.
+//
+// We can make this optional for advanced users who require handling
+// the response in all cases.
+//
+// Slack suggests this approach as a best practice:
+// https://api.slack.com/events-api#tips
+type fakeResponseWriter struct {
+	headers http.Header
+}
+
+// Wraps an HTTP Handler to respond to Slack's Events API challenge. If the handler gets
+// a JSON request that isn't the challenge event, it will forward the request to the underlying
+// handler for processing.
+func WithChallengeHandler(h http.Handler, opts ChallengeHandlerOptions) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+
+		r.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+
+		// If we have a valid payload from Slack, attempt to parse out the challenge
+		// event and respond to it.
+		if len(body) > 0 {
+			evt := challengeEvent{}
+			err = json.Unmarshal(body, &evt)
+			// If the body is invalid JSON, we should return a BadRequest,
+			// but we shouldn't complain about bad types, etc. since this may
+			// be a conflicting payload from Slack
+			if _, ok := err.(*json.SyntaxError); ok {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			if err == nil && strings.TrimSpace(evt.Type) == challengeEventType {
+				w.Header().Set("Content-Type", "text/plain")
+				// XXX: We can likely ignore this error, if we fail to respond
+				//      slack _should_ retry to send the request.
+				_, _ = w.Write(evt.Challenge)
+				return
+			}
+		}
+
+		// If we didn't intercept the challenge event, pass it off to the underlying
+		// HTTP handler. The sync handler should be called inline with the real ResponseWriter
+		// while the async handler should write a 200 OK and pass the event off to the handler
+		if opts.SyncProcessing {
+			h.ServeHTTP(w, r)
+		} else {
+			w.WriteHeader(http.StatusOK)
+			go h.ServeHTTP(newResponseWriter(), r)
+		}
+	})
+}
+
+func newResponseWriter() *fakeResponseWriter {
+	return &fakeResponseWriter{
+		headers: make(http.Header),
+	}
+}
+
+func (r *fakeResponseWriter) Header() http.Header {
+	return r.headers
+}
+
+func (r *fakeResponseWriter) Write(body []byte) (int, error) {
+	return len(body), nil
+}
+
+func (r *fakeResponseWriter) WriteHeader(status int) {}

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -1,0 +1,159 @@
+package slack
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+var challengeResponse = []byte("challenge")
+var challengeBody, _ = json.Marshal(challengeEvent{
+	Token:     "1234",
+	Challenge: challengeResponse,
+	Type:      challengeEventType,
+})
+
+var eventBody = []byte("{ \"foo\": \"bar\"}")
+
+func TestChallengeHandlerResponses(t *testing.T) {
+	var teapotBody = []byte("I'm a teapot")
+	var emptyBody = []byte("")
+	teapotHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+		w.Write(teapotBody)
+	})
+
+	cases := []struct {
+		Options      ChallengeHandlerOptions
+		RequestBody  []byte
+		ExpectedCode int
+		ExpectedBody []byte
+	}{
+		// Tests that the sync handler will rely on the underlying handler
+		// for event processing / responses
+		{
+			Options:      ChallengeHandlerOptions{SyncProcessing: true},
+			RequestBody:  eventBody,
+			ExpectedCode: http.StatusTeapot,
+			ExpectedBody: teapotBody,
+		},
+		// Tests that the sync handler will rely on the challenge handler
+		// for challenge responses
+		{
+			Options:      ChallengeHandlerOptions{SyncProcessing: true},
+			RequestBody:  challengeBody,
+			ExpectedCode: http.StatusOK,
+			ExpectedBody: challengeResponse,
+		},
+		// Tests that the sync handler will return 400 on invalid json
+		{
+			Options:      ChallengeHandlerOptions{SyncProcessing: true},
+			RequestBody:  []byte("c"),
+			ExpectedCode: http.StatusBadRequest,
+			ExpectedBody: []byte("invalid character 'c' looking for beginning of value\n"),
+		},
+		// Tests that the async handler will rely on the challenge handler
+		// for responses
+		{
+			Options:      ChallengeHandlerOptions{},
+			RequestBody:  eventBody,
+			ExpectedCode: http.StatusOK,
+			ExpectedBody: emptyBody,
+		},
+		// Tests that the async handler will rely on the challenge handler
+		// for challenge responses
+		{
+			Options:      ChallengeHandlerOptions{},
+			RequestBody:  challengeBody,
+			ExpectedCode: http.StatusOK,
+			ExpectedBody: challengeResponse,
+		},
+		// Tests that the async handler will return 400 on invalid json
+		{
+			Options:      ChallengeHandlerOptions{},
+			RequestBody:  []byte("c"),
+			ExpectedCode: http.StatusBadRequest,
+			ExpectedBody: []byte("invalid character 'c' looking for beginning of value\n"),
+		},
+	}
+
+	for i, test := range cases {
+		wrappedHandler := WithChallengeHandler(teapotHandler, test.Options)
+
+		resp := httptest.NewRecorder()
+		req, err := http.NewRequest("POST", "/webhook", bytes.NewBuffer(test.RequestBody))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		wrappedHandler.ServeHTTP(resp, req)
+		if resp.Code != test.ExpectedCode {
+			t.Errorf("[Case %d]: Server returned status code %d, expected %d", i, resp.Code, test.ExpectedCode)
+		}
+
+		if resp.Body.String() != string(test.ExpectedBody) {
+			t.Errorf("[Case %d] Server returned body %q, expected %q", i, resp.Body, string(test.ExpectedBody))
+		}
+	}
+}
+
+// The default challenge handler runs each http handler in its own Goroutine
+// and responds 200 back to Slack for you.
+func ExampleWithChallengeHandler(t *testing.T) {
+	type SlackEvent struct {
+		Type           string          `json:"type"`
+		EventTimestamp string          `json:"event_ts"`
+		Timestamp      string          `json:"ts"`
+		Event          json.RawMessage `json:"event"`
+	}
+
+	webhookHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			return
+		}
+		msg := SlackEvent{}
+		json.Unmarshal(body, &msg)
+		fmt.Printf("Got Event: %s", msg.Type)
+	})
+
+	http.Handle("/webhook", WithChallengeHandler(webhookHandler, ChallengeHandlerOptions{}))
+	http.ListenAndServe(":8000", nil)
+}
+
+// If you want to respond to the Events API yourself, you can configure
+// the webhook handler to use synchronous processing. Slack has a 3 second timeout in
+// which you must respond, therefor you should respond to the API prior to processing
+// the event.
+func ExampleWithChallengeHandler_withSyncProcessing(t *testing.T) {
+	type SlackEvent struct {
+		Type           string          `json:"type"`
+		EventTimestamp string          `json:"event_ts"`
+		Timestamp      string          `json:"ts"`
+		Event          json.RawMessage `json:"event"`
+	}
+
+	webhookHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		go func() {
+			msg := SlackEvent{}
+			json.Unmarshal(body, &msg)
+			fmt.Printf("Got Event: %s", msg.Type)
+		}()
+		w.WriteHeader(http.StatusOK)
+	})
+
+	http.Handle("/webhook", WithChallengeHandler(webhookHandler, ChallengeHandlerOptions{
+		SyncProcessing: true,
+	}))
+	http.ListenAndServe(":8000", nil)
+}


### PR DESCRIPTION
Hey there! We're currently using the slack library in our project, but had a need to use the Events API as well. I'm trying to contribute back some middleware we developed to get the Event API up and running.

I saw this was requested in #94, and unfortunately I don't have time to write parsers for all the event structures right now, I'm hoping that this middleware is general enough to provide as a starting point for future work.

Commit Message:
In order to use slack's Events API, your webhook must respond to a challenge request from Slack. This commit adds middleware that will look for Slack's challenge request and responds. Any other valid JSON request is forwarded to the user's handler for parsing.

