### PR TITLE
cleanup some error handling

### DIFF
--- a/bots.go
+++ b/bots.go
@@ -16,7 +16,7 @@ type Bot struct {
 
 type botResponseFull struct {
 	Bot `json:"bot,omitempty"` // GetBotInfo
-	SlackResponse
+	WebResponse
 }
 
 func botRequest(ctx context.Context, client HTTPRequester, path string, values url.Values, debug bool) (*botResponseFull, error) {

--- a/channels.go
+++ b/channels.go
@@ -14,7 +14,7 @@ type channelResponseFull struct {
 	Topic        string    `json:"topic"`
 	NotInChannel bool      `json:"not_in_channel"`
 	History
-	SlackResponse
+	WebResponse
 }
 
 // Channel contains information about the channel

--- a/chat.go
+++ b/chat.go
@@ -26,7 +26,7 @@ type chatResponseFull struct {
 	Channel   string `json:"channel"`
 	Timestamp string `json:"ts"`
 	Text      string `json:"text"`
-	SlackResponse
+	WebResponse
 }
 
 // PostMessageParameters contains all the parameters necessary (including the optional ones) for a PostMessage() request
@@ -157,7 +157,7 @@ func (api *Client) SendMessageContext(ctx context.Context, channelID string, opt
 		return "", "", "", err
 	}
 
-	return response.Channel, response.Timestamp, response.Text, nil
+	return response.Channel, response.Timestamp, response.Text, response.Err()
 }
 
 // ApplyMsgOptions utility function for debugging/testing chat requests.

--- a/chat_test.go
+++ b/chat_test.go
@@ -1,0 +1,32 @@
+package slack
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func postMessageInvalidChannelHandler(rw http.ResponseWriter, r *http.Request) {
+	rw.Header().Set("Content-Type", "application/json")
+	response, _ := json.Marshal(chatResponseFull{
+		WebResponse: WebResponse{Ok: false, Error: "channel_not_found"},
+	})
+	rw.Write(response)
+}
+
+func TestPostMessageInvalidChannel(t *testing.T) {
+	http.HandleFunc("/chat.postMessage", postMessageInvalidChannelHandler)
+	once.Do(startServer)
+	SLACK_API = "http://" + serverAddr + "/"
+	api := New("testing-token")
+	_, _, err := api.PostMessage("CXXXXXXXX", "hello", PostMessageParameters{})
+	if err == nil {
+		t.Errorf("Expected error: %s; instead succeeded", "channel_not_found")
+		return
+	}
+
+	if err.Error() != "channel_not_found" {
+		t.Errorf("Expected error: %s; received: %s", "channel_not_found", err)
+		return
+	}
+}

--- a/conversation.go
+++ b/conversation.go
@@ -88,7 +88,7 @@ func (api *Client) GetUsersInConversationContext(ctx context.Context, params *Ge
 	response := struct {
 		Members          []string         `json:"members"`
 		ResponseMetaData responseMetaData `json:"response_metadata"`
-		SlackResponse
+		WebResponse
 	}{}
 	err := post(ctx, api.httpclient, "conversations.members", values, &response, api.debug)
 	if err != nil {
@@ -111,15 +111,13 @@ func (api *Client) ArchiveConversationContext(ctx context.Context, channelID str
 		"token":   {api.token},
 		"channel": {channelID},
 	}
-	response := SlackResponse{}
+	response := WebResponse{}
 	err := post(ctx, api.httpclient, "conversations.archive", values, &response, api.debug)
 	if err != nil {
 		return err
 	}
-	if !response.Ok {
-		return errors.New(response.Error)
-	}
-	return nil
+
+	return response.Err()
 }
 
 // UnArchiveConversation reverses conversation archival
@@ -133,15 +131,13 @@ func (api *Client) UnArchiveConversationContext(ctx context.Context, channelID s
 		"token":   {api.token},
 		"channel": {channelID},
 	}
-	response := SlackResponse{}
+	response := WebResponse{}
 	err := post(ctx, api.httpclient, "conversations.unarchive", values, &response, api.debug)
 	if err != nil {
 		return err
 	}
-	if !response.Ok {
-		return errors.New(response.Error)
-	}
-	return nil
+
+	return response.Err()
 }
 
 // SetTopicOfConversation sets the topic for a conversation
@@ -157,17 +153,15 @@ func (api *Client) SetTopicOfConversationContext(ctx context.Context, channelID,
 		"topic":   {topic},
 	}
 	response := struct {
-		SlackResponse
+		WebResponse
 		Channel *Channel `json:"channel"`
 	}{}
 	err := post(ctx, api.httpclient, "conversations.setTopic", values, &response, api.debug)
 	if err != nil {
 		return nil, err
 	}
-	if !response.Ok {
-		return nil, errors.New(response.Error)
-	}
-	return response.Channel, nil
+
+	return response.Channel, response.Err()
 }
 
 // SetPurposeOfConversation sets the purpose for a conversation
