### PR TITLE
Use v0.8.0 of github.com/pkg/errors

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,10 +14,10 @@
   version = "v1.2.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/pkg/errors"
   packages = ["."]
-  revision = "816c9085562cd7ee03e7f8188a1cfd942858cded"
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
 
 [[projects]]
   name = "github.com/pmezard/go-difflib"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -10,7 +10,7 @@ ignored = ["github.com/lusis/slack-test"]
 
 [[constraint]]
   name = "github.com/pkg/errors"
-  branch = "master"
+  version = "0.8.0"
 
 [prune]
   go-tests = true

--- a/vendor/github.com/pkg/errors/.travis.yml
+++ b/vendor/github.com/pkg/errors/.travis.yml
@@ -1,13 +1,10 @@
 language: go
 go_import_path: github.com/pkg/errors
 go:
-  - 1.4.x
-  - 1.5.x
-  - 1.6.x
-  - 1.7.x
-  - 1.8.x
-  - 1.9.x
-  - 1.10.x
+  - 1.4.3
+  - 1.5.4
+  - 1.6.2
+  - 1.7.1
   - tip
 
 script:

--- a/vendor/github.com/pkg/errors/README.md
+++ b/vendor/github.com/pkg/errors/README.md
@@ -1,4 +1,4 @@
-# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![AppVeyor](https://ci.appveyor.com/api/projects/status/b98mptawhudj53ep/branch/master?svg=true)](https://ci.appveyor.com/project/davecheney/errors/branch/master) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors) [![Sourcegraph](https://sourcegraph.com/github.com/pkg/errors/-/badge.svg)](https://sourcegraph.com/github.com/pkg/errors?badge)
+# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![AppVeyor](https://ci.appveyor.com/api/projects/status/b98mptawhudj53ep/branch/master?svg=true)](https://ci.appveyor.com/project/davecheney/errors/branch/master) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors)
 
 Package errors provides simple error handling primitives.
 
@@ -47,6 +47,6 @@ We welcome pull requests, bug fixes and issue reports. With that said, the bar f
 
 Before proposing a change, please discuss your change by raising an issue.
 
-## License
+## Licence
 
 BSD-2-Clause

