### PR TITLE
rtm disconnect cleanup

### DIFF
--- a/dialog.go
+++ b/dialog.go
@@ -3,7 +3,6 @@ package slack
 import (
 	"context"
 	"encoding/json"
-	"errors"
 )
 
 // InputType is the type of the dialog input type
@@ -89,7 +88,7 @@ func (api *Client) OpenDialog(triggerID string, dialog Dialog) (err error) {
 // EXPERIMENTAL: dialog functionality is currently experimental, api is not considered stable.
 func (api *Client) OpenDialogContext(ctx context.Context, triggerID string, dialog Dialog) (err error) {
 	if triggerID == "" {
-		return errors.New("received empty parameters")
+		return ErrParametersMissing
 	}
 
 	req := DialogTrigger{

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,17 @@
+package slack
+
+import "github.com/nlopes/slack/internal/errorsx"
+
+// Errors returned by various methods.
+const (
+	ErrAlreadyDisconnected  = errorsx.String("Invalid call to Disconnect - Slack API is already disconnected")
+	ErrParametersMissing    = errorsx.String("received empty parameters")
+	ErrInvalidConfiguration = errorsx.String("invalid configuration")
+	ErrMissingHeaders       = errorsx.String("missing headers")
+	ErrExpiredTimestamp     = errorsx.String("timestamp is too old")
+)
+
+// internal errors
+const (
+	errPaginationComplete = errorsx.String("pagination complete")
+)

--- a/files.go
+++ b/files.go
@@ -2,7 +2,6 @@ package slack
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -292,7 +291,7 @@ func (api *Client) DeleteFileComment(commentID, fileID string) error {
 // DeleteFileCommentContext deletes a file's comment with a custom context
 func (api *Client) DeleteFileCommentContext(ctx context.Context, fileID, commentID string) (err error) {
 	if fileID == "" || commentID == "" {
-		return errors.New("received empty parameters")
+		return ErrParametersMissing
 	}
 
 	values := url.Values{

--- a/im.go
+++ b/im.go
@@ -23,9 +23,7 @@ type imResponseFull struct {
 // IM contains information related to the Direct Message channel
 type IM struct {
 	conversation
-	IsIM          bool   `json:"is_im"`
-	User          string `json:"user"`
-	IsUserDeleted bool   `json:"is_user_deleted"`
+	IsUserDeleted bool `json:"is_user_deleted"`
 }
 
 func imRequest(ctx context.Context, client httpClient, path string, values url.Values, d debug) (*imResponseFull, error) {

--- a/internal/errorsx/errorsx.go
+++ b/internal/errorsx/errorsx.go
@@ -1,0 +1,8 @@
+package errorsx
+
+// String representing an error, useful for declaring string constants as errors.
+type String string
+
+func (t String) Error() string {
+	return string(t)
+}

--- a/misc.go
+++ b/misc.go
@@ -265,12 +265,6 @@ func okJSONHandler(rw http.ResponseWriter, r *http.Request) {
 	rw.Write(response)
 }
 
-type errorString string
-
-func (t errorString) Error() string {
-	return string(t)
-}
-
 // timerReset safely reset a timer, see time.Timer.Reset for details.
 func timerReset(t *time.Timer, d time.Duration) {
 	if !t.Stop() {

--- a/rtm.go
+++ b/rtm.go
@@ -112,14 +112,13 @@ func RTMOptionConnParams(connParams url.Values) RTMOption {
 func (api *Client) NewRTM(options ...RTMOption) *RTM {
 	result := &RTM{
 		Client:           *api,
-		wasIntentional:   true,
-		isConnected:      false,
 		IncomingEvents:   make(chan RTMEvent, 50),
 		outgoingMessages: make(chan OutgoingMessage, 20),
 		pingInterval:     defaultPingInterval,
 		pingDeadman:      time.NewTimer(deadmanDuration(defaultPingInterval)),
 		killChannel:      make(chan bool),
-		disconnected:     make(chan struct{}, 1),
+		disconnected:     make(chan struct{}),
+		disconnectedm:    &sync.Once{},
 		forcePing:        make(chan bool),
 		rawEvents:        make(chan json.RawMessage),
 		idGen:            NewSafeID(1),

--- a/security.go
+++ b/security.go
@@ -4,7 +4,6 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"hash"
 	"net/http"
@@ -34,7 +33,7 @@ func unsafeSignatureVerifier(header http.Header, secret string) (_ SecretsVerifi
 	stimestamp := header.Get(hTimestamp)
 
 	if signature == "" || stimestamp == "" {
-		return SecretsVerifier{}, errors.New("missing headers")
+		return SecretsVerifier{}, ErrMissingHeaders
 	}
 
 	if bsignature, err = hex.DecodeString(strings.TrimPrefix(signature, "v0=")); err != nil {
@@ -70,7 +69,7 @@ func NewSecretsVerifier(header http.Header, secret string) (sv SecretsVerifier, 
 
 	diff := absDuration(time.Since(time.Unix(timestamp, 0)))
 	if diff > 5*time.Minute {
-		return SecretsVerifier{}, fmt.Errorf("timestamp is too old")
+		return SecretsVerifier{}, ErrExpiredTimestamp
 	}
 
 	return sv, err

--- a/users.go
+++ b/users.go
@@ -12,7 +12,6 @@ const (
 	DEFAULT_USER_PHOTO_CROP_X = -1
 	DEFAULT_USER_PHOTO_CROP_Y = -1
 	DEFAULT_USER_PHOTO_CROP_W = -1
-	errPaginationComplete     = errorString("pagination complete")
 )
 
 // UserProfile contains all the information details of a given user

--- a/websocket.go
+++ b/websocket.go
@@ -33,11 +33,10 @@ type RTM struct {
 	IncomingEvents   chan RTMEvent
 	outgoingMessages chan OutgoingMessage
 	killChannel      chan bool
-	disconnected     chan struct{} // disconnected is closed when Disconnect is invoked, regardless of connection state. Allows for ManagedConnection to not leak.
+	disconnected     chan struct{}
+	disconnectedm    *sync.Once
 	forcePing        chan bool
 	rawEvents        chan json.RawMessage
-	wasIntentional   bool
-	isConnected      bool
 
 	// UserDetails upon connection
 	info *Info
@@ -58,26 +57,25 @@ type RTM struct {
 	connParams url.Values
 }
 
+// signal that we are disconnected by closing the channel.
+// protect it with a mutex to ensure it only happens once.
+func (rtm *RTM) disconnect() {
+	rtm.disconnectedm.Do(func() {
+		close(rtm.disconnected)
+	})
+}
+
 // Disconnect and wait, blocking until a successful disconnection.
 func (rtm *RTM) Disconnect() error {
-	// avoid RTM disconnect race conditions
-	rtm.mu.Lock()
-	defer rtm.mu.Unlock()
-
-	// always push into the disconnected channel when invoked,
+	// always push into the kill channel when invoked,
 	// this lets the ManagedConnection() function properly clean up.
 	// if the buffer is full then just continue on.
 	select {
-	case rtm.disconnected <- struct{}{}:
-	default:
-	}
-
-	if !rtm.isConnected {
+	case rtm.killChannel <- true:
+		return nil
+	case <-rtm.disconnected:
 		return errors.New("Invalid call to Disconnect - Slack API is already disconnected")
 	}
-
-	rtm.killChannel <- true
-	return nil
 }
 
 // GetInfo returns the info structure received when calling


### PR DESCRIPTION
simplifies the logic around disconnecting.

hopefully removing many potential deadlocks in the communication channels.

should also pave the way to being able to gracefully close the IncomingEvents channel for end users.


related issue #423 