### PR TITLE
Fixed PostMessage error bug.  fixed #294

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/url"
 	"strings"
 )
@@ -155,6 +156,11 @@ func (api *Client) SendMessageContext(ctx context.Context, channelID string, opt
 
 	if err = post(ctx, api.httpclient, string(config.mode), config.values, &response, api.debug); err != nil {
 		return "", "", "", err
+	}
+
+	//Check slack response for error
+	if response.SlackResponse.Ok == false {
+		return "", "", "", fmt.Errorf("slack API error: %s", response.SlackResponse.Error)
 	}
 
 	return response.Channel, response.Timestamp, response.Text, nil


### PR DESCRIPTION
Added condition to check `SlackResponse` for any Error.
[info](https://api.slack.com/web)
```
{
    "ok": true,
    "stuff": "This is good"
}
```
```
{
    "ok": false,
    "error": "something_bad"
}
```
if `SlackResponse.Ok` is false `SendMessageContext` will return an Error.

If any issue please let me know.

Thank you.