### PR TITLE
Add ReplaceOriginal field to PostMessageParameters

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -21,6 +21,7 @@ const (
 	DEFAULT_MESSAGE_ICON_EMOJI       = ""
 	DEFAULT_MESSAGE_MARKDOWN         = true
 	DEFAULT_MESSAGE_ESCAPE_TEXT      = true
+	DEFAULT_MESSAGE_REPLACE_ORIGINAL = false
 )
 
 type chatResponseFull struct {
@@ -56,6 +57,7 @@ type PostMessageParameters struct {
 	IconEmoji       string       `json:"icon_emoji"`
 	Markdown        bool         `json:"mrkdwn,omitempty"`
 	EscapeText      bool         `json:"escape_text"`
+	ReplaceOriginal bool         `json:"replace_original"`
 
 	// chat.postEphemeral support
 	Channel string `json:"channel"`
@@ -78,6 +80,7 @@ func NewPostMessageParameters() PostMessageParameters {
 		IconEmoji:       DEFAULT_MESSAGE_ICON_EMOJI,
 		Markdown:        DEFAULT_MESSAGE_MARKDOWN,
 		EscapeText:      DEFAULT_MESSAGE_ESCAPE_TEXT,
+		ReplaceOriginal: DEFAULT_MESSAGE_REPLACE_ORIGINAL,
 	}
 }
 


### PR DESCRIPTION
Add the ReplaceOriginal/replace_original field for support of interactive messages

When responding to messages the `replace_original` field is needed to prevent an update to the message.

https://api.slack.com/interactive-messages

```
Responding immediately with a JSON message body will replace the current message in its entirety by default. If you explicitly indicate that you want to create a new message instead, specify a literal false in the replace_original field.
```