### PR TITLE
Block related interface changes/utility additions

### DIFF
--- a/block.go
+++ b/block.go
@@ -31,6 +31,12 @@ const (
 
 // block defines an interface all block types should implement
 // to ensure consistency between blocks.
+type block interface {
+	blockType() MessageBlockType
+}
+
+// Block is the exported version of the block interface and is used to pass
+// multiple blocks in exported variadic functions, etc.
 type Block interface {
 	blockType() MessageBlockType
 }
@@ -45,7 +51,7 @@ func NewBlockMessage(blocks ...Block) Message {
 }
 
 // AddBlockMessage appends a block to the end of the existing list of blocks
-func AddBlockMessage(message Message, newBlk Block) Message {
+func AddBlockMessage(message Message, newBlk block) Message {
 	message.Msg.Blocks = append(message.Msg.Blocks, newBlk)
 	return message
 }

--- a/block.go
+++ b/block.go
@@ -29,14 +29,8 @@ const (
 	motOptionGroup  MessageObjectType = "option_group"
 )
 
-// block defines an interface all block types should implement
+// Block defines an interface all block types should implement
 // to ensure consistency between blocks.
-type block interface {
-	blockType() MessageBlockType
-}
-
-// Block is the exported version of the block interface and is used to pass
-// multiple blocks in exported variadic functions, etc.
 type Block interface {
 	blockType() MessageBlockType
 }
@@ -51,7 +45,7 @@ func NewBlockMessage(blocks ...Block) Message {
 }
 
 // AddBlockMessage appends a block to the end of the existing list of blocks
-func AddBlockMessage(message Message, newBlk block) Message {
+func AddBlockMessage(message Message, newBlk Block) Message {
 	message.Msg.Blocks = append(message.Msg.Blocks, newBlk)
 	return message
 }

--- a/block.go
+++ b/block.go
@@ -31,12 +31,12 @@ const (
 
 // block defines an interface all block types should implement
 // to ensure consistency between blocks.
-type block interface {
+type Block interface {
 	blockType() MessageBlockType
 }
 
 // NewBlockMessage creates a new Message that contains one or more blocks to be displayed
-func NewBlockMessage(blocks ...block) Message {
+func NewBlockMessage(blocks ...Block) Message {
 	return Message{
 		Msg: Msg{
 			Blocks: blocks,
@@ -45,7 +45,7 @@ func NewBlockMessage(blocks ...block) Message {
 }
 
 // AddBlockMessage appends a block to the end of the existing list of blocks
-func AddBlockMessage(message Message, newBlk block) Message {
+func AddBlockMessage(message Message, newBlk Block) Message {
 	message.Msg.Blocks = append(message.Msg.Blocks, newBlk)
 	return message
 }

--- a/block_action.go
+++ b/block_action.go
@@ -6,7 +6,7 @@ package slack
 type ActionBlock struct {
 	Type     MessageBlockType `json:"type"`
 	BlockID  string           `json:"block_id,omitempty"`
-	Elements []blockElement   `json:"elements"`
+	Elements []BlockElement   `json:"elements"`
 }
 
 // blockType returns the type of the block
@@ -15,7 +15,7 @@ func (s ActionBlock) blockType() MessageBlockType {
 }
 
 // NewActionBlock returns a new instance of an Action Block
-func NewActionBlock(blockID string, elements ...blockElement) *ActionBlock {
+func NewActionBlock(blockID string, elements ...BlockElement) *ActionBlock {
 	return &ActionBlock{
 		Type:     mbtAction,
 		BlockID:  blockID,

--- a/block_context.go
+++ b/block_context.go
@@ -7,7 +7,7 @@ package slack
 type ContextBlock struct {
 	Type     MessageBlockType `json:"type"`
 	BlockID  string           `json:"block_id,omitempty"`
-	Elements []blockObject    `json:"elements"`
+	Elements []BlockObject    `json:"elements"`
 }
 
 // blockType returns the type of the block
@@ -16,7 +16,7 @@ func (s ContextBlock) blockType() MessageBlockType {
 }
 
 // NewContextBlock returns a newinstance of a context block
-func NewContextBlock(blockID string, elements ...blockObject) *ContextBlock {
+func NewContextBlock(blockID string, elements ...BlockObject) *ContextBlock {
 	return &ContextBlock{
 		Type:     mbtContext,
 		BlockID:  blockID,

--- a/block_divider.go
+++ b/block_divider.go
@@ -15,7 +15,6 @@ func (s DividerBlock) blockType() MessageBlockType {
 
 // NewDividerBlock returns a new instance of a divider block
 func NewDividerBlock() *DividerBlock {
-
 	return &DividerBlock{
 		Type: mbtDivider,
 	}

--- a/block_element.go
+++ b/block_element.go
@@ -2,9 +2,8 @@ package slack
 
 // https://api.slack.com/reference/messaging/block-elements
 
-// blockElement defines an interface that all block element types should
-// implement.
-type blockElement interface {
+// BlockElement defines an interface that all block element types should implement.
+type BlockElement interface {
 	blockType() MessageElementType
 }
 

--- a/block_element.go
+++ b/block_element.go
@@ -2,7 +2,13 @@ package slack
 
 // https://api.slack.com/reference/messaging/block-elements
 
-// BlockElement defines an interface that all block element types should implement.
+// blockElement defines an interface that all block element types should implement.
+type blockElement interface {
+	blockType() MessageElementType
+}
+
+// BlockElement is the exported version of the blockElement interface and is
+// used to pass multiple blockElements in exported variadic functions, etc.
 type BlockElement interface {
 	blockType() MessageElementType
 }

--- a/block_element.go
+++ b/block_element.go
@@ -2,13 +2,7 @@ package slack
 
 // https://api.slack.com/reference/messaging/block-elements
 
-// blockElement defines an interface that all block element types should implement.
-type blockElement interface {
-	blockType() MessageElementType
-}
-
-// BlockElement is the exported version of the blockElement interface and is
-// used to pass multiple blockElements in exported variadic functions, etc.
+// BlockElement defines an interface that all block element types should implement.
 type BlockElement interface {
 	blockType() MessageElementType
 }

--- a/block_object.go
+++ b/block_object.go
@@ -7,7 +7,7 @@ package slack
 // BlockObject defines an interface that all block object types should
 // implement.
 // @TODO: Is this interface needed?
-type blockObject interface {
+type BlockObject interface {
 	validateType() MessageObjectType
 }
 

--- a/block_object.go
+++ b/block_object.go
@@ -11,6 +11,7 @@ type BlockObject interface {
 	validateType() MessageObjectType
 }
 
+// BlockObject object types
 const (
 	MarkdownType  = "mrkdwn"
 	PlainTextType = "plain_text"

--- a/block_object.go
+++ b/block_object.go
@@ -11,6 +11,11 @@ type blockObject interface {
 	validateType() MessageObjectType
 }
 
+const (
+	MarkdownType  = "mrkdwn"
+	PlainTextType = "plain_text"
+)
+
 // ImageBlockObject An element to insert an image - this element can be used
 // in section and context blocks only. If you want a block with only an image
 // in it, you're looking for the image block.

--- a/block_section.go
+++ b/block_section.go
@@ -8,7 +8,7 @@ type SectionBlock struct {
 	Text      *TextBlockObject   `json:"text,omitempty"`
 	BlockID   string             `json:"block_id,omitempty"`
 	Fields    []*TextBlockObject `json:"fields,omitempty"`
-	Accessory blockElement       `json:"accessory,omitempty"`
+	Accessory BlockElement       `json:"accessory,omitempty"`
 }
 
 // blockType returns the type of the block
@@ -17,7 +17,7 @@ func (s SectionBlock) blockType() MessageBlockType {
 }
 
 // NewSectionBlock returns a new instance of a section block to be rendered
-func NewSectionBlock(textObj *TextBlockObject, fields []*TextBlockObject, accessory blockElement) *SectionBlock {
+func NewSectionBlock(textObj *TextBlockObject, fields []*TextBlockObject, accessory BlockElement) *SectionBlock {
 	return &SectionBlock{
 		Type:      mbtSection,
 		Text:      textObj,

--- a/block_section.go
+++ b/block_section.go
@@ -8,7 +8,7 @@ type SectionBlock struct {
 	Text      *TextBlockObject   `json:"text,omitempty"`
 	BlockID   string             `json:"block_id,omitempty"`
 	Fields    []*TextBlockObject `json:"fields,omitempty"`
-	Accessory BlockElement       `json:"accessory,omitempty"`
+	Accessory blockElement       `json:"accessory,omitempty"`
 }
 
 // blockType returns the type of the block
@@ -17,7 +17,7 @@ func (s SectionBlock) blockType() MessageBlockType {
 }
 
 // NewSectionBlock returns a new instance of a section block to be rendered
-func NewSectionBlock(textObj *TextBlockObject, fields []*TextBlockObject, accessory BlockElement) *SectionBlock {
+func NewSectionBlock(textObj *TextBlockObject, fields []*TextBlockObject, accessory blockElement) *SectionBlock {
 	return &SectionBlock{
 		Type:      mbtSection,
 		Text:      textObj,

--- a/chat.go
+++ b/chat.go
@@ -330,6 +330,21 @@ func MsgOptionAttachments(attachments ...Attachment) MsgOption {
 	}
 }
 
+// MsgOptionBlocks sets blocks for the message
+func MsgOptionBlocks(blocks ...Block) MsgOption {
+	return func(config *sendConfig) error {
+		if blocks == nil {
+			return nil
+		}
+
+		blocks, err := json.Marshal(blocks)
+		if err == nil {
+			config.values.Set("blocks", string(blocks))
+		}
+		return err
+	}
+}
+
 // MsgOptionEnableLinkUnfurl enables link unfurling
 func MsgOptionEnableLinkUnfurl() MsgOption {
 	return func(config *sendConfig) error {

--- a/messages.go
+++ b/messages.go
@@ -94,7 +94,7 @@ type Msg struct {
 	DeleteOriginal  bool   `json:"delete_original"`
 
 	// Block type Message
-	Blocks []block `json:"blocks,omitempty"`
+	Blocks []Block `json:"blocks,omitempty"`
 }
 
 // Icon is used for bot messages


### PR DESCRIPTION
# Summary 
Started messing around with blocks on some pet projects and there were a few changes I thought might be helpful. Have tested locally, but just started using blocks very recently so please feel free to let me know if I'm missing anything. 

### Changes
I split each of the three changes in this PR into separate commits:
1. **Exporting the block/blockElement interfaces**
The main reason I did this was so that I could use an array of elements/blocks with variadic functions such as `NewActionBlock` and `MsgOptionBlocks` (new method I added in this PR).
2. **Adding a `MsgOption` helper method for blocks**
This is pretty self-explanatory. I personally found the attachment version helpful and would like to have a block counterpart.
3. **Adding exported consts for both of the text object types**
Just didn't like having to input the text value every time here.