### PR TITLE
Enhance GetUserGroups call with params

### DIFF
--- a/usergroups.go
+++ b/usergroups.go
@@ -122,32 +122,50 @@ func (api *Client) EnableUserGroupContext(ctx context.Context, userGroup string)
 	return response.UserGroup, nil
 }
 
-// GetUserGroupsParams contains arguments for GetUserGroups call
-type GetUserGroupsParams struct {
-	// IncludeCount	- Include the number of users in each User Group. Default: false
-	IncludeCount bool
-	// IncludeDisabled - Include disabled User Groups. Default: false
-	IncludeDisabled bool
-	// IncludeUsers - Include the list of users for each User Group. Default: false
-	IncludeUsers bool
-}
+// GetUserGroupsOption options for the GetUserGroups method call.
+type GetUserGroupsOption func(*GetUserGroupsParams)
 
-// NewGetUserGroupsParams creates a new instance GetUserGroupsParams with defaults
-func NewGetUserGroupsParams() GetUserGroupsParams {
-	return GetUserGroupsParams{
-		IncludeCount:    false,
-		IncludeDisabled: false,
-		IncludeUsers:    false,
+// GetUserGroupsOptionIncludeCount include the number of users in each User Group (default: false)
+func GetUserGroupsOptionIncludeCount(b bool) GetUserGroupsOption {
+	return func(params *GetUserGroupsParams) {
+		params.IncludeCount = b
 	}
 }
 
+// GetUserGroupsOptionIncludeDisabled include disabled User Groups (default: false)
+func GetUserGroupsOptionIncludeDisabled(b bool) GetUserGroupsOption {
+	return func(params *GetUserGroupsParams) {
+		params.IncludeDisabled = b
+	}
+}
+
+// GetUserGroupsOptionIncludeUsers include the list of users for each User Group (default: false)
+func GetUserGroupsOptionIncludeUsers(b bool) GetUserGroupsOption {
+	return func(params *GetUserGroupsParams) {
+		params.IncludeUsers = b
+	}
+}
+
+// GetUserGroupsParams contains arguments for GetUserGroups method call
+type GetUserGroupsParams struct {
+	IncludeCount    bool
+	IncludeDisabled bool
+	IncludeUsers    bool
+}
+
 // GetUserGroups returns a list of user groups for the team
-func (api *Client) GetUserGroups(params GetUserGroupsParams) ([]UserGroup, error) {
-	return api.GetUserGroupsContext(context.Background(), params)
+func (api *Client) GetUserGroups(options ...GetUserGroupsOption) ([]UserGroup, error) {
+	return api.GetUserGroupsContext(context.Background(), options...)
 }
 
 // GetUserGroupsContext returns a list of user groups for the team with a custom context
-func (api *Client) GetUserGroupsContext(ctx context.Context, params GetUserGroupsParams) ([]UserGroup, error) {
+func (api *Client) GetUserGroupsContext(ctx context.Context, options ...GetUserGroupsOption) ([]UserGroup, error) {
+	params := GetUserGroupsParams{}
+
+	for _, opt := range options {
+		opt(&params)
+	}
+
 	values := url.Values{
 		"token": {api.token},
 	}

--- a/usergroups.go
+++ b/usergroups.go
@@ -25,6 +25,7 @@ type UserGroup struct {
 	DeletedBy   string         `json:"deleted_by"`
 	Prefs       UserGroupPrefs `json:"prefs"`
 	UserCount   int            `json:"user_count"`
+	Users       []string       `json:"users"`
 }
 
 // UserGroupPrefs contains default channels and groups (private channels)
@@ -121,15 +122,43 @@ func (api *Client) EnableUserGroupContext(ctx context.Context, userGroup string)
 	return response.UserGroup, nil
 }
 
+// GetUserGroupsParams contains arguments for GetUserGroups call
+type GetUserGroupsParams struct {
+	// IncludeCount	- Include the number of users in each User Group. Default: false
+	IncludeCount bool
+	// IncludeDisabled - Include disabled User Groups. Default: false
+	IncludeDisabled bool
+	// IncludeUsers - Include the list of users for each User Group. Default: false
+	IncludeUsers bool
+}
+
+// NewGetUserGroupsParams creates a new instance GetUserGroupsParams with defaults
+func NewGetUserGroupsParams() GetUserGroupsParams {
+	return GetUserGroupsParams{
+		IncludeCount:    false,
+		IncludeDisabled: false,
+		IncludeUsers:    false,
+	}
+}
+
 // GetUserGroups returns a list of user groups for the team
-func (api *Client) GetUserGroups() ([]UserGroup, error) {
-	return api.GetUserGroupsContext(context.Background())
+func (api *Client) GetUserGroups(params GetUserGroupsParams) ([]UserGroup, error) {
+	return api.GetUserGroupsContext(context.Background(), params)
 }
 
 // GetUserGroupsContext returns a list of user groups for the team with a custom context
-func (api *Client) GetUserGroupsContext(ctx context.Context) ([]UserGroup, error) {
+func (api *Client) GetUserGroupsContext(ctx context.Context, params GetUserGroupsParams) ([]UserGroup, error) {
 	values := url.Values{
 		"token": {api.token},
+	}
+	if params.IncludeCount {
+		values.Add("include_count", "true")
+	}
+	if params.IncludeDisabled {
+		values.Add("include_disabled", "true")
+	}
+	if params.IncludeUsers {
+		values.Add("include_users", "true")
 	}
 
 	response, err := userGroupRequest(ctx, api.httpclient, "usergroups.list", values, api.debug)

--- a/usergroups_test.go
+++ b/usergroups_test.go
@@ -126,7 +126,11 @@ func getUserGroups(rw http.ResponseWriter, r *http.Request) {
                   "group2",
                   "group3"
                 ]
-            },
+			},
+            "users": [
+                "user1",
+                "user2"	
+            ],
             "user_count": 2
         }
     ]
@@ -141,7 +145,10 @@ func TestGetUserGroups(t *testing.T) {
 	SLACK_API = "http://" + serverAddr + "/"
 	api := New("testing-token")
 
-	userGroups, err := api.GetUserGroups()
+	params := NewGetUserGroupsParams()
+	params.IncludeUsers = true
+
+	userGroups, err := api.GetUserGroups(params)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 		return
@@ -170,6 +177,10 @@ func TestGetUserGroups(t *testing.T) {
 		Prefs: UserGroupPrefs{
 			Channels: []string{"channel1", "channel2"},
 			Groups:   []string{"group1", "group2", "group3"},
+		},
+		Users: []string{
+			"user1",
+			"user2",
 		},
 		UserCount: 2,
 	}

--- a/usergroups_test.go
+++ b/usergroups_test.go
@@ -145,10 +145,7 @@ func TestGetUserGroups(t *testing.T) {
 	SLACK_API = "http://" + serverAddr + "/"
 	api := New("testing-token")
 
-	params := NewGetUserGroupsParams()
-	params.IncludeUsers = true
-
-	userGroups, err := api.GetUserGroups(params)
+	userGroups, err := api.GetUserGroups(GetUserGroupsOptionIncludeUsers(true))
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 		return


### PR DESCRIPTION
- Create `GetUserGroupsParams` struct with field descriptions (from the [docs](https://api.slack.com/methods/usergroups.list#arguments))
- Propagate new parameters to `GetUserGroups` and `GetUserGroupsContext`
- Add list of users to `UserGroup` struct (when `IncludeUsers` is enabled)
- Update unit test to include a list of users

Heavily inspired by #218, which was never merged, but needed the users to be included as well.