### PR TITLE
Fix misconfigured package name used in examples/blocks/blocks.go

### DIFF
--- a/examples/blocks/blocks.go
+++ b/examples/blocks/blocks.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/MattDavisRV/slack"
+	"github.com/nlopes/slack"
 )
 
 // The functions below mock the different templates slack has as examples on their website.


### PR DESCRIPTION
`examples/blocks/blocks.go` was introduced in #480, but it doesn't use `nlopes/slack` package, but the PR's author's package.

I think that it is better to use the upstream repository, `nlpopes/slack`, to avoid confusion when running examples.
