### PR TITLE
Added a timestamp string argument to the rtm.NewOutgoingMessage function

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -331,6 +331,22 @@ func MsgOptionDisableMarkdown() MsgOption {
 	}
 }
 
+// MsgOptionTS sets the thread TS of the message to enable creating or replying to a thread
+func MsgOptionTS(ts string) MsgOption {
+	return func(config *sendConfig) error {
+		config.values.Set("thread_ts", ts)
+		return nil
+	}
+}
+
+// MsgOptionBroadcast sets reply_broadcast to true
+func MsgOptionBroadcast() MsgOption {
+	return func(config *sendConfig) error {
+		config.values.Set("reply_broadcast", "true")
+		return nil
+	}
+}
+
 // this function combines multiple options into a single option.
 func MsgOptionCompose(options ...MsgOption) MsgOption {
 	return func(c *sendConfig) error {

--- a/examples/websocket/websocket.go
+++ b/examples/websocket/websocket.go
@@ -27,7 +27,7 @@ func main() {
 			fmt.Println("Infos:", ev.Info)
 			fmt.Println("Connection counter:", ev.ConnectionCount)
 			// Replace C2147483705 with your Channel ID
-			rtm.SendMessage(rtm.NewOutgoingMessage("Hello world", "C2147483705"))
+			rtm.SendMessage(rtm.NewOutgoingMessage("Hello world", "C2147483705", ""))
 
 		case *slack.MessageEvent:
 			fmt.Printf("Message: %v\n", ev)

--- a/examples/websocket/websocket.go
+++ b/examples/websocket/websocket.go
@@ -27,7 +27,7 @@ func main() {
 			fmt.Println("Infos:", ev.Info)
 			fmt.Println("Connection counter:", ev.ConnectionCount)
 			// Replace C2147483705 with your Channel ID
-			rtm.SendMessage(rtm.NewOutgoingMessage("Hello world", "C2147483705", ""))
+			rtm.SendMessage(rtm.NewOutgoingMessage("Hello world", "C2147483705"))
 
 		case *slack.MessageEvent:
 			fmt.Printf("Message: %v\n", ev)

--- a/messages.go
+++ b/messages.go
@@ -8,7 +8,7 @@ type OutgoingMessage struct {
 	Text            string `json:"text,omitempty"`
 	Type            string `json:"type,omitempty"`
 	ThreadTimestamp string `json:"thread_ts,omitempty"`
-	ThreadBroadcast bool   `json:"thread_broadcast,omitempty"`
+	ThreadBroadcast bool   `json:"reply_broadcast,omitempty"`
 }
 
 // Message is an auxiliary type to allow us to have a message containing sub messages

--- a/messages.go
+++ b/messages.go
@@ -130,13 +130,14 @@ type Pong struct {
 // NewOutgoingMessage prepares an OutgoingMessage that the user can
 // use to send a message. Use this function to properly set the
 // messageID.
-func (rtm *RTM) NewOutgoingMessage(text string, channelID string) *OutgoingMessage {
+func (rtm *RTM) NewOutgoingMessage(text string, channelID string, threadTimestamp string) *OutgoingMessage {
 	id := rtm.idGen.Next()
 	return &OutgoingMessage{
-		ID:      id,
-		Type:    "message",
-		Channel: channelID,
-		Text:    text,
+		ID:              id,
+		Type:            "message",
+		Channel:         channelID,
+		Text:            text,
+		ThreadTimestamp: threadTimestamp,
 	}
 }
 

--- a/messages.go
+++ b/messages.go
@@ -8,6 +8,7 @@ type OutgoingMessage struct {
 	Text            string `json:"text,omitempty"`
 	Type            string `json:"type,omitempty"`
 	ThreadTimestamp string `json:"thread_ts,omitempty"`
+	ThreadBroadcast bool   `json:"thread_broadcast,omitempty"`
 }
 
 // Message is an auxiliary type to allow us to have a message containing sub messages
@@ -130,15 +131,18 @@ type Pong struct {
 // NewOutgoingMessage prepares an OutgoingMessage that the user can
 // use to send a message. Use this function to properly set the
 // messageID.
-func (rtm *RTM) NewOutgoingMessage(text string, channelID string, threadTimestamp string) *OutgoingMessage {
+func (rtm *RTM) NewOutgoingMessage(text string, channelID string, options ...RTMsgOption) *OutgoingMessage {
 	id := rtm.idGen.Next()
-	return &OutgoingMessage{
-		ID:              id,
-		Type:            "message",
-		Channel:         channelID,
-		Text:            text,
-		ThreadTimestamp: threadTimestamp,
+	msg := OutgoingMessage{
+		ID:      id,
+		Type:    "message",
+		Channel: channelID,
+		Text:    text,
 	}
+	for _, option := range options {
+		option(&msg)
+	}
+	return &msg
 }
 
 // NewTypingMessage prepares an OutgoingMessage that the user can
@@ -151,4 +155,22 @@ func (rtm *RTM) NewTypingMessage(channelID string) *OutgoingMessage {
 		Type:    "typing",
 		Channel: channelID,
 	}
+}
+
+// RTMsgOption allows configuration of various options available for sending an RTM message
+type RTMsgOption func(*OutgoingMessage)
+
+// RTMsgOptionTS sets thead timestamp of an outgoing message in order to respond to a thread
+func RTMsgOptionTS(threadTimestamp string) RTMsgOption {
+	return func(msg *OutgoingMessage) {
+		msg.ThreadTimestamp = threadTimestamp
+	}
+}
+
+// RTMsgOptionBroadcast sets broadcast reply to channel to "true"
+func RTMsgOptionBroadcast() RTMsgOption {
+	return func(msg *OutgoingMessage) {
+		msg.ThreadBroadcast = true
+	}
+
 }


### PR DESCRIPTION
Enables function to be used to reply to or start a new thread

Per slack guidelines, an empty string starts a new thread/posts directly to channel, but any TS string that matches a previous post adds a reply. Test fix just passes an empty string. 