### PR TITLE
 #403 Handle batch_presence_aware

### DIFF
--- a/examples/connparams/connparams.go
+++ b/examples/connparams/connparams.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/nlopes/slack"
+)
+
+func main() {
+	api := slack.New(
+		"YOUR TOKEN HERE",
+		slack.OptionDebug(true),
+		slack.OptionLog(log.New(os.Stdout, "slack-bot: ", log.Lshortfile|log.LstdFlags)),
+	)
+
+	// turn on the batch_presence_aware option
+	rtm := api.NewRTM(slack.RTMOptionConnParams(map[string]string{
+		"batch_presence_aware": "1",
+	}))
+	go rtm.ManageConnection()
+
+	for msg := range rtm.IncomingEvents {
+		fmt.Print("Event Received: ")
+		switch ev := msg.Data.(type) {
+		case *slack.HelloEvent:
+			// Replace USER-ID-N here with your User IDs
+			rtm.SendMessage(rtm.NewSubscribeUserPresence([]string{
+				"USER-ID-1",
+				"USER-ID-2",
+			}))
+
+		case *slack.ConnectedEvent:
+			fmt.Println("Infos:", ev.Info)
+			fmt.Println("Connection counter:", ev.ConnectionCount)
+			// Replace C2147483705 with your Channel ID
+			rtm.SendMessage(rtm.NewOutgoingMessage("Hello world", "C2147483705"))
+
+		case *slack.MessageEvent:
+			fmt.Printf("Message: %v\n", ev)
+
+		case *slack.PresenceChangeEvent:
+			fmt.Printf("Presence Change: %v\n", ev)
+
+		case *slack.LatencyReport:
+			fmt.Printf("Current latency: %v\n", ev.Value)
+
+		case *slack.RTMError:
+			fmt.Printf("Error: %s\n", ev.Error())
+
+		case *slack.InvalidAuthEvent:
+			fmt.Printf("Invalid credentials")
+			return
+
+		default:
+
+			// Ignore other events..
+			// fmt.Printf("Unexpected: %v\n", msg.Data)
+		}
+	}
+}

--- a/examples/connparams/connparams.go
+++ b/examples/connparams/connparams.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 
 	"github.com/nlopes/slack"
@@ -16,8 +17,8 @@ func main() {
 	)
 
 	// turn on the batch_presence_aware option
-	rtm := api.NewRTM(slack.RTMOptionConnParams(map[string]string{
-		"batch_presence_aware": "1",
+	rtm := api.NewRTM(slack.RTMOptionConnParams(url.Values{
+		"batch_presence_aware": {"1"},
 	}))
 	go rtm.ManageConnection()
 

--- a/rtm.go
+++ b/rtm.go
@@ -101,7 +101,7 @@ func RTMOptionPingInterval(d time.Duration) RTMOption {
 }
 
 // RTMOptionConnParams installs parameters to embed into the connection URL.
-func RTMOptionConnParams(connParams map[string]string) RTMOption {
+func RTMOptionConnParams(connParams url.Values) RTMOption {
 	return func(rtm *RTM) {
 		rtm.connParams = connParams
 	}

--- a/rtm.go
+++ b/rtm.go
@@ -100,6 +100,13 @@ func RTMOptionPingInterval(d time.Duration) RTMOption {
 	}
 }
 
+// RTMOptionConnParams installs parameters to embed into the connection URL.
+func RTMOptionConnParams(connParams map[string]string) RTMOption {
+	return func(rtm *RTM) {
+		rtm.connParams = connParams
+	}
+}
+
 // NewRTM returns a RTM, which provides a fully managed connection to
 // Slack's websocket-based Real-Time Messaging protocol.
 func (api *Client) NewRTM(options ...RTMOption) *RTM {

--- a/websocket.go
+++ b/websocket.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"encoding/json"
 	"errors"
+	"net/url"
 	"sync"
 	"time"
 
@@ -56,7 +57,7 @@ type RTM struct {
 	mu *sync.Mutex
 
 	// connParams is a map of flags for connection parameters.
-	connParams map[string]string
+	connParams url.Values
 }
 
 // Disconnect and wait, blocking until a successful disconnection.

--- a/websocket.go
+++ b/websocket.go
@@ -54,6 +54,9 @@ type RTM struct {
 
 	// mu is mutex used to prevent RTM connection race conditions
 	mu *sync.Mutex
+
+	// connParams is a map of flags for connection parameters.
+	connParams map[string]string
 }
 
 // Disconnect and wait, blocking until a successful disconnection.

--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	stdurl "net/url"
 	"reflect"
 	"time"
 
@@ -156,6 +157,18 @@ func (rtm *RTM) startRTMAndDial(useRTMStart bool) (info *Info, _ *websocket.Conn
 		rtm.Debugf("Failed to start or connect to RTM: %s", err)
 		return nil, nil, err
 	}
+
+	// install connection parameters
+	u, err := stdurl.Parse(url)
+	if err != nil {
+		return nil, nil, err
+	}
+	q := u.Query()
+	for k, v := range rtm.connParams {
+		q.Set(k, v)
+	}
+	u.RawQuery = q.Encode()
+	url = u.String()
 
 	rtm.Debugf("Dialing to websocket on url %s", url)
 	// Only use HTTPS for connections to prevent MITM attacks on the connection.

--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -163,11 +163,7 @@ func (rtm *RTM) startRTMAndDial(useRTMStart bool) (info *Info, _ *websocket.Conn
 	if err != nil {
 		return nil, nil, err
 	}
-	q := u.Query()
-	for k, v := range rtm.connParams {
-		q.Set(k, v)
-	}
-	u.RawQuery = q.Encode()
+	u.RawQuery = rtm.connParams.Encode()
 	url = u.String()
 
 	rtm.Debugf("Dialing to websocket on url %s", url)

--- a/websocket_misc.go
+++ b/websocket_misc.go
@@ -43,9 +43,10 @@ type HelloEvent struct{}
 
 // PresenceChangeEvent represents the presence change event
 type PresenceChangeEvent struct {
-	Type     string `json:"type"`
-	Presence string `json:"presence"`
-	User     string `json:"user"`
+	Type     string   `json:"type"`
+	Presence string   `json:"presence"`
+	User     string   `json:"user"`
+	Users    []string `json:"users"`
 }
 
 // UserTypingEvent represents the user typing event


### PR DESCRIPTION
This is in relation to issue #403 

In order to support this:
1. batch_presence_aware is treated as a connection parameter
2. introduce a connParams map to host parameter to embed into the generated connection URL
3. example of usage is given in example/connparams/connparams.go

Kindly help to review, please feel free to feedback. Thanks !