### PR TITLE
Add previous message to slack message struct on edited messages

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -16,6 +16,7 @@ type OutgoingMessage struct {
 type Message struct {
 	Msg
 	SubMessage *Msg `json:"message,omitempty"`
+	PreviousMessage *Msg `json:"previous_message,omitempty"`
 }
 
 // Msg contains information about a slack message


### PR DESCRIPTION
If a message has been edited then Slack will send the previous message back when using RTM.
This PR just adds the previous message to the `Message` struct if it exists.

I've tested this using my own fork and it works as expected.