### PR TITLE
Add webhooks example

### DIFF
--- a/examples/webhooks/webhooks.go
+++ b/examples/webhooks/webhooks.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/nlopes/slack"
+)
+
+func main() {
+	attachment := slack.Attachment{
+		Color:         "good",
+		Fallback:      "You successfully posted by Incoming Webhook URL!",
+		AuthorName:    "nlopes/slack",
+		AuthorSubname: "github.com",
+		AuthorLink:    "https://github.com/nlopes/slack",
+		AuthorIcon:    "https://avatars2.githubusercontent.com/u/652790",
+		Text:          "<!channel> All text in Slack uses the same system of escaping: chat messages, direct messages, file comments, etc. :smile:\nSee <https://api.slack.com/docs/message-formatting#linking_to_channels_and_users>",
+		Footer:        "slack api",
+		FooterIcon:    "https://platform.slack-edge.com/img/default_application_icon.png",
+		Ts:            json.Number(strconv.FormatInt(time.Now().Unix(), 10)),
+	}
+	msg := slack.WebhookMessage{
+		Attachments: []slack.Attachment{attachment},
+	}
+
+	err := slack.PostWebhook("YOUR_WEBHOOK_URL_HERE", &msg)
+	if err != nil {
+		fmt.Println(err)
+	}
+}


### PR DESCRIPTION
I added the example code of [Incoming Webhooks](https://api.slack.com/incoming-webhooks) that we can most easily try the Slack API.