### PR TITLE
Update file interface - add shares attribute

### DIFF
--- a/files.go
+++ b/files.go
@@ -94,7 +94,7 @@ type share struct {
 }
 
 type shareFileInfo struct {
-	ReplyUsers      string `json:"reply_users"`
+	ReplyUsers      []string `json:"reply_users"`
 	ReplyUsersCount int    `json:"reply_users_count"`
 	ReplyCount      int    `json:"reply_count"`
 	Ts              string `json:"ts"`

--- a/files.go
+++ b/files.go
@@ -77,16 +77,31 @@ type File struct {
 	Lines            int    `json:"lines"`
 	LinesMore        int    `json:"lines_more"`
 
-	IsPublic        bool        `json:"is_public"`
-	PublicURLShared bool        `json:"public_url_shared"`
-	Channels        []string    `json:"channels"`
-	Groups          []string    `json:"groups"`
-	IMs             []string    `json:"ims"`
-	InitialComment  Comment     `json:"initial_comment"`
-	CommentsCount   int         `json:"comments_count"`
-	NumStars        int         `json:"num_stars"`
-	IsStarred       bool        `json:"is_starred"`
-	Shares          interface{} `json:"shares"`
+	IsPublic        bool     `json:"is_public"`
+	PublicURLShared bool     `json:"public_url_shared"`
+	Channels        []string `json:"channels"`
+	Groups          []string `json:"groups"`
+	IMs             []string `json:"ims"`
+	InitialComment  Comment  `json:"initial_comment"`
+	CommentsCount   int      `json:"comments_count"`
+	NumStars        int      `json:"num_stars"`
+	IsStarred       bool     `json:"is_starred"`
+	Shares          share    `json:"shares"`
+}
+
+type share struct {
+	Public map[string][]shareFileInfo `json:"public"`
+}
+
+type shareFileInfo struct {
+	ReplyUsers      string `json:"reply_users"`
+	ReplyUsersCount int    `json:"reply_users_count"`
+	ReplyCount      int    `json:"reply_count"`
+	Ts              string `json:"ts"`
+	ThreadTs        string `json:"thread_ts"`
+	LatestReply     string `json:"latest_reply"`
+	ChannelName     string `json:"channel_name"`
+	TeamID          string `json:"team_id"`
 }
 
 // FileUploadParameters contains all the parameters necessary (including the optional ones) for an UploadFile() request.

--- a/files.go
+++ b/files.go
@@ -95,13 +95,13 @@ type share struct {
 
 type shareFileInfo struct {
 	ReplyUsers      []string `json:"reply_users"`
-	ReplyUsersCount int    `json:"reply_users_count"`
-	ReplyCount      int    `json:"reply_count"`
-	Ts              string `json:"ts"`
-	ThreadTs        string `json:"thread_ts"`
-	LatestReply     string `json:"latest_reply"`
-	ChannelName     string `json:"channel_name"`
-	TeamID          string `json:"team_id"`
+	ReplyUsersCount int      `json:"reply_users_count"`
+	ReplyCount      int      `json:"reply_count"`
+	Ts              string   `json:"ts"`
+	ThreadTs        string   `json:"thread_ts"`
+	LatestReply     string   `json:"latest_reply"`
+	ChannelName     string   `json:"channel_name"`
+	TeamID          string   `json:"team_id"`
 }
 
 // FileUploadParameters contains all the parameters necessary (including the optional ones) for an UploadFile() request.

--- a/files.go
+++ b/files.go
@@ -86,14 +86,14 @@ type File struct {
 	CommentsCount   int      `json:"comments_count"`
 	NumStars        int      `json:"num_stars"`
 	IsStarred       bool     `json:"is_starred"`
-	Shares          share    `json:"shares"`
+	Shares          Share    `json:"shares"`
 }
 
-type share struct {
-	Public map[string][]shareFileInfo `json:"public"`
+type Share struct {
+	Public map[string][]ShareFileInfo `json:"public"`
 }
 
-type shareFileInfo struct {
+type ShareFileInfo struct {
 	ReplyUsers      []string `json:"reply_users"`
 	ReplyUsersCount int      `json:"reply_users_count"`
 	ReplyCount      int      `json:"reply_count"`

--- a/files.go
+++ b/files.go
@@ -77,15 +77,16 @@ type File struct {
 	Lines            int    `json:"lines"`
 	LinesMore        int    `json:"lines_more"`
 
-	IsPublic        bool     `json:"is_public"`
-	PublicURLShared bool     `json:"public_url_shared"`
-	Channels        []string `json:"channels"`
-	Groups          []string `json:"groups"`
-	IMs             []string `json:"ims"`
-	InitialComment  Comment  `json:"initial_comment"`
-	CommentsCount   int      `json:"comments_count"`
-	NumStars        int      `json:"num_stars"`
-	IsStarred       bool     `json:"is_starred"`
+	IsPublic        bool        `json:"is_public"`
+	PublicURLShared bool        `json:"public_url_shared"`
+	Channels        []string    `json:"channels"`
+	Groups          []string    `json:"groups"`
+	IMs             []string    `json:"ims"`
+	InitialComment  Comment     `json:"initial_comment"`
+	CommentsCount   int         `json:"comments_count"`
+	NumStars        int         `json:"num_stars"`
+	IsStarred       bool        `json:"is_starred"`
+	Shares          interface{} `json:"shares"`
 }
 
 // FileUploadParameters contains all the parameters necessary (including the optional ones) for an UploadFile() request.


### PR DESCRIPTION
We use your library in Go to create a Slack's app and play with files but we find out that the File struct is not up to date from Slack API (https://api.slack.com/methods/files.info). 
So we just add the shares struct.