### PR TITLE
better naming for some internal methods

### DIFF
--- a/bots.go
+++ b/bots.go
@@ -21,7 +21,7 @@ type botResponseFull struct {
 
 func botRequest(ctx context.Context, client HTTPRequester, path string, values url.Values, debug bool) (*botResponseFull, error) {
 	response := &botResponseFull{}
-	err := postPath(ctx, client, path, values, response, debug)
+	err := postSlackMethod(ctx, client, path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}

--- a/chat.go
+++ b/chat.go
@@ -164,7 +164,7 @@ func (api *Client) SendMessageContext(ctx context.Context, channelID string, opt
 		return "", "", "", err
 	}
 
-	if err = postPath(ctx, api.httpclient, string(config.mode), config.values, &response, api.debug); err != nil {
+	if err = postSlackMethod(ctx, api.httpclient, string(config.mode), config.values, &response, api.debug); err != nil {
 		return "", "", "", err
 	}
 

--- a/conversation.go
+++ b/conversation.go
@@ -90,7 +90,7 @@ func (api *Client) GetUsersInConversationContext(ctx context.Context, params *Ge
 		ResponseMetaData responseMetaData `json:"response_metadata"`
 		SlackResponse
 	}{}
-	err := postPath(ctx, api.httpclient, "conversations.members", values, &response, api.debug)
+	err := postSlackMethod(ctx, api.httpclient, "conversations.members", values, &response, api.debug)
 	if err != nil {
 		return nil, "", err
 	}
@@ -112,7 +112,7 @@ func (api *Client) ArchiveConversationContext(ctx context.Context, channelID str
 		"channel": {channelID},
 	}
 	response := SlackResponse{}
-	err := postPath(ctx, api.httpclient, "conversations.archive", values, &response, api.debug)
+	err := postSlackMethod(ctx, api.httpclient, "conversations.archive", values, &response, api.debug)
 	if err != nil {
 		return err
 	}
@@ -132,7 +132,7 @@ func (api *Client) UnArchiveConversationContext(ctx context.Context, channelID s
 		"channel": {channelID},
 	}
 	response := SlackResponse{}
-	err := postPath(ctx, api.httpclient, "conversations.unarchive", values, &response, api.debug)
+	err := postSlackMethod(ctx, api.httpclient, "conversations.unarchive", values, &response, api.debug)
 	if err != nil {
 		return err
 	}
@@ -156,7 +156,7 @@ func (api *Client) SetTopicOfConversationContext(ctx context.Context, channelID,
 		SlackResponse
 		Channel *Channel `json:"channel"`
 	}{}
-	err := postPath(ctx, api.httpclient, "conversations.setTopic", values, &response, api.debug)
+	err := postSlackMethod(ctx, api.httpclient, "conversations.setTopic", values, &response, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func (api *Client) SetPurposeOfConversationContext(ctx context.Context, channelI
 		SlackResponse
 		Channel *Channel `json:"channel"`
 	}{}
-	err := postPath(ctx, api.httpclient, "conversations.setPurpose", values, &response, api.debug)
+	err := postSlackMethod(ctx, api.httpclient, "conversations.setPurpose", values, &response, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +204,7 @@ func (api *Client) RenameConversationContext(ctx context.Context, channelID, cha
 		SlackResponse
 		Channel *Channel `json:"channel"`
 	}{}
-	err := postPath(ctx, api.httpclient, "conversations.rename", values, &response, api.debug)
+	err := postSlackMethod(ctx, api.httpclient, "conversations.rename", values, &response, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func (api *Client) InviteUsersToConversationContext(ctx context.Context, channel
 		SlackResponse
 		Channel *Channel `json:"channel"`
 	}{}
-	err := postPath(ctx, api.httpclient, "conversations.invite", values, &response, api.debug)
+	err := postSlackMethod(ctx, api.httpclient, "conversations.invite", values, &response, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -249,7 +249,7 @@ func (api *Client) KickUserFromConversationContext(ctx context.Context, channelI
 		"user":    {user},
 	}
 	response := SlackResponse{}
-	err := postPath(ctx, api.httpclient, "conversations.kick", values, &response, api.debug)
+	err := postSlackMethod(ctx, api.httpclient, "conversations.kick", values, &response, api.debug)
 	if err != nil {
 		return err
 	}
@@ -274,7 +274,7 @@ func (api *Client) CloseConversationContext(ctx context.Context, channelID strin
 		AlreadyClosed bool `json:"already_closed"`
 	}{}
 
-	err = postPath(ctx, api.httpclient, "conversations.close", values, &response, api.debug)
+	err = postSlackMethod(ctx, api.httpclient, "conversations.close", values, &response, api.debug)
 	if err != nil {
 		return false, false, err
 	}
@@ -392,7 +392,7 @@ func (api *Client) GetConversationRepliesContext(ctx context.Context, params *Ge
 		Messages []Message `json:"messages"`
 	}{}
 
-	err = postPath(ctx, api.httpclient, "conversations.replies", values, &response, api.debug)
+	err = postSlackMethod(ctx, api.httpclient, "conversations.replies", values, &response, api.debug)
 	if err != nil {
 		return nil, false, "", err
 	}
@@ -432,7 +432,7 @@ func (api *Client) GetConversationsContext(ctx context.Context, params *GetConve
 		ResponseMetaData responseMetaData `json:"response_metadata"`
 		SlackResponse
 	}{}
-	err = postPath(ctx, api.httpclient, "conversations.list", values, &response, api.debug)
+	err = postSlackMethod(ctx, api.httpclient, "conversations.list", values, &response, api.debug)
 	if err != nil {
 		return nil, "", err
 	}
@@ -469,7 +469,7 @@ func (api *Client) OpenConversationContext(ctx context.Context, params *OpenConv
 		AlreadyOpen bool     `json:"already_open"`
 		SlackResponse
 	}{}
-	err := postPath(ctx, api.httpclient, "conversations.open", values, &response, api.debug)
+	err := postSlackMethod(ctx, api.httpclient, "conversations.open", values, &response, api.debug)
 	if err != nil {
 		return nil, false, false, err
 	}
@@ -493,7 +493,7 @@ func (api *Client) JoinConversationContext(ctx context.Context, channelID string
 		} `json:"response_metadata"`
 		SlackResponse
 	}{}
-	err := postPath(ctx, api.httpclient, "conversations.join", values, &response, api.debug)
+	err := postSlackMethod(ctx, api.httpclient, "conversations.join", values, &response, api.debug)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -555,7 +555,7 @@ func (api *Client) GetConversationHistoryContext(ctx context.Context, params *Ge
 
 	response := GetConversationHistoryResponse{}
 
-	err := postPath(ctx, api.httpclient, "conversations.history", values, &response, api.debug)
+	err := postSlackMethod(ctx, api.httpclient, "conversations.history", values, &response, api.debug)
 	if err != nil {
 		return nil, err
 	}

--- a/conversation_test.go
+++ b/conversation_test.go
@@ -241,7 +241,7 @@ func TestGetUsersInConversation(t *testing.T) {
 }
 
 func TestArchiveConversation(t *testing.T) {
-	http.HandleFunc("/conversations.archive", okJsonHandler)
+	http.HandleFunc("/conversations.archive", okJSONHandler)
 	once.Do(startServer)
 	SLACK_API = "http://" + serverAddr + "/"
 	api := New("testing-token")
@@ -253,7 +253,7 @@ func TestArchiveConversation(t *testing.T) {
 }
 
 func TestUnArchiveConversation(t *testing.T) {
-	http.HandleFunc("/conversations.unarchive", okJsonHandler)
+	http.HandleFunc("/conversations.unarchive", okJSONHandler)
 	once.Do(startServer)
 	SLACK_API = "http://" + serverAddr + "/"
 	api := New("testing-token")
@@ -354,7 +354,7 @@ func TestInviteUsersToConversation(t *testing.T) {
 }
 
 func TestKickUserFromConversation(t *testing.T) {
-	http.HandleFunc("/conversations.kick", okJsonHandler)
+	http.HandleFunc("/conversations.kick", okJSONHandler)
 	once.Do(startServer)
 	SLACK_API = "http://" + serverAddr + "/"
 	api := New("testing-token")

--- a/dnd.go
+++ b/dnd.go
@@ -38,7 +38,7 @@ type dndTeamInfoResponse struct {
 
 func dndRequest(ctx context.Context, client HTTPRequester, path string, values url.Values, debug bool) (*dndResponseFull, error) {
 	response := &dndResponseFull{}
-	err := postPath(ctx, client, path, values, response, debug)
+	err := postSlackMethod(ctx, client, path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func (api *Client) EndDNDContext(ctx context.Context) error {
 
 	response := &SlackResponse{}
 
-	if err := postPath(ctx, api.httpclient, "dnd.endDnd", values, response, api.debug); err != nil {
+	if err := postSlackMethod(ctx, api.httpclient, "dnd.endDnd", values, response, api.debug); err != nil {
 		return err
 	}
 
@@ -120,7 +120,7 @@ func (api *Client) GetDNDTeamInfoContext(ctx context.Context, users []string) (m
 	}
 	response := &dndTeamInfoResponse{}
 
-	if err := postPath(ctx, api.httpclient, "dnd.teamInfo", values, response, api.debug); err != nil {
+	if err := postSlackMethod(ctx, api.httpclient, "dnd.teamInfo", values, response, api.debug); err != nil {
 		return nil, err
 	}
 	if !response.Ok {

--- a/emoji.go
+++ b/emoji.go
@@ -23,7 +23,7 @@ func (api *Client) GetEmojiContext(ctx context.Context) (map[string]string, erro
 	}
 	response := &emojiResponseFull{}
 
-	err := postPath(ctx, api.httpclient, "emoji.list", values, response, api.debug)
+	err := postSlackMethod(ctx, api.httpclient, "emoji.list", values, response, api.debug)
 	if err != nil {
 		return nil, err
 	}

--- a/im.go
+++ b/im.go
@@ -31,7 +31,7 @@ type IM struct {
 
 func imRequest(ctx context.Context, client HTTPRequester, path string, values url.Values, debug bool) (*imResponseFull, error) {
 	response := &imResponseFull{}
-	err := postPath(ctx, client, path, values, response, debug)
+	err := postSlackMethod(ctx, client, path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}

--- a/misc.go
+++ b/misc.go
@@ -171,6 +171,7 @@ func doPost(ctx context.Context, client HTTPRequester, req *http.Request, intf i
 	return parseResponseBody(resp.Body, intf, debug)
 }
 
+// post JSON.
 func postJSON(ctx context.Context, client HTTPRequester, endpoint, token string, json []byte, intf interface{}, debug bool) error {
 	reqBody := bytes.NewBuffer(json)
 	req, err := http.NewRequest("POST", endpoint, reqBody)
@@ -182,6 +183,7 @@ func postJSON(ctx context.Context, client HTTPRequester, endpoint, token string,
 	return doPost(ctx, client, req, intf, debug)
 }
 
+// post a url encoded form.
 func postForm(ctx context.Context, client HTTPRequester, endpoint string, values url.Values, intf interface{}, debug bool) error {
 	reqBody := strings.NewReader(values.Encode())
 	req, err := http.NewRequest("POST", endpoint, reqBody)
@@ -192,7 +194,8 @@ func postForm(ctx context.Context, client HTTPRequester, endpoint string, values
 	return doPost(ctx, client, req, intf, debug)
 }
 
-func postPath(ctx context.Context, client HTTPRequester, path string, values url.Values, intf interface{}, debug bool) error {
+// post to a slack web method.
+func postSlackMethod(ctx context.Context, client HTTPRequester, path string, values url.Values, intf interface{}, debug bool) error {
 	return postForm(ctx, client, SLACK_API+path, values, intf, debug)
 }
 
@@ -214,7 +217,7 @@ func logResponse(resp *http.Response, debug bool) error {
 	return nil
 }
 
-func okJsonHandler(rw http.ResponseWriter, r *http.Request) {
+func okJSONHandler(rw http.ResponseWriter, r *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
 	response, _ := json.Marshal(SlackResponse{
 		Ok: true,

--- a/misc_test.go
+++ b/misc_test.go
@@ -41,7 +41,7 @@ func TestParseResponse(t *testing.T) {
 		"token": {validToken},
 	}
 	responsePartial := &SlackResponse{}
-	err := postPath(context.Background(), http.DefaultClient, "parseResponse", values, responsePartial, false)
+	err := postSlackMethod(context.Background(), http.DefaultClient, "parseResponse", values, responsePartial, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -53,7 +53,7 @@ func TestParseResponseNoToken(t *testing.T) {
 	SLACK_API = "http://" + serverAddr + "/"
 	values := url.Values{}
 	responsePartial := &SlackResponse{}
-	err := postPath(context.Background(), http.DefaultClient, "parseResponse", values, responsePartial, false)
+	err := postSlackMethod(context.Background(), http.DefaultClient, "parseResponse", values, responsePartial, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 		return
@@ -73,7 +73,7 @@ func TestParseResponseInvalidToken(t *testing.T) {
 		"token": {"whatever"},
 	}
 	responsePartial := &SlackResponse{}
-	err := postPath(context.Background(), http.DefaultClient, "parseResponse", values, responsePartial, false)
+	err := postSlackMethod(context.Background(), http.DefaultClient, "parseResponse", values, responsePartial, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 		return

--- a/oauth.go
+++ b/oauth.go
@@ -55,7 +55,7 @@ func GetOAuthResponseContext(ctx context.Context, clientID, clientSecret, code, 
 		"redirect_uri":  {redirectURI},
 	}
 	response := &OAuthResponse{}
-	err = postPath(ctx, customHTTPClient, "oauth.access", values, response, debug)
+	err = postSlackMethod(ctx, customHTTPClient, "oauth.access", values, response, debug)
 	if err != nil {
 		return nil, err
 	}

--- a/pins.go
+++ b/pins.go
@@ -34,7 +34,7 @@ func (api *Client) AddPinContext(ctx context.Context, channel string, item ItemR
 	}
 
 	response := &SlackResponse{}
-	if err := postPath(ctx, api.httpclient, "pins.add", values, response, api.debug); err != nil {
+	if err := postSlackMethod(ctx, api.httpclient, "pins.add", values, response, api.debug); err != nil {
 		return err
 	}
 
@@ -63,7 +63,7 @@ func (api *Client) RemovePinContext(ctx context.Context, channel string, item It
 	}
 
 	response := &SlackResponse{}
-	if err := postPath(ctx, api.httpclient, "pins.remove", values, response, api.debug); err != nil {
+	if err := postSlackMethod(ctx, api.httpclient, "pins.remove", values, response, api.debug); err != nil {
 		return err
 	}
 
@@ -83,7 +83,7 @@ func (api *Client) ListPinsContext(ctx context.Context, channel string) ([]Item,
 	}
 
 	response := &listPinsResponseFull{}
-	err := postPath(ctx, api.httpclient, "pins.list", values, response, api.debug)
+	err := postSlackMethod(ctx, api.httpclient, "pins.list", values, response, api.debug)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/reactions.go
+++ b/reactions.go
@@ -155,7 +155,7 @@ func (api *Client) AddReactionContext(ctx context.Context, name string, item Ite
 	}
 
 	response := &SlackResponse{}
-	if err := postPath(ctx, api.httpclient, "reactions.add", values, response, api.debug); err != nil {
+	if err := postSlackMethod(ctx, api.httpclient, "reactions.add", values, response, api.debug); err != nil {
 		return err
 	}
 
@@ -189,7 +189,7 @@ func (api *Client) RemoveReactionContext(ctx context.Context, name string, item 
 	}
 
 	response := &SlackResponse{}
-	if err := postPath(ctx, api.httpclient, "reactions.remove", values, response, api.debug); err != nil {
+	if err := postSlackMethod(ctx, api.httpclient, "reactions.remove", values, response, api.debug); err != nil {
 		return err
 	}
 
@@ -223,7 +223,7 @@ func (api *Client) GetReactionsContext(ctx context.Context, item ItemRef, params
 	}
 
 	response := &getReactionsResponseFull{}
-	if err := postPath(ctx, api.httpclient, "reactions.get", values, response, api.debug); err != nil {
+	if err := postSlackMethod(ctx, api.httpclient, "reactions.get", values, response, api.debug); err != nil {
 		return nil, err
 	}
 	if !response.Ok {
@@ -256,7 +256,7 @@ func (api *Client) ListReactionsContext(ctx context.Context, params ListReaction
 	}
 
 	response := &listReactionsResponseFull{}
-	err := postPath(ctx, api.httpclient, "reactions.list", values, response, api.debug)
+	err := postSlackMethod(ctx, api.httpclient, "reactions.list", values, response, api.debug)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/rtm.go
+++ b/rtm.go
@@ -38,7 +38,7 @@ func (api *Client) StartRTM() (info *Info, websocketURL string, err error) {
 // To have a fully managed Websocket connection, use `NewRTM`, and call `ManageConnection()` on it.
 func (api *Client) StartRTMContext(ctx context.Context) (info *Info, websocketURL string, err error) {
 	response := &infoResponseFull{}
-	err = postPath(ctx, api.httpclient, "rtm.start", url.Values{"token": {api.token}}, response, api.debug)
+	err = postSlackMethod(ctx, api.httpclient, "rtm.start", url.Values{"token": {api.token}}, response, api.debug)
 	if err != nil {
 		return nil, "", err
 	}
@@ -63,7 +63,7 @@ func (api *Client) ConnectRTM() (info *Info, websocketURL string, err error) {
 // To have a fully managed Websocket connection, use `NewRTM`, and call `ManageConnection()` on it.
 func (api *Client) ConnectRTMContext(ctx context.Context) (info *Info, websocketURL string, err error) {
 	response := &infoResponseFull{}
-	err = postPath(ctx, api.httpclient, "rtm.connect", url.Values{"token": {api.token}}, response, api.debug)
+	err = postSlackMethod(ctx, api.httpclient, "rtm.connect", url.Values{"token": {api.token}}, response, api.debug)
 	if err != nil {
 		api.Debugf("Failed to connect to RTM: %s", err)
 		return nil, "", err

--- a/search.go
+++ b/search.go
@@ -104,7 +104,7 @@ func (api *Client) _search(ctx context.Context, path, query string, params Searc
 	}
 
 	response = &searchResponseFull{}
-	err := postPath(ctx, api.httpclient, path, values, response, api.debug)
+	err := postSlackMethod(ctx, api.httpclient, path, values, response, api.debug)
 	if err != nil {
 		return nil, err
 	}

--- a/slack.go
+++ b/slack.go
@@ -101,7 +101,7 @@ func (api *Client) AuthTest() (response *AuthTestResponse, error error) {
 func (api *Client) AuthTestContext(ctx context.Context) (response *AuthTestResponse, error error) {
 	api.Debugf("Challenging auth...")
 	responseFull := &authTestResponseFull{}
-	err := postPath(ctx, api.httpclient, "auth.test", url.Values{"token": {api.token}}, responseFull, api.debug)
+	err := postSlackMethod(ctx, api.httpclient, "auth.test", url.Values{"token": {api.token}}, responseFull, api.debug)
 	if err != nil {
 		api.Debugf("failed to test for auth: %s", err)
 		return nil, err

--- a/stars.go
+++ b/stars.go
@@ -58,7 +58,7 @@ func (api *Client) AddStarContext(ctx context.Context, channel string, item Item
 	}
 
 	response := &SlackResponse{}
-	if err := postPath(ctx, api.httpclient, "stars.add", values, response, api.debug); err != nil {
+	if err := postSlackMethod(ctx, api.httpclient, "stars.add", values, response, api.debug); err != nil {
 		return err
 	}
 
@@ -87,7 +87,7 @@ func (api *Client) RemoveStarContext(ctx context.Context, channel string, item I
 	}
 
 	response := &SlackResponse{}
-	if err := postPath(ctx, api.httpclient, "stars.remove", values, response, api.debug); err != nil {
+	if err := postSlackMethod(ctx, api.httpclient, "stars.remove", values, response, api.debug); err != nil {
 		return err
 	}
 
@@ -115,7 +115,7 @@ func (api *Client) ListStarsContext(ctx context.Context, params StarsParameters)
 	}
 
 	response := &listResponseFull{}
-	err := postPath(ctx, api.httpclient, "stars.list", values, response, api.debug)
+	err := postSlackMethod(ctx, api.httpclient, "stars.list", values, response, api.debug)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/team.go
+++ b/team.go
@@ -69,7 +69,7 @@ func NewAccessLogParameters() AccessLogParameters {
 
 func teamRequest(ctx context.Context, client HTTPRequester, path string, values url.Values, debug bool) (*TeamResponse, error) {
 	response := &TeamResponse{}
-	err := postPath(ctx, client, path, values, response, debug)
+	err := postSlackMethod(ctx, client, path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func teamRequest(ctx context.Context, client HTTPRequester, path string, values 
 
 func billableInfoRequest(ctx context.Context, client HTTPRequester, path string, values url.Values, debug bool) (map[string]BillingActive, error) {
 	response := &BillableInfoResponse{}
-	err := postPath(ctx, client, path, values, response, debug)
+	err := postSlackMethod(ctx, client, path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func billableInfoRequest(ctx context.Context, client HTTPRequester, path string,
 
 func accessLogsRequest(ctx context.Context, client HTTPRequester, path string, values url.Values, debug bool) (*LoginResponse, error) {
 	response := &LoginResponse{}
-	err := postPath(ctx, client, path, values, response, debug)
+	err := postSlackMethod(ctx, client, path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}

--- a/usergroups.go
+++ b/usergroups.go
@@ -42,7 +42,7 @@ type userGroupResponseFull struct {
 
 func userGroupRequest(ctx context.Context, client HTTPRequester, path string, values url.Values, debug bool) (*userGroupResponseFull, error) {
 	response := &userGroupResponseFull{}
-	err := postPath(ctx, client, path, values, response, debug)
+	err := postSlackMethod(ctx, client, path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}

--- a/users.go
+++ b/users.go
@@ -547,7 +547,7 @@ func (api *Client) GetUserProfileContext(ctx context.Context, userID string, inc
 	}
 	resp := &getUserProfileResponse{}
 
-	err := postPath(ctx, api.httpclient, "users.profile.get", values, &resp, api.debug)
+	err := postSlackMethod(ctx, api.httpclient, "users.profile.get", values, &resp, api.debug)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
resolves linting and clearer usage, etc.