### PR TITLE
Add Name field to MessageActionEntity

### DIFF
--- a/slackevents/action_events.go
+++ b/slackevents/action_events.go
@@ -15,6 +15,7 @@ type MessageActionResponse struct {
 type MessageActionEntity struct {
 	ID     string `json:"id"`
 	Domain string `json:"domain"`
+	Name   string `json:"name"`
 }
 
 type MessageAction struct {


### PR DESCRIPTION
This PR fixes issue #425, For simplicity, I have decided to add to the existing type instead of creating separate for Channel and User 