### PR TITLE
start of experimental utility package

### DIFF
--- a/slackutilsx/slackutilsx.go
+++ b/slackutilsx/slackutilsx.go
@@ -1,0 +1,48 @@
+// Package slackutilsx is a utility package that doesn't promise API stability.
+// its for experimental functionality and utilities.
+package slackutilsx
+
+import "unicode/utf8"
+
+// ChannelType the type of channel based on the channelID
+type ChannelType int
+
+func (t ChannelType) String() string {
+	switch t {
+	case CTypeDM:
+		return "Direct"
+	case CTypeGroup:
+		return "Group"
+	case CTypeChannel:
+		return "Channel"
+	default:
+		return "Unknown"
+	}
+}
+
+const (
+	// Unknown represents channels we cannot properly detect.
+	CTypeUnknown ChannelType = iota
+	// DM is a private channel between two slack users.
+	CTypeDM
+	// Group is a group channel.
+	CTypeGroup
+	// Channel is a public channel.
+	CTypeChannel
+)
+
+// DetectChannelType converts a channelID to a ChannelType.
+// channelID must not be empty. However, if it is not empty, the channel type will default to Unknown.
+func DetectChannelType(channelID string) ChannelType {
+	// intentionally ignore the error and just default to CTypeUnknown
+	switch r, _ := utf8.DecodeRuneInString(channelID); r {
+	case 'C':
+		return CTypeChannel
+	case 'G':
+		return CTypeGroup
+	case 'D':
+		return CTypeDM
+	default:
+		return CTypeUnknown
+	}
+}

--- a/slackutilsx/slackutilsx_test.go
+++ b/slackutilsx/slackutilsx_test.go
@@ -1,0 +1,19 @@
+package slackutilsx
+
+import (
+	"testing"
+)
+
+func TestDetectChannelType(t *testing.T) {
+	test := func(channelID string, expected ChannelType) {
+		if computed := DetectChannelType(channelID); computed != expected {
+			t.Errorf("expected channelID %s to have type %s, got: %s", channelID, expected, computed)
+		}
+	}
+
+	test("G11111111", CTypeGroup)
+	test("D11111111", CTypeDM)
+	test("C11111111", CTypeChannel)
+	test("", CTypeUnknown)
+	test("X11111111", CTypeUnknown)
+}


### PR DESCRIPTION
a way for us to add functionality without promising reliability and backwards compatibility while working on the feature set.

this PR contains a simple utility method for determining the channel type based on the
channel ID.