### PR TITLE
Read user response metadata from correct JSON key

### DIFF
--- a/users.go
+++ b/users.go
@@ -173,7 +173,7 @@ type userResponseFull struct {
 	User         `json:"user,omitempty"` // GetUserInfo
 	UserPresence                         // GetUserPresence
 	WebResponse
-	Metadata ResponseMetadata
+	Metadata ResponseMetadata `json:"response_metadata"`
 }
 
 type UserSetPhotoParams struct {


### PR DESCRIPTION
I noticed that `GetUsers` does not retrieve all results when there are more than 200 users in an organization. I believe this is happening because the API calls in `users.go` are looking for response metadata under the "metadata" key of the response, whereas the metadata are actually found under the "response_metadata" key.