@@ -183,17 +177,15 @@ func (api *Client) SetPurposeOfConversationContext(ctx context.Context, channelI
 		"purpose": {purpose},
 	}
 	response := struct {
-		SlackResponse
+		WebResponse
 		Channel *Channel `json:"channel"`
 	}{}
 	err := post(ctx, api.httpclient, "conversations.setPurpose", values, &response, api.debug)
 	if err != nil {
 		return nil, err
 	}
-	if !response.Ok {
-		return nil, errors.New(response.Error)
-	}
-	return response.Channel, nil
+
+	return response.Channel, response.Err()
 }
 
 // RenameConversation renames a conversation
@@ -209,17 +201,15 @@ func (api *Client) RenameConversationContext(ctx context.Context, channelID, cha
 		"name":    {channelName},
 	}
 	response := struct {
-		SlackResponse
+		WebResponse
 		Channel *Channel `json:"channel"`
 	}{}
 	err := post(ctx, api.httpclient, "conversations.rename", values, &response, api.debug)
 	if err != nil {
 		return nil, err
 	}
-	if !response.Ok {
-		return nil, errors.New(response.Error)
-	}
-	return response.Channel, nil
+
+	return response.Channel, response.Err()
 }
 
 // InviteUsersToConversation invites users to a channel
@@ -235,17 +225,15 @@ func (api *Client) InviteUsersToConversationContext(ctx context.Context, channel
 		"users":   {strings.Join(users, ",")},
 	}
 	response := struct {
-		SlackResponse
+		WebResponse
 		Channel *Channel `json:"channel"`
 	}{}
 	err := post(ctx, api.httpclient, "conversations.invite", values, &response, api.debug)
 	if err != nil {
 		return nil, err
 	}
-	if !response.Ok {
-		return nil, errors.New(response.Error)
-	}
-	return response.Channel, nil
+
+	return response.Channel, response.Err()
 }
 
 // KickUserFromConversation removes a user from a conversation
@@ -260,15 +248,13 @@ func (api *Client) KickUserFromConversationContext(ctx context.Context, channelI
 		"channel": {channelID},
 		"user":    {user},
 	}
-	response := SlackResponse{}
+	response := WebResponse{}
 	err := post(ctx, api.httpclient, "conversations.kick", values, &response, api.debug)
 	if err != nil {
 		return err
 	}
-	if !response.Ok {
-		return errors.New(response.Error)
-	}
-	return nil
+
+	return response.Err()
 }
 
 // CloseConversation closes a direct message or multi-person direct message
@@ -283,7 +269,7 @@ func (api *Client) CloseConversationContext(ctx context.Context, channelID strin
 		"channel": {channelID},
 	}
 	response := struct {
-		SlackResponse
+		WebResponse
 		NoOp          bool `json:"no_op"`
 		AlreadyClosed bool `json:"already_closed"`
 	}{}
@@ -292,10 +278,8 @@ func (api *Client) CloseConversationContext(ctx context.Context, channelID strin
 	if err != nil {
 		return false, false, err
 	}
-	if !response.Ok {
-		return false, false, errors.New(response.Error)
-	}
-	return response.NoOp, response.AlreadyClosed, nil
+
+	return response.NoOp, response.AlreadyClosed, response.Err()
 }
 
 // CreateConversation initiates a public or private channel-based conversation
@@ -315,10 +299,8 @@ func (api *Client) CreateConversationContext(ctx context.Context, channelName st
 	if err != nil {
 		return nil, err
 	}
-	if !response.Ok {
-		return nil, errors.New(response.Error)
-	}
-	return &response.Channel, nil
+
+	return &response.Channel, response.Err()
 }
 
 // GetConversationInfo retrieves information about a conversation
@@ -338,10 +320,8 @@ func (api *Client) GetConversationInfoContext(ctx context.Context, channelID str
 	if err != nil {
 		return nil, err
 	}
-	if !response.Ok {
-		return nil, errors.New(response.Error)
-	}
-	return &response.Channel, nil
+
+	return &response.Channel, response.Err()
 }
 
 // LeaveConversation leaves a conversation
@@ -357,11 +337,7 @@ func (api *Client) LeaveConversationContext(ctx context.Context, channelID strin
 	}
 
 	response, err := channelRequest(ctx, api.httpclient, "conversations.leave", values, api.debug)
