### PR TITLE
Added include_locale in Web APIs

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -173,8 +173,9 @@ func (api *Client) GetChannelInfo(channelID string) (*Channel, error) {
 // see https://api.slack.com/methods/channels.info
 func (api *Client) GetChannelInfoContext(ctx context.Context, channelID string) (*Channel, error) {
 	values := url.Values{
-		"token":   {api.token},
-		"channel": {channelID},
+		"token":          {api.token},
+		"channel":        {channelID},
+		"include_locale": {strconv.FormatBool(true)},
 	}
 
 	response, err := channelRequest(ctx, api.httpclient, "channels.info", values, api)

--- a/groups.go
+++ b/groups.go
@@ -256,8 +256,9 @@ func (api *Client) GetGroupInfo(group string) (*Group, error) {
 // GetGroupInfoContext retrieves the given group with a custom context
 func (api *Client) GetGroupInfoContext(ctx context.Context, group string) (*Group, error) {
 	values := url.Values{
-		"token":   {api.token},
-		"channel": {group},
+		"token":          {api.token},
+		"channel":        {group},
+		"include_locale": {strconv.FormatBool(true)},
 	}
 
 	response, err := groupRequest(ctx, api.httpclient, "groups.info", values, api)

--- a/users.go
+++ b/users.go
@@ -226,8 +226,9 @@ func (api *Client) GetUserInfo(user string) (*User, error) {
 // GetUserInfoContext will retrieve the complete user information with a custom context
 func (api *Client) GetUserInfoContext(ctx context.Context, user string) (*User, error) {
 	values := url.Values{
-		"token": {api.token},
-		"user":  {user},
+		"token":          {api.token},
+		"user":           {user},
+		"include_locale": {"true"},
 	}
 
 	response, err := userRequest(ctx, api.httpclient, "users.info", values, api)

--- a/users.go
+++ b/users.go
@@ -228,7 +228,7 @@ func (api *Client) GetUserInfoContext(ctx context.Context, user string) (*User, 
 	values := url.Values{
 		"token":          {api.token},
 		"user":           {user},
-		"include_locale": {"true"},
+		"include_locale": {strconv.FormatBool(true)},
 	}
 
 	response, err := userRequest(ctx, api.httpclient, "users.info", values, api)
@@ -303,10 +303,11 @@ func (t UserPagination) Next(ctx context.Context) (_ UserPagination, err error) 
 	t.previousResp = t.previousResp.initialize()
 
 	values := url.Values{
-		"limit":    {strconv.Itoa(t.limit)},
-		"presence": {strconv.FormatBool(t.presence)},
-		"token":    {t.c.token},
-		"cursor":   {t.previousResp.Cursor},
+		"limit":          {strconv.Itoa(t.limit)},
+		"presence":       {strconv.FormatBool(t.presence)},
+		"token":          {t.c.token},
+		"cursor":         {t.previousResp.Cursor},
+		"include_locale": {strconv.FormatBool(true)},
 	}
 
 	if resp, err = userRequest(ctx, t.c.httpclient, "users.list", values, t.c); err != nil {


### PR DESCRIPTION
Hi, thank you for building such a great package!
Not sure this is handled by other PRs, but I added `include_locale` in several APIs so that Slack returns locale by default.

According to [Slack doc](https://api.slack.com/changelog/2017-09-locale-locale-locale), the locale is opt-in and doesn't seem to have any side-effect, therefore using it as default is reasonable.

Looking forward for your comments!