### PR TITLE
Fix t.Errorf failing on go:tip for lacking formatting directives

### DIFF
--- a/dialog_test.go
+++ b/dialog_test.go
@@ -299,7 +299,7 @@ func TestOpenDialog(t *testing.T) {
 	}
 	err = api.OpenDialog("", *dialog)
 	if err == nil {
-		t.Errorf("Did not error with empty trigger", err)
+		t.Errorf("Did not error with empty trigger: %s", err)
 		return
 	}
 }


### PR DESCRIPTION
https://github.com/nlopes/slack/blob/347a74b1ea3055e8adcf17d2e14cbf3939238f6f/dialog_test.go#L302

Check: https://travis-ci.org/nlopes/slack/jobs/409531576