### PR TITLE
Improve usage of interface{} in the HTTP helper functions

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -66,7 +66,7 @@ func fileUploadReq(ctx context.Context, path, fieldname, filename string, values
 	return req, nil
 }
 
-func parseResponseBody(body io.ReadCloser, intf *interface{}, debug bool) error {
+func parseResponseBody(body io.ReadCloser, intf interface{}, debug bool) error {
 	response, err := ioutil.ReadAll(body)
 	if err != nil {
 		return err
@@ -77,7 +77,7 @@ func parseResponseBody(body io.ReadCloser, intf *interface{}, debug bool) error 
 		logger.Printf("parseResponseBody: %s\n", string(response))
 	}
 
-	return json.Unmarshal(response, &intf)
+	return json.Unmarshal(response, intf)
 }
 
 func postLocalWithMultipartResponse(ctx context.Context, client HTTPRequester, path, fpath, fieldname string, values url.Values, intf interface{}, debug bool) error {
@@ -119,7 +119,7 @@ func postWithMultipartResponse(ctx context.Context, client HTTPRequester, path, 
 		return fmt.Errorf("Slack server error: %s.", resp.Status)
 	}
 
-	return parseResponseBody(resp.Body, &intf, debug)
+	return parseResponseBody(resp.Body, intf, debug)
 }
 
 func postForm(ctx context.Context, client HTTPRequester, endpoint string, values url.Values, intf interface{}, debug bool) error {
@@ -151,7 +151,7 @@ func postForm(ctx context.Context, client HTTPRequester, endpoint string, values
 		return fmt.Errorf("Slack server error: %s.", resp.Status)
 	}
 
-	return parseResponseBody(resp.Body, &intf, debug)
+	return parseResponseBody(resp.Body, intf, debug)
 }
 
 func post(ctx context.Context, client HTTPRequester, path string, values url.Values, intf interface{}, debug bool) error {


### PR DESCRIPTION
The HTTP helper functions (post and postForm) take an `intf interface{}`
parameter, with the goal of using it to unmarshal the JSON response. This
requires that those calling the helper functions pass in a pointer to the type
they want to unmarshal the JSON in to.

The `parseResponseBody` function was a bit different in that it took a
`*interface{}` instead. Looking at its behaviors, this looks to have been
accidental when the unmarshaling behavior was implemented early on (1b96f659ad).
`json.Unmarshal` needs the `interface{}` value itself to contain a pointer, it
doesn't need to (and probably shouldn't) be a pointer.

To go in to deeper detail, the `interface{}` itself encapsulates the original
value and its type. When the JSON Unmarshaler tries to use the value within the
interface, it needs it to be a pointer so that it can manipulate the data and
set the values. The interface being a pointer only allows you to change what
data it encapsulates, and that's not generally how you'd use `interface{}` with
JSON.

This change updates the `*interface{}` typed argument of `parseResponseBody` to
be `interface{}` instead, and updates all of the call sites to use the new API.

Signed-off-by: Tim Heckman <t@heckman.io>