### PR TITLE
Added auth.revoke endpoint

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,43 @@
+package slack
+
+import (
+	"context"
+	"errors"
+	"net/url"
+)
+
+// AuthRevokeResponse contains our Auth response from the auth.revoke endpoint
+type AuthRevokeResponse struct {
+	SlackResponse      // Contains the "ok", and "Error", if any
+	Revoked       bool `json:"revoked,omitempty"`
+}
+
+// authRequest sends the actual request, and unmarshals the response
+func authRequest(ctx context.Context, client HTTPRequester, path string, values url.Values, debug bool) (*AuthRevokeResponse, error) {
+	response := &AuthRevokeResponse{}
+	err := postSlackMethod(ctx, client, path, values, response, debug)
+	if err != nil {
+		return nil, err
+	}
+	if !response.Ok {
+		return nil, errors.New(response.Error)
+	}
+	return response, nil
+}
+
+// SendAuthRevoke will send a revocation for our token
+func (api *Client) SendAuthRevoke(token string) (*AuthRevokeResponse, error) {
+	return api.SendAuthRevokeContext(context.Background(), token)
+}
+
+// SendAuthRevokeContext will retrieve the satus from api.test
+func (api *Client) SendAuthRevokeContext(ctx context.Context, token string) (*AuthRevokeResponse, error) {
+	if token == "" {
+		token = api.token
+	}
+	values := url.Values{
+		"token": {token},
+	}
+
+	return authRequest(ctx, api.httpclient, "auth.revoke", values, api.debug)
+}


### PR DESCRIPTION

This change adds the auth.revoke endpoint, so that you can revoke your own tokens.