### PR TITLE
[minor] Add option to skip verification token check on slackevents.ParseEvent

### DIFF
--- a/slackevents/parsers.go
+++ b/slackevents/parsers.go
@@ -143,6 +143,13 @@ func OptionVerifyToken(v verifier) Option {
 	}
 }
 
+// OptionNoVerifyToken skips the check of the Slack verification token
+func OptionNoVerifyToken() Option {
+	return func(cfg *Config) {
+		cfg.TokenVerified = true
+	}
+}
+
 type TokenComparator struct {
 	VerificationToken string
 }

--- a/slackevents/parsers_test.go
+++ b/slackevents/parsers_test.go
@@ -128,3 +128,18 @@ func TestBadTokenVerification(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestNoTokenVerification(t *testing.T) {
+	urlVerificationEvent := `
+		{
+			"token": "fake-token",
+			"challenge": "aljdsflaji3jj",
+			"type": "url_verification"
+		}
+	`
+	_, e := ParseEvent(json.RawMessage(urlVerificationEvent), OptionNoVerifyToken())
+	if e != nil {
+		fmt.Println(e)
+		t.Fail()
+	}
+}


### PR DESCRIPTION
## Context

For teams that have moved to using the new [Signing Secrets](https://github.com/nlopes/slack/issues/353), they may want to disable the use of Verification Tokens.

Normally, you would pass `OptionVerifyToken(...)` to the `slackevents.ParseEvent` function.  If you chose not to send any options, the function would return with `Invalid verification token`.

## Objective

By passing `OptionNoVerifyToken()` to `slackevents.ParseEvent`, the token check is skipped and no error is returned.