### PR TITLE
Fix incorrect URL for users.setPhoto method

### DIFF
--- a/users.go
+++ b/users.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/url"
+	"strconv"
 )
 
 const (
@@ -287,13 +288,13 @@ func (api *Client) SetUserPhotoContext(ctx context.Context, image string, params
 		"token": {api.token},
 	}
 	if params.CropX != DEFAULT_USER_PHOTO_CROP_X {
-		values.Add("crop_x", string(params.CropX))
+		values.Add("crop_x", strconv.Itoa(params.CropX))
 	}
 	if params.CropY != DEFAULT_USER_PHOTO_CROP_Y {
-		values.Add("crop_y", string(params.CropY))
+		values.Add("crop_y", strconv.Itoa(params.CropX))
 	}
 	if params.CropW != DEFAULT_USER_PHOTO_CROP_W {
-		values.Add("crop_w", string(params.CropW))
+		values.Add("crop_w", strconv.Itoa(params.CropW))
 	}
 
 	err := postLocalWithMultipartResponse(ctx, api.httpclient, "users.setPhoto", image, "image", values, response, api.debug)

--- a/users.go
+++ b/users.go
@@ -296,7 +296,7 @@ func (api *Client) SetUserPhotoContext(ctx context.Context, image string, params
 		values.Add("crop_w", string(params.CropW))
 	}
 
-	err := postLocalWithMultipartResponse(ctx, api.httpclient, SLACK_API+"users.setPhoto", image, "image", values, response, api.debug)
+	err := postLocalWithMultipartResponse(ctx, api.httpclient, "users.setPhoto", image, "image", values, response, api.debug)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This change fixes a bug wherein `SLACK_API` was being prepended to the `users.setPhoto` path twice. I believe this is the same issue that was fixed in #266.