### PR TITLE
add support for pin events

### DIFF
--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -98,6 +98,33 @@ type MemberJoinedChannelEvent struct {
 	Inviter     string `json:"inviter"`
 }
 
+type pinEvent struct {
+	Type           string `json:"type"`
+	User           string `json:"user"`
+	Item           Item   `json:"item"`
+	Channel        string `json:"channel_id"`
+	EventTimestamp string `json:"event_ts"`
+	HasPins        bool   `json:"has_pins,omitempty"`
+}
+
+// PinAddedEvent An item was pinned to a channel - https://api.slack.com/events/pin_added
+type PinAddedEvent pinEvent
+
+// PinRemovedEvent An item was unpinned from a channel - https://api.slack.com/events/pin_removed
+type PinRemovedEvent pinEvent
+
+// JSONTime exists so that we can have a String method converting the date
+type JSONTime int64
+
+// Comment contains all the information relative to a comment
+type Comment struct {
+	ID        string   `json:"id,omitempty"`
+	Created   JSONTime `json:"created,omitempty"`
+	Timestamp JSONTime `json:"timestamp,omitempty"`
+	User      string   `json:"user,omitempty"`
+	Comment   string   `json:"comment,omitempty"`
+}
+
 // File is a file upload
 type File struct {
 	ID                 string `json:"id"`
@@ -160,6 +187,27 @@ type Icon struct {
 	IconEmoji string `json:"icon_emoji,omitempty"`
 }
 
+// Item is any type of slack message - message, file, or file comment.
+type Item struct {
+	Type      string       `json:"type"`
+	Channel   string       `json:"channel,omitempty"`
+	Message   *ItemMessage `json:"message,omitempty"`
+	File      *File        `json:"file,omitempty"`
+	Comment   *Comment     `json:"comment,omitempty"`
+	Timestamp string       `json:"ts,omitempty"`
+}
+
+// ItemMessage is the event message
+type ItemMessage struct {
+	Type            string   `json:"type"`
+	User            string   `json:"user"`
+	Text            string   `json:"text"`
+	Timestamp       string   `json:"ts"`
+	PinnedTo        []string `json:"pinned_to"`
+	ReplaceOriginal bool     `json:"replace_original"`
+	DeleteOriginal  bool     `json:"delete_original"`
+}
+
 // IsEdited checks if the MessageEvent is caused by an edit
 func (e MessageEvent) IsEdited() bool {
 	return e.Message != nil &&
@@ -181,6 +229,10 @@ const (
 	Message = "message"
 	// Member Joined Channel
 	MemberJoinedChannel = "member_joined_channel"
+	// PinAdded An item was pinned to a channel
+	PinAdded = "pin_added"
+	// PinRemoved An item was unpinned from a channel
+	PinRemoved = "pin_removed"
 )
 
 // EventsAPIInnerEventMapping maps INNER Event API events to their corresponding struct
@@ -194,4 +246,6 @@ var EventsAPIInnerEventMapping = map[string]interface{}{
 	LinkShared:            LinkSharedEvent{},
 	Message:               MessageEvent{},
 	MemberJoinedChannel:   MemberJoinedChannelEvent{},
+	PinAdded:              PinAddedEvent{},
+	PinRemoved:            PinRemovedEvent{},
 }

--- a/slackevents/inner_events_test.go
+++ b/slackevents/inner_events_test.go
@@ -144,3 +144,59 @@ func TestBotMessageEvent(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestPinAdded(t *testing.T) {
+	rawE := []byte(`
+			{
+				"type": "pin_added",
+				"user": "U061F7AUR",
+				"item": {
+					"type": "message",
+					"channel":"C0LAN2Q65",
+					"message":{
+						"type":"message",
+						"user":"U061F7AUR",
+						"text": "<@U0LAN0Z89> is it everything a river should be?",
+						"ts":"1539904112.000100",
+						"pinned_to":["C0LAN2Q65"],
+						"replace_original":false,
+						"delete_original":false
+					}
+				},
+				"channel_id":"C0LAN2Q65",
+				"event_ts": "1515449522000016"
+		}
+	`)
+	err := json.Unmarshal(rawE, &PinAddedEvent{})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestPinRemoved(t *testing.T) {
+	rawE := []byte(`
+			{
+				"type": "pin_removed",
+				"user": "U061F7AUR",
+				"item": {
+					"type": "message",
+					"channel":"C0LAN2Q65",
+					"message":{
+						"type":"message",
+						"user":"U061F7AUR",
+						"text": "<@U0LAN0Z89> is it everything a river should be?",
+						"ts":"1539904112.000100",
+						"pinned_to":["C0LAN2Q65"],
+						"replace_original":false,
+						"delete_original":false
+					}
+				},
+				"channel_id":"C0LAN2Q65",
+				"event_ts": "1515449522000016"
+		}
+	`)
+	err := json.Unmarshal(rawE, &PinRemovedEvent{})
+	if err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
## Objective
We want to be able to handle `pin_added` and `pin_removed` events.
## Context
We want to use this library to handle pin events. When an item is pinned or unpinned in slack we want our app to handle those events.
Most of the new structs in this file are copied pasted from the slack package. The only new is `ItemMessage`. We had to use that name because `Message` is already declared as a constant.

It would be really awesome if we can put structs that are shared between the `slack` and `slackevents` package in a package they both import so we reduce code duplication. But I believe that can be accomplished in a separate PR.