-	if err != nil {
-		return false, err
-	}
-
-	return response.NotInChannel, nil
+	return response.NotInChannel, err
 }
 
 type GetConversationRepliesParameters struct {
@@ -404,7 +380,7 @@ func (api *Client) GetConversationRepliesContext(ctx context.Context, params *Ge
 		values.Add("inclusive", "0")
 	}
 	response := struct {
-		SlackResponse
+		WebResponse
 		HasMore          bool `json:"has_more"`
 		ResponseMetaData struct {
 			NextCursor string `json:"next_cursor"`
@@ -416,10 +392,8 @@ func (api *Client) GetConversationRepliesContext(ctx context.Context, params *Ge
 	if err != nil {
 		return nil, false, "", err
 	}
-	if !response.Ok {
-		return nil, false, "", errors.New(response.Error)
-	}
-	return response.Messages, response.HasMore, response.ResponseMetaData.NextCursor, nil
+
+	return response.Messages, response.HasMore, response.ResponseMetaData.NextCursor, response.Err()
 }
 
 type GetConversationsParameters struct {
@@ -452,16 +426,14 @@ func (api *Client) GetConversationsContext(ctx context.Context, params *GetConve
 	response := struct {
 		Channels         []Channel        `json:"channels"`
 		ResponseMetaData responseMetaData `json:"response_metadata"`
-		SlackResponse
+		WebResponse
 	}{}
 	err = post(ctx, api.httpclient, "conversations.list", values, &response, api.debug)
 	if err != nil {
 		return nil, "", err
 	}
-	if !response.Ok {
-		return nil, "", errors.New(response.Error)
-	}
-	return response.Channels, response.ResponseMetaData.NextCursor, nil
+
+	return response.Channels, response.ResponseMetaData.NextCursor, response.Err()
 }
 
 type OpenConversationParameters struct {
@@ -491,16 +463,14 @@ func (api *Client) OpenConversationContext(ctx context.Context, params *OpenConv
 		Channel     *Channel `json:"channel"`
 		NoOp        bool     `json:"no_op"`
 		AlreadyOpen bool     `json:"already_open"`
-		SlackResponse
+		WebResponse
 	}{}
 	err := post(ctx, api.httpclient, "conversations.open", values, &response, api.debug)
 	if err != nil {
 		return nil, false, false, err
 	}
-	if !response.Ok {
-		return nil, false, false, errors.New(response.Error)
-	}
-	return response.Channel, response.NoOp, response.AlreadyOpen, nil
+
+	return response.Channel, response.NoOp, response.AlreadyOpen, response.Err()
 }
 
 // JoinConversation joins an existing conversation
@@ -517,14 +487,14 @@ func (api *Client) JoinConversationContext(ctx context.Context, channelID string
 		ResponseMetaData *struct {
 			Warnings []string `json:"warnings"`
 		} `json:"response_metadata"`
-		SlackResponse
+		WebResponse
 	}{}
 	err := post(ctx, api.httpclient, "conversations.join", values, &response, api.debug)
 	if err != nil {
 		return nil, "", nil, err
 	}
-	if !response.Ok {
-		return nil, "", nil, errors.New(response.Error)
+	if response.Err() != nil {
+		return nil, "", nil, response.Err()
 	}
 	var warnings []string
 	if response.ResponseMetaData != nil {
@@ -543,7 +513,7 @@ type GetConversationHistoryParameters struct {
 }
 
 type GetConversationHistoryResponse struct {
-	SlackResponse
+	WebResponse
 	HasMore          bool   `json:"has_more"`
 	PinCount         int    `json:"pin_count"`
 	Latest           string `json:"latest"`

--- a/conversation_test.go
+++ b/conversation_test.go
@@ -208,11 +208,11 @@ func getTestMembers() []string {
 func getUsersInConversation(rw http.ResponseWriter, r *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
 	response, _ := json.Marshal(struct {
-		SlackResponse
+		WebResponse
 		Members          []string         `json:"members"`
 		ResponseMetaData responseMetaData `json:"response_metadata"`
 	}{
-		SlackResponse:    SlackResponse{Ok: true},
+		WebResponse:      WebResponse{Ok: true},
 		Members:          getTestMembers(),
 		ResponseMetaData: responseMetaData{NextCursor: ""},
 	})
@@ -279,11 +279,11 @@ func getTestChannel() *Channel {
 func okChannelJsonHandler(rw http.ResponseWriter, r *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
 	response, _ := json.Marshal(struct {
-		SlackResponse
+		WebResponse
 		Channel *Channel `json:"channel"`
 	}{
-		SlackResponse: SlackResponse{Ok: true},
-		Channel:       getTestChannel(),
+		WebResponse: WebResponse{Ok: true},
+		Channel:     getTestChannel(),
 	})
 	rw.Write(response)
 }
@@ -368,11 +368,11 @@ func TestKickUserFromConversation(t *testing.T) {
 func closeConversationHandler(rw http.ResponseWriter, r *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
 	response, _ := json.Marshal(struct {
-		SlackResponse
+		WebResponse
 		NoOp          bool `json:"no_op"`
 		AlreadyClosed bool `json:"already_closed"`
 	}{
-		SlackResponse: SlackResponse{Ok: true}})
+		WebResponse: WebResponse{Ok: true}})
 	rw.Write(response)
 }
 
@@ -423,10 +423,10 @@ func TestGetConversationInfo(t *testing.T) {
 func leaveConversationHandler(rw http.ResponseWriter, r *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
 	response, _ := json.Marshal(struct {
-		SlackResponse
+		WebResponse
 		NotInChannel bool `json:"not_in_channel"`
 	}{
-		SlackResponse: SlackResponse{Ok: true}})
+		WebResponse: WebResponse{Ok: true}})
 	rw.Write(response)
 }
 
@@ -445,15 +445,15 @@ func TestLeaveConversation(t *testing.T) {
 func getConversationRepliesHander(rw http.ResponseWriter, r *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
 	response, _ := json.Marshal(struct {
-		SlackResponse
+		WebResponse
 		HasMore          bool `json:"has_more"`
 		ResponseMetaData struct {
 			NextCursor string `json:"next_cursor"`
 		} `json:"response_metadata"`
 		Messages []Message `json:"messages"`
 	}{
-		SlackResponse: SlackResponse{Ok: true},
-		Messages:      []Message{}})
+		WebResponse: WebResponse{Ok: true},
+		Messages:    []Message{}})
 	rw.Write(response)
 }
 
@@ -476,14 +476,14 @@ func TestGetConversationReplies(t *testing.T) {
 func getConversationsHander(rw http.ResponseWriter, r *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
 	response, _ := json.Marshal(struct {
-		SlackResponse
+		WebResponse
 		ResponseMetaData struct {
 			NextCursor string `json:"next_cursor"`
 		} `json:"response_metadata"`
 		Channels []Channel `json:"channels"`
 	}{
-		SlackResponse: SlackResponse{Ok: true},
-		Channels:      []Channel{}})
+		WebResponse: WebResponse{Ok: true},
+		Channels:    []Channel{}})
 	rw.Write(response)
 }
 
@@ -503,12 +503,12 @@ func TestGetConversations(t *testing.T) {
 func openConversationHandler(rw http.ResponseWriter, r *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
 	response, _ := json.Marshal(struct {
-		SlackResponse
+		WebResponse
 		NoOp        bool     `json:"no_op"`
 		AlreadyOpen bool     `json:"already_open"`
 		Channel     *Channel `json:"channel"`
 	}{
-		SlackResponse: SlackResponse{Ok: true}})
+		WebResponse: WebResponse{Ok: true}})
 	rw.Write(response)
 }
 
@@ -533,9 +533,9 @@ func joinConversationHandler(rw http.ResponseWriter, r *http.Request) {
 		ResponseMetaData *struct {
 			Warnings []string `json:"warnings"`
 		} `json:"response_metadata"`
-		SlackResponse
+		WebResponse
 	}{
-		SlackResponse: SlackResponse{Ok: true}})
+		WebResponse: WebResponse{Ok: true}})
 	rw.Write(response)
 }
 
@@ -554,7 +554,7 @@ func TestJoinConversation(t *testing.T) {
 func getConversationHistoryHandler(rw http.ResponseWriter, r *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
 	response, _ := json.Marshal(GetConversationHistoryResponse{
-		SlackResponse: SlackResponse{Ok: true}})
+		WebResponse: WebResponse{Ok: true}})
 	rw.Write(response)
 }
 