--- a/vendor/github.com/pkg/errors/stack.go
+++ b/vendor/github.com/pkg/errors/stack.go
@@ -46,8 +46,7 @@ func (f Frame) line() int {
 //
 // Format accepts flags that alter the printing of some verbs, as follows:
 //
-//    %+s   function name and path of source file relative to the compile time
-//          GOPATH separated by \n\t (<funcname>\n\t<path>)
+//    %+s   path of source file relative to the compile time GOPATH
 //    %+v   equivalent to %+s:%d
 func (f Frame) Format(s fmt.State, verb rune) {
 	switch verb {
@@ -80,14 +79,6 @@ func (f Frame) Format(s fmt.State, verb rune) {
 // StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
 type StackTrace []Frame
 
-// Format formats the stack of Frames according to the fmt.Formatter interface.
-//
-//    %s	lists source files for each Frame in the stack
-//    %v	lists the source file and line number for each Frame in the stack
-//
-// Format accepts flags that alter the printing of some verbs, as follows:
-//
-//    %+v   Prints filename, function, and line number for each Frame in the stack.
 func (st StackTrace) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':
@@ -144,4 +135,44 @@ func funcname(name string) string {
 	name = name[i+1:]
 	i = strings.Index(name, ".")
 	return name[i+1:]
+}
+
+func trimGOPATH(name, file string) string {
+	// Here we want to get the source file path relative to the compile time
+	// GOPATH. As of Go 1.6.x there is no direct way to know the compiled
+	// GOPATH at runtime, but we can infer the number of path segments in the
+	// GOPATH. We note that fn.Name() returns the function name qualified by
+	// the import path, which does not include the GOPATH. Thus we can trim
+	// segments from the beginning of the file path until the number of path
+	// separators remaining is one more than the number of path separators in
+	// the function name. For example, given:
+	//
+	//    GOPATH     /home/user
+	//    file       /home/user/src/pkg/sub/file.go
+	//    fn.Name()  pkg/sub.Type.Method
+	//
+	// We want to produce:
+	//
+	//    pkg/sub/file.go
+	//
+	// From this we can easily see that fn.Name() has one less path separator
+	// than our desired output. We count separators from the end of the file
+	// path until it finds two more than in the function name and then move
+	// one character forward to preserve the initial path segment without a
+	// leading separator.
+	const sep = "/"
+	goal := strings.Count(name, sep) + 2
+	i := len(file)
+	for n := 0; n < goal; n++ {
+		i = strings.LastIndex(file[:i], sep)
+		if i == -1 {
+			// not enough separators found, set i so that the slice expression
+			// below leaves file unmodified
+			i = -len(sep)
+			break
+		}
+	}
+	// get back to 0 or trim the leading separator
+	file = file[i+len(sep):]
+	return file
 }


### PR DESCRIPTION
# Context

There is a transitive dependency resolution error with `dep ensure` when using this slack package on `master` (which pins [github.com/pkg/errors][1] on `master`) because it conflicts with other libraries that pin other versions on the same `errors` package.

## Example
Gopkg.toml
```
[[constraint]]
  name = "github.com/andygrunwald/go-jira"
  version = "1.5.0"

[[constraint]]
  name = "github.com/nlopes/slack"
  branch = "master"

[prune]
  go-tests = true
  unused-packages = true
```

main.go
```
package main

import (
	"fmt"
	"os"

	jira "github.com/andygrunwald/go-jira"
	"github.com/nlopes/slack"
)

func main() {
	jiraClient, _ := jira.NewClient(nil, "https://issues.apache.org/jira/")
	fmt.Printf("Jira Client: %+v", jiraClient)

	slackToken := os.Getenv("SLACK_TOKEN")
	slackClient := slack.New(slackToken, nil)
	fmt.Printf("Slack Client: %+v", slackClient)
}
```

Error seen from `dep ensure`:
```
$ dep ensure
Solving failure: No versions of github.com/andygrunwald/go-jira met constraints:
	v1.5.0: Could not introduce github.com/andygrunwald/go-jira@v1.5.0, as it has a dependency on github.com/pkg/errors with constraint ^0.8.0, which has no overlap with existing constraint master from github.com/nlopes/slack@master
	v1.4.0: Could not introduce github.com/andygrunwald/go-jira@v1.4.0, as it is not allowed by constraint ^1.5.0 from project github.com/ailsachiu/test.
	v1.3.0: Could not introduce github.com/andygrunwald/go-jira@v1.3.0, as it is not allowed by constraint ^1.5.0 from project github.com/ailsachiu/test.
	v1.2.0: Could not introduce github.com/andygrunwald/go-jira@v1.2.0, as it is not allowed by constraint ^1.5.0 from project github.com/ailsachiu/test.
	v1.1.0: Could not introduce github.com/andygrunwald/go-jira@v1.1.0, as it is not allowed by constraint ^1.5.0 from project github.com/ailsachiu/test.
	v1.0.0: Could not introduce github.com/andygrunwald/go-jira@v1.0.0, as it is not allowed by constraint ^1.5.0 from project github.com/ailsachiu/test.
	master: Could not introduce github.com/andygrunwald/go-jira@master, as it is not allowed by constraint ^1.5.0 from project github.com/ailsachiu/test.
	bob/handler_experiment: Could not introduce github.com/andygrunwald/go-jira@bob/handler_experiment, as it is not allowed by constraint ^1.5.0 from project github.com/ailsachiu/test.
```

`go-jira@1.5.0` pins to `v0.8.0`: https://github.com/andygrunwald/go-jira/blob/v1.5.0/Gopkg.toml#L36-L38

# Objective

Use `v0.8.0` for [github.com/pkg/errors][1].

Based on this comparison between `v0.8.0` to `master` branch https://github.com/pkg/errors/compare/master...v0.8.0, the major difference seems to be the `trimGOPATH` function, which this package is not using anyway. The other changes seem related to their build and tests.

[1]: https://github.com/pkg/errors