### PR TITLE
add `channels` optional argument to usergroups.update

### DIFF
--- a/usergroups.go
+++ b/usergroups.go
@@ -210,6 +210,10 @@ func (api *Client) UpdateUserGroupContext(ctx context.Context, userGroup UserGro
 		values["description"] = []string{userGroup.Description}
 	}
 
+	if len(userGroup.Prefs.Channels) > 0 {
+		values["channels"] = []string{strings.Join(userGroup.Prefs.Channels, ",")}
+	}
+
 	response, err := userGroupRequest(ctx, api.httpclient, "usergroups.update", values, api.debug)
 	if err != nil {
 		return UserGroup{}, err


### PR DESCRIPTION
[usergroups.update](https://api.slack.com/methods/usergroups.update) allows an optional argument, `channels`, for setting the list of default channels for the User Group. We should send this argument if it's provided.