--- a/dnd.go
+++ b/dnd.go
@@ -28,12 +28,12 @@ type DNDStatus struct {
 
 type dndResponseFull struct {
 	DNDStatus
-	SlackResponse
+	WebResponse
 }
 
 type dndTeamInfoResponse struct {
 	Users map[string]DNDStatus `json:"users"`
-	SlackResponse
+	WebResponse
 }
 
 func dndRequest(ctx context.Context, client HTTPRequester, path string, values url.Values, debug bool) (*dndResponseFull, error) {
@@ -59,15 +59,13 @@ func (api *Client) EndDNDContext(ctx context.Context) error {
 		"token": {api.token},
 	}
 
-	response := &SlackResponse{}
+	response := &WebResponse{}
 
 	if err := post(ctx, api.httpclient, "dnd.endDnd", values, response, api.debug); err != nil {
 		return err
 	}
-	if !response.Ok {
-		return errors.New(response.Error)
-	}
-	return nil
+
+	return response.Err()
 }
 
 // EndSnooze ends the current user's snooze mode

--- a/emoji.go
+++ b/emoji.go
@@ -8,7 +8,7 @@ import (
 
 type emojiResponseFull struct {
 	Emoji map[string]string `json:"emoji"`
-	SlackResponse
+	WebResponse
 }
 
 // GetEmoji retrieves all the emojis

--- a/files.go
+++ b/files.go
@@ -120,7 +120,7 @@ type fileResponseFull struct {
 	Comments []Comment `json:"comments"`
 	Files    []File    `json:"files"`
 
-	SlackResponse
+	WebResponse
 }
 
 // NewGetFilesParameters provides an instance of GetFilesParameters with all the sane default values set

--- a/files_test.go
+++ b/files_test.go
@@ -110,14 +110,14 @@ func TestSlack_DeleteFileComment(t *testing.T) {
 func authTestHandler(rw http.ResponseWriter, r *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
 	response, _ := json.Marshal(authTestResponseFull{
-		SlackResponse: SlackResponse{Ok: true}})
+		WebResponse: WebResponse{Ok: true}})
 	rw.Write(response)
 }
 
 func uploadFileHandler(rw http.ResponseWriter, r *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
 	response, _ := json.Marshal(fileResponseFull{
-		SlackResponse: SlackResponse{Ok: true}})
+		WebResponse: WebResponse{Ok: true}})
 	rw.Write(response)
 }
 

