### PR TITLE
Support `thread_ts` parameter for Incoming Webhook

### DIFF
--- a/webhooks.go
+++ b/webhooks.go
@@ -13,6 +13,7 @@ type WebhookMessage struct {
 	IconEmoji   string       `json:"icon_emoji,omitempty"`
 	IconURL     string       `json:"icon_url,omitempty"`
 	Channel     string       `json:"channel,omitempty"`
+	ThreadTS    string       `json:"thread_ts,omitempty"`
 	Text        string       `json:"text,omitempty"`
 	Attachments []Attachment `json:"attachments,omitempty"`
 }

--- a/webhooks.go
+++ b/webhooks.go
@@ -9,13 +9,13 @@ import (
 )
 
 type WebhookMessage struct {
-	Username    string       `json:"username,omitempty"`
-	IconEmoji   string       `json:"icon_emoji,omitempty"`
-	IconURL     string       `json:"icon_url,omitempty"`
-	Channel     string       `json:"channel,omitempty"`
-	ThreadTS    string       `json:"thread_ts,omitempty"`
-	Text        string       `json:"text,omitempty"`
-	Attachments []Attachment `json:"attachments,omitempty"`
+	Username         string       `json:"username,omitempty"`
+	IconEmoji        string       `json:"icon_emoji,omitempty"`
+	IconURL          string       `json:"icon_url,omitempty"`
+	Channel          string       `json:"channel,omitempty"`
+	ThreadTimestamp  string       `json:"thread_ts,omitempty"`
+	Text             string       `json:"text,omitempty"`
+	Attachments      []Attachment `json:"attachments,omitempty"`
 }
 
 func PostWebhook(url string, msg *WebhookMessage) error {


### PR DESCRIPTION
Support `thread_ts` parameter for replying on existing threads via Incoming Webhooks.
Verification for API support can be checked [here](https://api.slack.com/incoming-webhooks).