### PR TITLE
Add Edited to MessageEvent

### DIFF
--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -70,6 +70,11 @@ type MessageEvent struct {
 	ChannelType     string      `json:"channel_type"`
 	EventTimeStamp  json.Number `json:"event_ts"`
 
+	// Edited Message
+	Message         *MessageEvent `json:"message,omitempty"`
+	PreviousMessage *MessageEvent `json:"previous_message,omitempty"`
+	Edited          *Edited       `json:"edited,omitempty"`
+
 	// Message Subtypes
 	SubType string `json:"subtype,omitempty"`
 
@@ -79,10 +84,22 @@ type MessageEvent struct {
 	Icons    *Icon  `json:"icons,omitempty"`
 }
 
+// Edited is included when a Message is edited
+type Edited struct {
+	User      string `json:"user"`
+	TimeStamp string `json:"ts"`
+}
+
 // Icon is used for bot messages
 type Icon struct {
 	IconURL   string `json:"icon_url,omitempty"`
 	IconEmoji string `json:"icon_emoji,omitempty"`
+}
+
+// IsEdited checks if the MessageEvent is caused by an edit
+func (e MessageEvent) IsEdited() bool {
+	return e.Message != nil &&
+		e.Message.Edited != nil
 }
 
 const (

--- a/slackevents/inner_events_test.go
+++ b/slackevents/inner_events_test.go
@@ -107,7 +107,17 @@ func TestMessageEvent(t *testing.T) {
 				"text": "Live long and prospect.",
 				"ts": "1355517523.000005",
 				"event_ts": "1355517523.000005",
-				"channel_type": "channel"
+				"channel_type": "channel",
+				"message": {
+					"text": "To infinity and beyond.",
+					"edited": {
+						"user": "U2147483697",
+						"ts": "1355517524.000000"
+					}
+				},
+				"previous_message": {
+					"text": "Live long and prospect."
+				}
 		}
 	`)
 	err := json.Unmarshal(rawE, &MessageEvent{})


### PR DESCRIPTION
If a message is edited, a `message` event is sent to the Events API with the following extra keys:

```json
{
  "message": {
    "text": "To infinity and beyond.",
    "edited": {
      "user": "U2147483697",
      "ts": "1355517524.000000"
    }
  },
  "previous_message": {
    "text": "Live long and prospect."
  }
}
```

This PR adds those fields to the respective `slackevents.MessageEvent` struct used while parsing and mapping this type of event.

This PR also adds a method `IsEdited() bool` to the `slackevents.MessageEvent` struct for accessibility.