### PR TITLE
Fix ephemeral message timestamp

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -23,10 +23,18 @@ const (
 )
 
 type chatResponseFull struct {
-	Channel   string `json:"channel"`
-	Timestamp string `json:"ts"`
-	Text      string `json:"text"`
+	Channel          string `json:"channel"`
+	Timestamp        string `json:"ts"`
+	MessageTimeStamp string `json:"message_ts"`
+	Text             string `json:"text"`
 	SlackResponse
+}
+
+func (c chatResponseFull) getMessageTimestamp() string {
+	if len(c.Timestamp) > 0 {
+		return c.Timestamp
+	}
+	return c.MessageTimeStamp
 }
 
 // PostMessageParameters contains all the parameters necessary (including the optional ones) for a PostMessage() request
@@ -157,7 +165,7 @@ func (api *Client) SendMessageContext(ctx context.Context, channelID string, opt
 		return "", "", "", err
 	}
 
-	return response.Channel, response.Timestamp, response.Text, response.Err()
+	return response.Channel, response.getMessageTimestamp(), response.Text, response.Err()
 }
 
 // ApplyMsgOptions utility function for debugging/testing chat requests.

--- a/chat.go
+++ b/chat.go
@@ -24,12 +24,15 @@ const (
 
 type chatResponseFull struct {
 	Channel          string `json:"channel"`
-	Timestamp        string `json:"ts"`
-	MessageTimeStamp string `json:"message_ts"`
+	Timestamp        string `json:"ts"`         //Regualr message timestamp
+	MessageTimeStamp string `json:"message_ts"` //Ephemeral message timestamp
 	Text             string `json:"text"`
 	SlackResponse
 }
 
+// getMessageTimestamp will inspect the `chatResponseFull` to ruturn a timestamp value
+// in `chat.postMessage` its under `ts`
+// in `chat.postEphemeral` its under `message_ts`
 func (c chatResponseFull) getMessageTimestamp() string {
 	if len(c.Timestamp) > 0 {
 		return c.Timestamp


### PR DESCRIPTION
a possible fix for https://github.com/nlopes/slack/issues/347
Added a new variable called `MessageTimeStamp` to `chatResponseFull` struct with an function to fetch the timestamp so we can return in an ephemeral post message
