### PR TITLE
Add access to the thread_ts for app_mention event.

### DIFF
--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -12,12 +12,13 @@ type EventsAPIInnerEvent struct {
 
 // AppMentionEvent is an (inner) EventsAPI subscribable event.
 type AppMentionEvent struct {
-	Type           string      `json:"type"`
-	User           string      `json:"user"`
-	Text           string      `json:"text"`
-	TimeStamp      string      `json:"ts"`
-	Channel        string      `json:"channel"`
-	EventTimeStamp json.Number `json:"event_ts"`
+	Type            string      `json:"type"`
+	User            string      `json:"user"`
+	Text            string      `json:"text"`
+	TimeStamp       string      `json:"ts"`
+	ThreadTimeStamp string      `json:"thread_ts"`
+	Channel         string      `json:"channel"`
+	EventTimeStamp  json.Number `json:"event_ts"`
 }
 
 // AppUninstalledEvent Your Slack app was uninstalled.

--- a/slackevents/inner_events_test.go
+++ b/slackevents/inner_events_test.go
@@ -12,6 +12,7 @@ func TestAppMention(t *testing.T) {
 				"user": "U061F7AUR",
 				"text": "<@U0LAN0Z89> is it everything a river should be?",
 				"ts": "1515449522.000016",
+				"thread_ts": "1515449522.000016",
 				"channel": "C0LAN2Q65",
 				"event_ts": "1515449522000016"
 		}


### PR DESCRIPTION
Slack is sending the `thread_ts` as part of the `app_mention` event payload, however because it is not in the struct, there was no access to it without manually parsing the raw json response.

This is important in order to be able to know the parent `ts` in order to keep conversation flow.