### PR TITLE
conversation: Fix call to post function

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -134,7 +134,7 @@ func (api *Client) GetConversationsForUserContext(ctx context.Context, params *G
 		ResponseMetaData responseMetaData `json:"response_metadata"`
 		SlackResponse
 	}{}
-	err = post(ctx, api.httpclient, "users.conversations", values, &response, api.debug)
+	err = postSlackMethod(ctx, api.httpclient, "users.conversations", values, &response, api.debug)
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
Current version fails with error: `./conversation.go:137:8: undefined: post`

This error is introduced by the latest commit, I assume it's supposed to be `postSlackMethod`