### PR TITLE
Error when user forgets to set the Filename when using a Reader for file uploads

### DIFF
--- a/files.go
+++ b/files.go
@@ -93,6 +93,8 @@ type File struct {
 //
 // There are three ways to upload a file. You can either set Content if file is small, set Reader if file is large,
 // or provide a local file path in File to upload it from your filesystem.
+//
+// Note that when using the Reader option, you *must* specify the Filename, otherwise the Slack API isn't happy.
 type FileUploadParameters struct {
 	File            string
 	Content         string

--- a/files.go
+++ b/files.go
@@ -223,6 +223,9 @@ func (api *Client) UploadFileContext(ctx context.Context, params FileUploadParam
 	if err != nil {
 		return nil, err
 	}
+	if params.Filename == "" {
+		return nil, fmt.Errorf("files.upload: FileUploadParameters.Filename is mandatory")
+	}
 	response := &fileResponseFull{}
 	values := url.Values{
 		"token": {api.token},
@@ -251,9 +254,6 @@ func (api *Client) UploadFileContext(ctx context.Context, params FileUploadParam
 	} else if params.File != "" {
 		err = postLocalWithMultipartResponse(ctx, api.httpclient, "files.upload", params.File, "file", values, response, api)
 	} else if params.Reader != nil {
-		if params.Filename == "" {
-			return nil, fmt.Errorf("files.upload: FileUploadParameters.Filename is mandatory when supplying a Reader option")
-		}
 		err = postWithMultipartResponse(ctx, api.httpclient, "files.upload", params.Filename, "file", values, params.Reader, response, api)
 	}
 	if err != nil {

--- a/files.go
+++ b/files.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/url"
 	"strconv"
@@ -248,6 +249,9 @@ func (api *Client) UploadFileContext(ctx context.Context, params FileUploadParam
 	} else if params.File != "" {
 		err = postLocalWithMultipartResponse(ctx, api.httpclient, "files.upload", params.File, "file", values, response, api)
 	} else if params.Reader != nil {
+		if params.Filename == "" {
+			return nil, fmt.Errorf("files.upload: FileUploadParameters.Filename is mandatory when supplying a Reader option")
+		}
 		err = postWithMultipartResponse(ctx, api.httpclient, "files.upload", params.Filename, "file", values, params.Reader, response, api)
 	}
 	if err != nil {

--- a/files_test.go
+++ b/files_test.go
@@ -167,7 +167,7 @@ func TestUploadFileWithoutFilename(t *testing.T) {
 		t.Fatal("Expected error when omitting filename, instead got nil")
 	}
 
-	if !strings.Contains(err.Error(), ".Filename is mandatory when supplying a Reader") {
-		t.Errorf("Error message should mention empty FileUploadParameters.Filename when supplying a Reader to UploadFile")
+	if !strings.Contains(err.Error(), ".Filename is mandatory") {
+		t.Errorf("Error message should mention empty FileUploadParameters.Filename")
 	}
 }

--- a/files_test.go
+++ b/files_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -149,5 +150,24 @@ func TestUploadFile(t *testing.T) {
 		Channels: []string{"CXXXXXXXX"}}
 	if _, err := api.UploadFile(params); err != nil {
 		t.Errorf("Unexpected error: %s", err)
+	}
+}
+
+func TestUploadFileWithoutFilename(t *testing.T) {
+	once.Do(startServer)
+	APIURL = "http://" + serverAddr + "/"
+	api := New("testing-token")
+
+	reader := bytes.NewBufferString("test reader")
+	params := FileUploadParameters{
+		Reader:   reader,
+		Channels: []string{"CXXXXXXXX"}}
+	_, err := api.UploadFile(params)
+	if err == nil {
+		t.Fatal("Expected error when omitting filename, instead got nil")
+	}
+
+	if !strings.Contains(err.Error(), ".Filename is mandatory when supplying a Reader") {
+		t.Errorf("Error message should mention empty FileUploadParameters.Filename when supplying a Reader to UploadFile")
 	}
 }


### PR DESCRIPTION
I just got bit by this issue and took me a while of investigating to get to the bottom. See [this gist](https://gist.github.com/nubunto/030bead224f1829c60149b0b04d2c19e) for more information on how to reproduce.

This PR adds a small piece of documentation to the FileUploadParameters type, specifying that you'll get errors when using the Reader and not providing the Filename.

It also enforces that semantic in the `UploadFileContext` method, by checking when there is a provided Reader, the Filename option is also set. It also adds a test for this behaviour.