### PR TITLE
fix deadlock between disconnect and connect.

### DIFF
--- a/rtm.go
+++ b/rtm.go
@@ -112,7 +112,7 @@ func (api *Client) NewRTM(options ...RTMOption) *RTM {
 		isConnected:      false,
 		wasIntentional:   true,
 		killChannel:      make(chan bool),
-		disconnected:     make(chan struct{}),
+		disconnected:     make(chan struct{}, 1),
 		forcePing:        make(chan bool),
 		rawEvents:        make(chan json.RawMessage),
 		idGen:            NewSafeID(1),

--- a/websocket.go
+++ b/websocket.go
@@ -72,9 +72,14 @@ func (rtm *RTM) Disconnect() error {
 	// avoid RTM disconnect race conditions
 	rtm.mu.Lock()
 	defer rtm.mu.Unlock()
-	// this channel is always closed on disconnect. lets the ManagedConnection() function
-	// properly clean up.
-	close(rtm.disconnected)
+
+	// always push into the disconnected channel when invoked,
+	// this lets the ManagedConnection() function properly clean up.
+	// if the buffer is full then just continue on.
+	select {
+	case rtm.disconnected <- struct{}{}:
+	default:
+	}
 
 	if !rtm.isConnected {
 		return errors.New("Invalid call to Disconnect - Slack API is already disconnected")


### PR DESCRIPTION
deadlock occurs because ManagedConnect acquired the lock prior to invoking .connect
which can infinitely loop attempting to make a connection. then if Disconnect is invoked it cannot acquire the lock to proceed with the disconnection.
