### PR TITLE
Add chat.getPermalink support

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -474,7 +474,7 @@ func (api *Client) GetPermalinkContext(ctx context.Context, params *PermalinkPar
 		Permalink string `json:"permalink"`
 		SlackResponse
 	}{}
-	err := getSlackMethod(ctx, api.httpclient, "chat.getPermalink", values, &response, api.debug)
+	err := getSlackMethod(ctx, api.httpclient, "chat.getPermalink", values, &response, api)
 	if err != nil {
 		return "", err
 	}

--- a/chat.go
+++ b/chat.go
@@ -445,3 +445,38 @@ func MsgOptionPostMessageParameters(params PostMessageParameters) MsgOption {
 		return nil
 	}
 }
+
+// PermalinkParameters are the parameters required to get a permalink to a
+// message. Slack documentation can be found here:
+// https://api.slack.com/methods/chat.getPermalink
+type PermalinkParameters struct {
+	Channel string
+	Ts      string
+}
+
+// GetPermalink returns the permalink for a message. It takes
+// PermalinkParameters and returns a string containing the permalink. It
+// returns an error if unable to retrieve the permalink.
+func (api *Client) GetPermalink(params *PermalinkParameters) (string, error) {
+	return api.GetPermalinkContext(context.Background(), params)
+}
+
+// GetPermalinkContext returns the permalink for a message using a custom context.
+func (api *Client) GetPermalinkContext(ctx context.Context, params *PermalinkParameters) (string, error) {
+	values := url.Values{
+		"token":      {api.token},
+		"channel":    {params.Channel},
+		"message_ts": {params.Ts},
+	}
+
+	response := struct {
+		Channel   string `json:"channel"`
+		Permalink string `json:"permalink"`
+		SlackResponse
+	}{}
+	err := getSlackMethod(ctx, api.httpclient, "chat.getPermalink", values, &response, api.debug)
+	if err != nil {
+		return "", err
+	}
+	return response.Permalink, response.Err()
+}

--- a/chat_test.go
+++ b/chat_test.go
@@ -30,3 +30,41 @@ func TestPostMessageInvalidChannel(t *testing.T) {
 		return
 	}
 }
+
+func TestGetPermalink(t *testing.T) {
+	channel := "C1H9RESGA"
+	timeStamp := "p135854651500008"
+
+	http.HandleFunc("/chat.getPermalink", func(rw http.ResponseWriter, r *http.Request) {
+
+		if got, want := r.Header.Get("Content-Type"), "application/x-www-form-urlencoded"; got != want {
+			t.Errorf("request uses unexpected content type: got %s, want %s", got, want)
+		}
+
+		if got, want := r.URL.Query().Get("channel"), channel; got != want {
+			t.Errorf("request contains unexpected channel: got %s, want %s", got, want)
+		}
+
+		if got, want := r.URL.Query().Get("message_ts"), timeStamp; got != want {
+			t.Errorf("request contains unexpected message timestamp: got %s, want %s", got, want)
+		}
+
+		rw.Header().Set("Content-Type", "application/json")
+		response := []byte("{\"ok\": true, \"channel\": \"" + channel + "\", \"permalink\": \"https://ghostbusters.slack.com/archives/" + channel + "/" + timeStamp + "\"}")
+		rw.Write(response)
+	})
+
+	once.Do(startServer)
+	SLACK_API = "http://" + serverAddr + "/"
+	api := New("testing-token")
+	pp := PermalinkParameters{Channel: channel, Ts: timeStamp}
+	pl, err := api.GetPermalink(&pp)
+
+	if got, want := pl, "https://ghostbusters.slack.com/archives/C1H9RESGA/p135854651500008"; got != want {
+		t.Errorf("unexpected permalink: got %s, want %s", got, want)
+	}
+
+	if err != nil {
+		t.Errorf("unexpected error returned: %v", err)
+	}
+}

--- a/chat_test.go
+++ b/chat_test.go
@@ -55,7 +55,7 @@ func TestGetPermalink(t *testing.T) {
 	})
 
 	once.Do(startServer)
-	SLACK_API = "http://" + serverAddr + "/"
+	APIURL = "http://" + serverAddr + "/"
 	api := New("testing-token")
 	pp := PermalinkParameters{Channel: channel, Ts: timeStamp}
 	pl, err := api.GetPermalink(&pp)

--- a/misc.go
+++ b/misc.go
@@ -199,6 +199,22 @@ func postSlackMethod(ctx context.Context, client httpClient, path string, values
 	return postForm(ctx, client, APIURL+path, values, intf, d)
 }
 
+// get a slack web method.
+func getSlackMethod(ctx context.Context, client HTTPRequester, path string, values url.Values, intf interface{}, debug bool) error {
+	return getResource(ctx, client, SLACK_API+path, values, intf, debug)
+}
+
+func getResource(ctx context.Context, client HTTPRequester, endpoint string, values url.Values, intf interface{}, debug bool) error {
+	req, err := http.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.URL.RawQuery = values.Encode()
+
+	return doPost(ctx, client, req, intf, debug)
+}
+
 func parseAdminResponse(ctx context.Context, client httpClient, method string, teamName string, values url.Values, intf interface{}, d debug) error {
 	endpoint := fmt.Sprintf(WEBAPIURLFormat, teamName, method, time.Now().Unix())
 	return postForm(ctx, client, endpoint, values, intf, d)

--- a/misc.go
+++ b/misc.go
@@ -200,11 +200,11 @@ func postSlackMethod(ctx context.Context, client httpClient, path string, values
 }
 
 // get a slack web method.
-func getSlackMethod(ctx context.Context, client HTTPRequester, path string, values url.Values, intf interface{}, debug bool) error {
-	return getResource(ctx, client, SLACK_API+path, values, intf, debug)
+func getSlackMethod(ctx context.Context, client httpClient, path string, values url.Values, intf interface{}, d debug) error {
+	return getResource(ctx, client, APIURL+path, values, intf, d)
 }
 
-func getResource(ctx context.Context, client HTTPRequester, endpoint string, values url.Values, intf interface{}, debug bool) error {
+func getResource(ctx context.Context, client httpClient, endpoint string, values url.Values, intf interface{}, d debug) error {
 	req, err := http.NewRequest("GET", endpoint, nil)
 	if err != nil {
 		return err
@@ -212,7 +212,7 @@ func getResource(ctx context.Context, client HTTPRequester, endpoint string, val
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.URL.RawQuery = values.Encode()
 
-	return doPost(ctx, client, req, intf, debug)
+	return doPost(ctx, client, req, intf, d)
 }
 
 func parseAdminResponse(ctx context.Context, client httpClient, method string, teamName string, values url.Values, intf interface{}, d debug) error {


### PR DESCRIPTION
Fixes #411 by providing a GetPermalink function. Included tests validate a successful request and associated response.