### PR TITLE
Add ability to verify via signing secrets for improved security

### DIFF
--- a/security.go
+++ b/security.go
@@ -46,5 +46,5 @@ func (v SecretsVerifier) Ensure(signingSecret string) error {
 		return nil
 	}
 
-	return errors.New("invalid token")
+	return errors.New("invalid request")
 }

--- a/security.go
+++ b/security.go
@@ -20,7 +20,7 @@ type SecretsVerifier struct {
 // NewSecretsVerifier returns a SecretsVerifier object in exchange for an http.Header object and signing secret
 func NewSecretsVerifier(header http.Header, signingSecret string) (SecretsVerifier, error) {
 	if header["X-Slack-Signature"][0] == "" || header["X-Slack-Request-Timestamp"][0] == "" {
-		return SecretsVerifier{}, errors.New("headers are empty, cannot create SecretsVerifier")
+		return SecretsVerifier{}, errors.New("Headers are empty, cannot create SecretsVerifier")
 	}
 
 	hash := hmac.New(sha256.New, []byte(signingSecret))
@@ -43,5 +43,5 @@ func (v SecretsVerifier) Ensure() error {
 		return nil
 	}
 
-	return fmt.Errorf("invalid request verification token %s, expected %s", v.slackSig, computed)
+	return fmt.Errorf("Expected signing signature: %s, but computed: %s", v.slackSig, computed)
 }

--- a/security.go
+++ b/security.go
@@ -37,7 +37,7 @@ func (v *SecretsVerifier) Write(body []byte) (n int, err error) {
 }
 
 // Ensure compares the signature sent from Slack with the actual computed hash to judge validity
-func (v SecretsVerifier) Ensure(signingSecret string) error {
+func (v SecretsVerifier) Ensure() error {
 	computed := "v0=" + string(hex.EncodeToString(v.hmac.Sum(nil)))
 	if computed == v.slackSig {
 		return nil

--- a/security.go
+++ b/security.go
@@ -6,45 +6,42 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"hash"
 	"net/http"
 )
 
 // SecretsVerifier contains the information needed to verify that the request comes from Slack
 type SecretsVerifier struct {
-	slackSig    string
-	timeStamp   string
-	requestBody string
+	slackSig  string
+	timeStamp string
+	hmac      hash.Hash
 }
 
-// NewSecretsVerifierFromHeader returns a new SecretsVerifier object in exchange for an http.Header object
-func NewSecretsVerifierFromHeader(header http.Header) (SecretsVerifier, error) {
+// NewSecretsVerifier returns a SecretsVerifier object in exchange for an http.Header object and signing secret
+func NewSecretsVerifier(header http.Header, signingSecret string) (SecretsVerifier, error) {
 	if header["X-Slack-Signature"][0] == "" || header["X-Slack-Request-Timestamp"][0] == "" {
 		return SecretsVerifier{}, errors.New("headers are empty, cannot create SecretsVerifier")
 	}
 
+	hash := hmac.New(sha256.New, []byte(signingSecret))
+	hash.Write([]byte(fmt.Sprintf("v0:%s:", header["X-Slack-Request-Timestamp"][0])))
 	return SecretsVerifier{
 		slackSig:  header["X-Slack-Signature"][0],
 		timeStamp: header["X-Slack-Request-Timestamp"][0],
+		hmac:      hash,
 	}, nil
 }
 
 func (v *SecretsVerifier) Write(body []byte) (n int, err error) {
-	v.requestBody = string(body)
-	return len(body), nil
+	return v.hmac.Write(body)
 }
 
 // Ensure compares the signature sent from Slack with the actual computed hash to judge validity
 func (v SecretsVerifier) Ensure(signingSecret string) error {
-	message := fmt.Sprintf("v0:%v:%v", v.timeStamp, v.requestBody)
-
-	mac := hmac.New(sha256.New, []byte(signingSecret))
-	mac.Write([]byte(message))
-
-	actualSignature := "v0=" + string(hex.EncodeToString(mac.Sum(nil)))
-	fmt.Printf("actual: %s expected: %s", actualSignature, v.slackSig)
-	if actualSignature == v.slackSig {
+	computed := "v0=" + string(hex.EncodeToString(v.hmac.Sum(nil)))
+	if computed == v.slackSig {
 		return nil
 	}
 
-	return errors.New("invalid request")
+	return fmt.Errorf("invalid request verification token %s, expected %s", v.slackSig, computed)
 }

--- a/security.go
+++ b/security.go
@@ -16,8 +16,8 @@ type SecretsVerifier struct {
 	requestBody string
 }
 
-// NewSecretVerifierFromHeader returns a new SecretsVerifier object in exchange for an http.Header object
-func NewSecretVerifierFromHeader(header http.Header) (SecretsVerifier, error) {
+// NewSecretsVerifierFromHeader returns a new SecretsVerifier object in exchange for an http.Header object
+func NewSecretsVerifierFromHeader(header http.Header) (SecretsVerifier, error) {
 	if header["X-Slack-Signature"][0] == "" || header["X-Slack-Request-Timestamp"][0] == "" {
 		return SecretsVerifier{}, errors.New("headers are empty, cannot create SecretsVerifier")
 	}
@@ -43,7 +43,6 @@ func (v SecretsVerifier) Ensure(signingSecret string) error {
 	actualSignature := "v0=" + string(hex.EncodeToString(mac.Sum(nil)))
 	fmt.Printf("actual: %s expected: %s", actualSignature, v.slackSig)
 	if actualSignature == v.slackSig {
-		fmt.Printf("bingo")
 		return nil
 	}
 

--- a/security.go
+++ b/security.go
@@ -1,0 +1,51 @@
+package slack
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// SecretsVerifier contains the information needed to verify that the request comes from Slack
+type SecretsVerifier struct {
+	slackSig    string
+	timeStamp   string
+	requestBody string
+}
+
+// NewSecretVerifierFromHeader returns a new SecretsVerifier object in exchange for an http.Header object
+func NewSecretVerifierFromHeader(header http.Header) (SecretsVerifier, error) {
+	if header["X-Slack-Signature"][0] == "" || header["X-Slack-Request-Timestamp"][0] == "" {
+		return SecretsVerifier{}, errors.New("headers are empty, cannot create SecretsVerifier")
+	}
+
+	return SecretsVerifier{
+		slackSig:  header["X-Slack-Signature"][0],
+		timeStamp: header["X-Slack-Request-Timestamp"][0],
+	}, nil
+}
+
+func (v *SecretsVerifier) Write(body []byte) (n int, err error) {
+	v.requestBody = string(body)
+	return len(body), nil
+}
+
+// Ensure compares the signature sent from Slack with the actual computed hash to judge validity
+func (v SecretsVerifier) Ensure(signingSecret string) error {
+	message := fmt.Sprintf("v0:%v:%v", v.timeStamp, v.requestBody)
+
+	mac := hmac.New(sha256.New, []byte(signingSecret))
+	mac.Write([]byte(message))
+
+	actualSignature := "v0=" + string(hex.EncodeToString(mac.Sum(nil)))
+	fmt.Printf("actual: %s expected: %s", actualSignature, v.slackSig)
+	if actualSignature == v.slackSig {
+		fmt.Printf("bingo")
+		return nil
+	}
+
+	return errors.New("invalid token")
+}

--- a/security_test.go
+++ b/security_test.go
@@ -1,0 +1,104 @@
+package slack
+
+import (
+	"io"
+	"log"
+	"net/http"
+	"testing"
+)
+
+const (
+	validSigningSecret   = "e6b19c573432dcc6b075501d51b51bb8"
+	invalidSigningSecret = "e6b19c573432dcc6b075501d51b51boo"
+	validBody            = `{"token":"aF5ynEYQH0dFN9imlgcADxDB","team_id":"XXXXXXXXX","api_app_id":"YYYYYYYYY","event":{"type":"app_mention","user":"AAAAAAAAA","text":"<@EEEEEEEEE> hello world","client_msg_id":"477cc591-ch73-a14z-4db8-g0cd76321bec","ts":"1531431954.000073","channel":"TTTTTTTTT","event_ts":"1531431954.000073"},"type":"event_callback","event_id":"TvBP7LRED7","event_time":1531431954,"authed_users":["EEEEEEEEE"]}`
+	invalidBody          = `{"token":"12345678abcdefghlmnopqrs","team_id":"XXXXXXXXX","api_app_id":"YYYYYYYYY","event":{"type":"app_mention","user":"AAAAAAAAA","text":"<@EEEEEEEEE> hello world","client_msg_id":"477cc591-ch73-a14z-4db8-g0cd76321bec","ts":"1531431954.000073","channel":"TTTTTTTTT","event_ts":"1531431954.000073"},"type":"event_callback","event_id":"TvBP7LRED7","event_time":1531431954,"authed_users":["EEEEEEEEE"]}`
+)
+
+func newHeader(valid bool) http.Header {
+	h := http.Header{}
+	if valid {
+		h.Set("X-Slack-Signature", "v0=adada4ed31709aef585c2580ca3267678c6a8eaeb7e0c1aca3ee57b656886b2c")
+		h.Set("X-Slack-Request-Timestamp", "1531431954")
+	} else {
+		h.Set("X-Slack-Signature", "")
+	}
+	return h
+}
+
+func TestNewSecretsVerifier(t *testing.T) {
+	tests := []struct {
+		title         string
+		header        http.Header
+		signingSecret string
+		expectError   bool
+	}{
+		{
+			title:         "Testing with acceptable params",
+			header:        newHeader(true),
+			signingSecret: "abcdefg12345",
+			expectError:   false,
+		},
+		{
+			title:         "Testing with unacceptable params",
+			header:        newHeader(false),
+			signingSecret: "abcdefg12345",
+			expectError:   true,
+		},
+	}
+
+	for _, test := range tests {
+		_, err := NewSecretsVerifier(test.header, test.signingSecret)
+
+		if !test.expectError && err != nil {
+			log.Fatalf("%s: Unexpected error: %s in test", test.title, err)
+		} else if test.expectError == true && err == nil {
+			log.Fatalf("Expected error but got none")
+		}
+	}
+}
+
+func TestEnsure(t *testing.T) {
+	tests := []struct {
+		title         string
+		header        http.Header
+		signingSecret string
+		body          string
+		expectError   bool
+	}{
+		{
+			title:         "Testing with acceptable signing secret and valid body",
+			header:        newHeader(true),
+			signingSecret: validSigningSecret,
+			body:          validBody,
+			expectError:   false,
+		},
+		{
+			title:         "Testing with unacceptable signing secret and valid body",
+			header:        newHeader(true),
+			signingSecret: invalidSigningSecret,
+			body:          validBody,
+			expectError:   true,
+		},
+		{
+			title:         "Testing with acceptable signing secret and invalid body",
+			header:        newHeader(true),
+			signingSecret: validSigningSecret,
+			body:          invalidBody,
+			expectError:   true,
+		},
+	}
+
+	for _, test := range tests {
+		sv, _ := NewSecretsVerifier(test.header, test.signingSecret)
+		io.WriteString(&sv, test.body)
+
+		err := sv.Ensure()
+
+		if !test.expectError && err != nil {
+			log.Fatalf("%s: Unexpected error: %s in test", test.title, err)
+		} else if test.expectError == true && err == nil {
+			log.Fatalf("Expected error but got none")
+		}
+	}
+
+}


### PR DESCRIPTION
Verification tokens have been deprecated by Slack and, while still usable, are far less secure than the new signing secrets method of verifying requests. This PR adds `security.go`, which will allow users to easily judge the validity of their incoming requests. 

Reference: https://api.slack.com/docs/verifying-requests-from-slack#about
