### PR TITLE
Fix logging for expected and computed signatures

### DIFF
--- a/security.go
+++ b/security.go
@@ -88,7 +88,7 @@ func (v SecretsVerifier) Ensure() error {
 		return nil
 	}
 
-	return fmt.Errorf("Expected signing signature: %s, but computed: %s", v.signature, computed)
+	return fmt.Errorf("Expected signing signature: %s, but computed: %s", hex.EncodeToString(v.signature), hex.EncodeToString(computed))
 }
 
 func abs64(n int64) int64 {


### PR DESCRIPTION
# Summary
While working on a personal project I noticed that some logging in the `security.go` file wasn't outputting properly. I suppose alternatively we could edit this statement altogether, but logging output looks strange in it's current state. 

## Example current output
`Expected signing signature: 1C_V^K^t-lƕ*", but computed: ^OԬNf3/9Knn1`