### PR TITLE
Count characters rather than bytes

### DIFF
--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -274,7 +274,7 @@ func (rtm *RTM) sendWithDeadline(msg interface{}) error {
 // and instead lets a future failed 'PING' detect the failed connection.
 func (rtm *RTM) sendOutgoingMessage(msg OutgoingMessage) {
 	rtm.Debugln("Sending message:", msg)
-	if len(msg.Text) > MaxMessageTextLength {
+	if len([]rune(msg.Text)) > MaxMessageTextLength {
 		rtm.IncomingEvents <- RTMEvent{"outgoing_error", &MessageTooLongEvent{
 			Message:   msg,
 			MaxLength: MaxMessageTextLength,


### PR DESCRIPTION
The limit suggested by Slack is referring to the number of characters, not the number of bytes which is returned from len() on a string. Converting to a rune slice is a quick way to get the correct number of characters in the message text.