### PR TITLE
Capture response metadata properly

### DIFF
--- a/users.go
+++ b/users.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log"
 	"net/url"
 	"strconv"
 )
@@ -173,7 +172,7 @@ type userResponseFull struct {
 	User         `json:"user,omitempty"` // GetUserInfo
 	UserPresence                         // GetUserPresence
 	SlackResponse
-	Metadata ResponseMetadata
+	Metadata ResponseMetadata `json:"response_metadata"`
 }
 
 type UserSetPhotoParams struct {
@@ -312,7 +311,6 @@ func (t UserPagination) Next(ctx context.Context) (_ UserPagination, err error) 
 	}
 
 	if resp, err = userRequest(ctx, t.c.httpclient, "users.list", values, t.c.debug); err != nil {
-		log.Println("error during user request", err)
 		return t, err
 	}
 


### PR DESCRIPTION
This also removes an extraneous log statement.