--- a/groups.go
+++ b/groups.go
@@ -25,7 +25,7 @@ type groupResponseFull struct {
 	AlreadyInGroup bool    `json:"already_in_group"`
 	Channel        Channel `json:"channel"`
 	History
-	SlackResponse
+	WebResponse
 }
 
 func groupRequest(ctx context.Context, client HTTPRequester, path string, values url.Values, debug bool) (*groupResponseFull, error) {

--- a/im.go
+++ b/im.go
@@ -18,7 +18,7 @@ type imResponseFull struct {
 	Channel       imChannel `json:"channel"`
 	IMs           []IM      `json:"ims"`
 	History
-	SlackResponse
+	WebResponse
 }
 
 // IM contains information related to the Direct Message channel

--- a/misc.go
+++ b/misc.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -19,14 +20,16 @@ import (
 )
 
 type WebResponse struct {
-	Ok    bool      `json:"ok"`
-	Error *WebError `json:"error"`
+	Ok    bool   `json:"ok"`
+	Error string `json:"error"`
 }
 
-type WebError string
+func (t WebResponse) Err() error {
+	if t.Ok {
+		return nil
+	}
 
-func (s WebError) Error() string {
-	return string(s)
+	return errors.New(t.Error)
 }
 
 type RateLimitedError struct {
@@ -175,7 +178,7 @@ func logResponse(resp *http.Response, debug bool) error {
 
 func okJsonHandler(rw http.ResponseWriter, r *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
-	response, _ := json.Marshal(SlackResponse{
+	response, _ := json.Marshal(WebResponse{
 		Ok: true,
 	})
 	rw.Write(response)

--- a/misc_test.go
+++ b/misc_test.go
@@ -40,7 +40,7 @@ func TestParseResponse(t *testing.T) {
 	values := url.Values{
 		"token": {validToken},
 	}
-	responsePartial := &SlackResponse{}
+	responsePartial := &WebResponse{}
 	err := post(context.Background(), http.DefaultClient, "parseResponse", values, responsePartial, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
@@ -52,7 +52,7 @@ func TestParseResponseNoToken(t *testing.T) {
 	once.Do(startServer)
 	SLACK_API = "http://" + serverAddr + "/"
 	values := url.Values{}
-	responsePartial := &SlackResponse{}
+	responsePartial := &WebResponse{}
 	err := post(context.Background(), http.DefaultClient, "parseResponse", values, responsePartial, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
@@ -72,7 +72,7 @@ func TestParseResponseInvalidToken(t *testing.T) {
 	values := url.Values{
 		"token": {"whatever"},
 	}
-	responsePartial := &SlackResponse{}
+	responsePartial := &WebResponse{}
 	err := post(context.Background(), http.DefaultClient, "parseResponse", values, responsePartial, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)

--- a/oauth.go
+++ b/oauth.go
@@ -26,7 +26,7 @@ type OAuthResponse struct {
 	IncomingWebhook OAuthResponseIncomingWebhook `json:"incoming_webhook"`
 	Bot             OAuthResponseBot             `json:"bot"`
 	UserID          string                       `json:"user_id,omitempty"`
-	SlackResponse
+	WebResponse
 }
 
 // GetOAuthToken retrieves an AccessToken

--- a/pins.go
+++ b/pins.go
@@ -9,7 +9,7 @@ import (
 type listPinsResponseFull struct {
 	Items  []Item
 	Paging `json:"paging"`
-	SlackResponse
+	WebResponse
 }
 
 // AddPin pins an item in a channel
@@ -33,14 +33,12 @@ func (api *Client) AddPinContext(ctx context.Context, channel string, item ItemR
 		values.Set("file_comment", item.Comment)
 	}
 
-	response := &SlackResponse{}
+	response := &WebResponse{}
 	if err := post(ctx, api.httpclient, "pins.add", values, response, api.debug); err != nil {
 		return err
 	}
-	if !response.Ok {
-		return errors.New(response.Error)
-	}
-	return nil
+
+	return response.Err()
 }
 
 // RemovePin un-pins an item from a channel
@@ -64,14 +62,12 @@ func (api *Client) RemovePinContext(ctx context.Context, channel string, item It
 		values.Set("file_comment", item.Comment)
 	}
 
-	response := &SlackResponse{}
+	response := &WebResponse{}
 	if err := post(ctx, api.httpclient, "pins.remove", values, response, api.debug); err != nil {
 		return err
 	}
-	if !response.Ok {
-		return errors.New(response.Error)
-	}
-	return nil
+
+	return response.Err()
 }
 
 // ListPins returns information about the items a user reacted to.

--- a/reactions.go
+++ b/reactions.go
@@ -44,7 +44,7 @@ type getReactionsResponseFull struct {
 	FC struct {
 		Reactions []ItemReaction
 	} `json:"comment"`
-	SlackResponse
+	WebResponse
 }
 
 func (res getReactionsResponseFull) extractReactions() []ItemReaction {
@@ -102,7 +102,7 @@ type listReactionsResponseFull struct {
 		} `json:"comment"`
 	}
 	Paging `json:"paging"`
-	SlackResponse
+	WebResponse
 }
 
 func (res listReactionsResponseFull) extractReactedItems() []ReactedItem {
@@ -154,14 +154,12 @@ func (api *Client) AddReactionContext(ctx context.Context, name string, item Ite
 		values.Set("file_comment", item.Comment)
 	}
 
-	response := &SlackResponse{}
+	response := &WebResponse{}
 	if err := post(ctx, api.httpclient, "reactions.add", values, response, api.debug); err != nil {
 		return err
 	}
-	if !response.Ok {
-		return errors.New(response.Error)
-	}
-	return nil
+
+	return response.Err()
 }
 
 // RemoveReaction removes a reaction emoji from a message, file or file comment.
@@ -190,14 +188,12 @@ func (api *Client) RemoveReactionContext(ctx context.Context, name string, item 
 		values.Set("file_comment", item.Comment)
 	}
 
-	response := &SlackResponse{}
+	response := &WebResponse{}
 	if err := post(ctx, api.httpclient, "reactions.remove", values, response, api.debug); err != nil {
 		return err
 	}
-	if !response.Ok {
-		return errors.New(response.Error)
-	}
-	return nil
+
+	return response.Err()
 }
 
 // GetReactions returns details about the reactions on an item.

--- a/rtm.go
+++ b/rtm.go
@@ -3,7 +3,6 @@ package slack
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/url"
 	"sync"
 	"time"
@@ -32,13 +31,11 @@ func (api *Client) StartRTMContext(ctx context.Context) (info *Info, websocketUR
 	response := &infoResponseFull{}
 	err = post(ctx, api.httpclient, "rtm.start", url.Values{"token": {api.token}}, response, api.debug)
 	if err != nil {
-		return nil, "", fmt.Errorf("post: %s", err)
+		return nil, "", err
 	}
-	if !response.Ok {
-		return nil, "", response.Error
-	}
+
 	api.Debugln("Using URL:", response.Info.URL)
-	return &response.Info, response.Info.URL, nil
+	return &response.Info, response.Info.URL, response.Err()
 }
 
 // ConnectRTM calls the "rtm.connect" endpoint and returns the provided URL and the compact Info block.
@@ -60,13 +57,11 @@ func (api *Client) ConnectRTMContext(ctx context.Context) (info *Info, websocket
 	err = post(ctx, api.httpclient, "rtm.connect", url.Values{"token": {api.token}}, response, api.debug)
 	if err != nil {
 		api.Debugf("Failed to connect to RTM: %s", err)
-		return nil, "", fmt.Errorf("post: %s", err)
+		return nil, "", err
 	}
-	if !response.Ok {
-		return nil, "", response.Error
-	}
+
 	api.Debugln("Using URL:", response.Info.URL)
-	return &response.Info, response.Info.URL, nil
+	return &response.Info, response.Info.URL, response.Err()
 }
 
 // RTMOption options for the managed RTM.

--- a/search.go
+++ b/search.go
@@ -69,7 +69,7 @@ type searchResponseFull struct {
 	Query          string `json:"query"`
 	SearchMessages `json:"messages"`
 	SearchFiles    `json:"files"`
-	SlackResponse
+	WebResponse
 }
 
 func NewSearchParameters() SearchParameters {

--- a/slack.go
+++ b/slack.go
@@ -35,11 +35,6 @@ func SetHTTPClient(client HTTPRequester) {
 	customHTTPClient = client
 }
 
-type SlackResponse struct {
-	Ok    bool   `json:"ok"`
-	Error string `json:"error"`
-}
-
 // ResponseMetadata holds pagination metadata
 type ResponseMetadata struct {
 	Cursor string `json:"next_cursor"`
@@ -62,7 +57,7 @@ type AuthTestResponse struct {
 }
 
 type authTestResponseFull struct {
-	SlackResponse
+	WebResponse
 	AuthTestResponse
 }
 

--- a/stars.go
+++ b/stars.go
@@ -24,7 +24,7 @@ type StarredItem Item
 type listResponseFull struct {
 	Items  []Item `json:"items"`
 	Paging `json:"paging"`
-	SlackResponse
+	WebResponse
 }
 
 // NewStarsParameters initialises StarsParameters with default values
@@ -57,14 +57,12 @@ func (api *Client) AddStarContext(ctx context.Context, channel string, item Item
 		values.Set("file_comment", item.Comment)
 	}
 
-	response := &SlackResponse{}
+	response := &WebResponse{}
 	if err := post(ctx, api.httpclient, "stars.add", values, response, api.debug); err != nil {
 		return err
 	}
-	if !response.Ok {
-		return errors.New(response.Error)
-	}
-	return nil
+
+	return response.Err()
 }
 
 // RemoveStar removes a starred item from a channel
@@ -88,14 +86,12 @@ func (api *Client) RemoveStarContext(ctx context.Context, channel string, item I
 		values.Set("file_comment", item.Comment)
 	}
 
-	response := &SlackResponse{}
+	response := &WebResponse{}
 	if err := post(ctx, api.httpclient, "stars.remove", values, response, api.debug); err != nil {
 		return err
 	}
-	if !response.Ok {
-		return errors.New(response.Error)
-	}
-	return nil
+
+	return response.Err()
 }
 
 // ListStars returns information about the stars a user added

--- a/team.go
+++ b/team.go
@@ -14,7 +14,7 @@ const (
 
 type TeamResponse struct {
 	Team TeamInfo `json:"team"`
-	SlackResponse
+	WebResponse
 }
 
 type TeamInfo struct {
@@ -28,7 +28,7 @@ type TeamInfo struct {
 type LoginResponse struct {
 	Logins []Login `json:"logins"`
 	Paging `json:"paging"`
-	SlackResponse
+	WebResponse
 }
 
 type Login struct {
@@ -46,7 +46,7 @@ type Login struct {
 
 type BillableInfoResponse struct {
 	BillableInfo map[string]BillingActive `json:"billable_info"`
-	SlackResponse
+	WebResponse
 }
 
 type BillingActive struct {

--- a/usergroups.go
+++ b/usergroups.go
@@ -37,7 +37,7 @@ type userGroupResponseFull struct {
 	UserGroups []UserGroup `json:"usergroups"`
 	UserGroup  UserGroup   `json:"usergroup"`
 	Users      []string    `json:"users"`
-	SlackResponse
+	WebResponse
 }
 
 func userGroupRequest(ctx context.Context, client HTTPRequester, path string, values url.Values, debug bool) (*userGroupResponseFull, error) {

--- a/users.go
+++ b/users.go
@@ -138,7 +138,7 @@ type UserPresence struct {
 type UserIdentityResponse struct {
 	User UserIdentity `json:"user"`
 	Team TeamIdentity `json:"team"`
-	SlackResponse
+	WebResponse
 }
 
 type UserIdentity struct {
@@ -172,7 +172,7 @@ type userResponseFull struct {
 	Members      []User                  `json:"members,omitempty"` // ListUsers
 	User         `json:"user,omitempty"` // GetUserInfo
 	UserPresence                         // GetUserPresence
-	SlackResponse
+	WebResponse
 	Metadata ResponseMetadata
 }
 
@@ -424,7 +424,7 @@ func (api *Client) SetUserPhoto(image string, params UserSetPhotoParams) error {
 
 // SetUserPhotoContext changes the currently authenticated user's profile image using a custom context
 func (api *Client) SetUserPhotoContext(ctx context.Context, image string, params UserSetPhotoParams) error {
-	response := &SlackResponse{}
+	response := &WebResponse{}
 	values := url.Values{
 		"token": {api.token},
 	}
@@ -442,10 +442,8 @@ func (api *Client) SetUserPhotoContext(ctx context.Context, image string, params
 	if err != nil {
 		return err
 	}
-	if !response.Ok {
-		return errors.New(response.Error)
-	}
-	return nil
+
+	return response.Err()
 }
 
 // DeleteUserPhoto deletes the current authenticated user's profile image
@@ -455,7 +453,7 @@ func (api *Client) DeleteUserPhoto() error {
 
 // DeleteUserPhotoContext deletes the current authenticated user's profile image with a custom context
 func (api *Client) DeleteUserPhotoContext(ctx context.Context) error {
-	response := &SlackResponse{}
+	response := &WebResponse{}
 	values := url.Values{
 		"token": {api.token},
 	}
@@ -464,10 +462,8 @@ func (api *Client) DeleteUserPhotoContext(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if !response.Ok {
-		return errors.New(response.Error)
-	}
-	return nil
+
+	return response.Err()
 }
 
 // SetUserCustomStatus will set a custom status and emoji for the currently
@@ -541,7 +537,7 @@ func (api *Client) GetUserProfile(userID string, includeLabels bool) (*UserProfi
 }
 
 type getUserProfileResponse struct {
-	SlackResponse
+	WebResponse
 	Profile *UserProfile `json:"profile"`
 }
 

--- a/users_test.go
+++ b/users_test.go
@@ -124,7 +124,7 @@ func httpTestErrReply(w http.ResponseWriter, clientErr bool, msg string) {
 
 	w.Header().Set("Content-Type", "application/json")
 
-	body, _ := json.Marshal(&SlackResponse{
+	body, _ := json.Marshal(&WebResponse{
 		Ok: false, Error: msg,
 	})
 
@@ -296,7 +296,7 @@ func getUserPage(max int64) func(rw http.ResponseWriter, r *http.Request) {
 	var n int64
 	return func(rw http.ResponseWriter, r *http.Request) {
 		var cpage int64
-		sresp := SlackResponse{
+		sresp := WebResponse{
 			Ok: true,
 		}
 		members := []User{
@@ -305,16 +305,16 @@ func getUserPage(max int64) func(rw http.ResponseWriter, r *http.Request) {
 		rw.Header().Set("Content-Type", "application/json")
 		if cpage = atomic.AddInt64(&n, 1); cpage == max {
 			response, _ := json.Marshal(userResponseFull{
-				SlackResponse: sresp,
-				Members:       members,
+				WebResponse: sresp,
+				Members:     members,
 			})
 			rw.Write(response)
 			return
 		}
 		response, _ := json.Marshal(userResponseFull{
-			SlackResponse: sresp,
-			Members:       members,
-			Metadata:      ResponseMetadata{Cursor: strconv.Itoa(int(cpage))},
+			WebResponse: sresp,
+			Members:     members,
+			Metadata:    ResponseMetadata{Cursor: strconv.Itoa(int(cpage))},
 		})
 		rw.Write(response)
 	}
@@ -428,8 +428,8 @@ func getUserProfileHandler(rw http.ResponseWriter, r *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
 	profile := getTestUserProfile()
 	resp, _ := json.Marshal(&getUserProfileResponse{
-		SlackResponse: SlackResponse{Ok: true},
-		Profile:       &profile})
+		WebResponse: WebResponse{Ok: true},
+		Profile:     &profile})
 	rw.Write(resp)
 }
 

--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -93,11 +93,12 @@ func (rtm *RTM) connect(connectionCount int, useRTMStart bool) (*Info, *websocke
 		if err == nil {
 			return info, conn, nil
 		}
+
 		// check for fatal errors - currently only invalid_auth
-		if sErr, ok := err.(*WebError); ok && (sErr.Error() == "invalid_auth" || sErr.Error() == "account_inactive") {
+		if err.Error() == "invalid_auth" || err.Error() == "account_inactive" {
 			rtm.Debugf("Invalid auth when connecting with RTM: %s", err)
 			rtm.IncomingEvents <- RTMEvent{"invalid_auth", &InvalidAuthEvent{}}
-			return nil, nil, sErr
+			return nil, nil, err
 		}
 
 		// any other errors are treated as recoverable and we try again after
@@ -126,10 +127,10 @@ func (rtm *RTM) connect(connectionCount int, useRTMStart bool) (*Info, *websocke
 // startRTMAndDial attempts to connect to the slack websocket. If useRTMStart is true,
 // then it returns the  full information returned by the "rtm.start" method on the
 // slack API. Else it uses the "rtm.connect" method to connect
-func (rtm *RTM) startRTMAndDial(useRTMStart bool) (*Info, *websocket.Conn, error) {
-	var info *Info
-	var url string
-	var err error
+func (rtm *RTM) startRTMAndDial(useRTMStart bool) (info *Info, _ *websocket.Conn, err error) {
+	var (
+		url string
+	)
 
 	if useRTMStart {
 		rtm.Debugf("Starting RTM")


### PR DESCRIPTION
SlackResponse and WebResponse were basically identical, this standardizes on WebResponse and adds a utility error method to WebResponse to clean up error handling throughout the library.

this is the base work I requested for #301, and includes the fix from that PR.