### PR TITLE
Add thread timestamp to message event

### DIFF
--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -12,12 +12,13 @@ type EventsAPIInnerEvent struct {
 
 // AppMentionEvent is an (inner) EventsAPI subscribable event.
 type AppMentionEvent struct {
-	Type           string      `json:"type"`
-	User           string      `json:"user"`
-	Text           string      `json:"text"`
-	TimeStamp      string      `json:"ts"`
-	Channel        string      `json:"channel"`
-	EventTimeStamp json.Number `json:"event_ts"`
+	Type            string      `json:"type"`
+	User            string      `json:"user"`
+	Text            string      `json:"text"`
+	TimeStamp       string      `json:"ts"`
+	Channel         string      `json:"channel"`
+	EventTimeStamp  json.Number `json:"event_ts"`
+	ThreadTimeStamp string      `json:"thread_ts"`
 }
 
 // AppUninstalledEvent Your Slack app was uninstalled.
@@ -60,15 +61,16 @@ type sharedLinks struct {
 // if ChannelType = "mim", A message was posted in a multiparty direct message channel
 // TODO: Improve this so that it is not required to manually parse ChannelType
 type MessageEvent struct {
-	Type           string      `json:"type"`
-	Subtype        string      `json:"subtype"`
-	User           string      `json:"user"`
-	Username       string      `json:"username"`
-	Text           string      `json:"text"`
-	TimeStamp      string      `json:"ts"`
-	Channel        string      `json:"channel"`
-	ChannelType    string      `json:"channel_type"`
-	EventTimeStamp json.Number `json:"event_ts"`
+	Type            string      `json:"type"`
+	Subtype         string      `json:"subtype"`
+	User            string      `json:"user"`
+	Username        string      `json:"username"`
+	Text            string      `json:"text"`
+	TimeStamp       string      `json:"ts"`
+	Channel         string      `json:"channel"`
+	ChannelType     string      `json:"channel_type"`
+	EventTimeStamp  json.Number `json:"event_ts"`
+	ThreadTimeStamp string      `json:"thread_ts"`
 }
 
 const (

--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -12,12 +12,13 @@ type EventsAPIInnerEvent struct {
 
 // AppMentionEvent is an (inner) EventsAPI subscribable event.
 type AppMentionEvent struct {
-	Type           string      `json:"type"`
-	User           string      `json:"user"`
-	Text           string      `json:"text"`
-	TimeStamp      string      `json:"ts"`
-	Channel        string      `json:"channel"`
-	EventTimeStamp json.Number `json:"event_ts"`
+	Type            string      `json:"type"`
+	User            string      `json:"user"`
+	Text            string      `json:"text"`
+	TimeStamp       string      `json:"ts"`
+	Channel         string      `json:"channel"`
+	EventTimeStamp  json.Number `json:"event_ts"`
+	ThreadTimeStamp string      `json:"thread_ts"`
 }
 
 // AppUninstalledEvent Your Slack app was uninstalled.
@@ -60,13 +61,14 @@ type sharedLinks struct {
 // if ChannelType = "mim", A message was posted in a multiparty direct message channel
 // TODO: Improve this so that it is not required to manually parse ChannelType
 type MessageEvent struct {
-	Type           string      `json:"type"`
-	User           string      `json:"user"`
-	Text           string      `json:"text"`
-	TimeStamp      string      `json:"ts"`
-	Channel        string      `json:"channel"`
-	ChannelType    string      `json:"channel_type"`
-	EventTimeStamp json.Number `json:"event_ts"`
+	Type            string      `json:"type"`
+	User            string      `json:"user"`
+	Text            string      `json:"text"`
+	TimeStamp       string      `json:"ts"`
+	Channel         string      `json:"channel"`
+	ChannelType     string      `json:"channel_type"`
+	EventTimeStamp  json.Number `json:"event_ts"`
+	ThreadTimeStamp string      `json:"thread_ts"`
 }
 
 const (

--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -12,13 +12,12 @@ type EventsAPIInnerEvent struct {
 
 // AppMentionEvent is an (inner) EventsAPI subscribable event.
 type AppMentionEvent struct {
-	Type            string      `json:"type"`
-	User            string      `json:"user"`
-	Text            string      `json:"text"`
-	TimeStamp       string      `json:"ts"`
-	Channel         string      `json:"channel"`
-	EventTimeStamp  json.Number `json:"event_ts"`
-	ThreadTimeStamp string      `json:"thread_ts"`
+	Type           string      `json:"type"`
+	User           string      `json:"user"`
+	Text           string      `json:"text"`
+	TimeStamp      string      `json:"ts"`
+	Channel        string      `json:"channel"`
+	EventTimeStamp json.Number `json:"event_ts"`
 }
 
 // AppUninstalledEvent Your Slack app was uninstalled.

--- a/slackevents/parsers.go
+++ b/slackevents/parsers.go
@@ -158,7 +158,7 @@ func ParseEvent(rawEvent json.RawMessage, opts ...Option) (EventsAPIEvent, error
 	}
 
 	if !cfg.TokenVerified {
-		return EventsAPIEvent{}, errors.New("No")
+		return EventsAPIEvent{}, errors.New("Invalid verification token")
 	}
 
 	if e.Type == CallbackEvent {

--- a/slackevents/parsers_test.go
+++ b/slackevents/parsers_test.go
@@ -17,6 +17,7 @@ func TestParserOuterCallBackEvent(t *testing.T) {
 				"event": {
 								"type": "app_mention",
 								"event_ts": "1234567890.123456",
+								"thread_ts": "1234567890.123456",
 								"user": "UXXXXXXX1"
 				},
 				"type": "event_callback",
@@ -82,6 +83,7 @@ func TestThatOuterCallbackEventHasInnerEvent(t *testing.T) {
 				"event": {
 								"type": "app_mention",
 								"event_ts": "1234567890.123456",
+								"thread_ts": "1234567890.123456",
 								"user": "UXXXXXXX1"
 				},
 				"type": "event_callback",


### PR DESCRIPTION
Status: **POST REVIEW CHANGES DONE**

- Added the `thread_ts` field to the`MessageEvent` struct for being able to reply to threads (docs: https://api.slack.com/docs/message-threading)

- Updated the token verification error message to be more informative.