### PR TITLE
Fixes race condition encountered when diconnecting from RTM API

### DIFF
--- a/rtm.go
+++ b/rtm.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -102,6 +103,7 @@ func (api *Client) NewRTM(options ...RTMOption) *RTM {
 		forcePing:        make(chan bool),
 		rawEvents:        make(chan json.RawMessage),
 		idGen:            NewSafeID(1),
+		mu:               &sync.Mutex{},
 	}
 
 	for _, opt := range options {

--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -27,6 +27,7 @@ import (
 func (rtm *RTM) ManageConnection() {
 	var connectionCount int
 	for {
+		rtm.mu.Lock()
 		connectionCount++
 		// start trying to connect
 		// the returned err is already passed onto the IncomingEvents channel
@@ -45,6 +46,7 @@ func (rtm *RTM) ManageConnection() {
 
 		rtm.conn = conn
 		rtm.isConnected = true
+		rtm.mu.Unlock()
 
 		rtm.Debugf("RTM connection succeeded on try %d", connectionCount)
 
@@ -488,5 +490,5 @@ var eventMapping = map[string]interface{}{
 	"reconnect_url": ReconnectUrlEvent{},
 
 	"member_joined_channel": MemberJoinedChannelEvent{},
-	"member_left_channel": MemberLeftChannelEvent{},
+	"member_left_channel":   MemberLeftChannelEvent{},
 }


### PR DESCRIPTION
The race condition is described in [#302](https://github.com/nlopes/slack/issues/302) including a small program that allows to reproduce it.

Closes nlopes/slack/#302