### PR TITLE
Allow Guest Invitations To Be Resent

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -62,6 +62,7 @@ func (api *Client) InviteGuestContext(ctx context.Context, teamName, channel, fi
 		"last_name":        {lastName},
 		"ultra_restricted": {"1"},
 		"token":            {api.token},
+		"resend":           {"true"},
 		"set_active":       {"true"},
 		"_attempts":        {"1"},
 	}
@@ -88,6 +89,7 @@ func (api *Client) InviteRestrictedContext(ctx context.Context, teamName, channe
 		"last_name":  {lastName},
 		"restricted": {"1"},
 		"token":      {api.token},
+		"resend":     {"true"},
 		"set_active": {"true"},
 		"_attempts":  {"1"},
 	}


### PR DESCRIPTION
When inviting single or multi channel guests to the team via `users.admin.invite`, there is an optional `resent` parameter that can be specified. 

* When not specified, you will receive an `already_invited` error when you try to invite an email address that has already been invited
* When specified, you will either receive:
  * An `ok` response, when the invite was resent
  * A `sent_recently` error when the prior invite was sent recently

I don't really see any downside or need for optionality here. If you're trying to invite someone, you want to invite them, even if they have received an invite. Slack has rules about recency (I assume to avoid people getting spammed), so you will sometimes still receive an error.

See also: https://github.com/ErikKalkoken/slackApiDoc/blob/master/users.admin.invite.md