### PR TITLE
Adds support for hint text on select inputs in Dialogs.

### DIFF
--- a/dialog_select.go
+++ b/dialog_select.go
@@ -25,6 +25,7 @@ type DialogInputSelect struct {
 	Options         []DialogSelectOption `json:"options,omitempty"`          //One of options or option_groups is required.
 	OptionGroups    []DialogOptionGroup  `json:"option_groups,omitempty"`    //Provide up to 100 options.
 	MinQueryLength  int                  `json:"min_query_length,omitempty"` //Optional. minimum characters before query is sent.
+	Hint            string               `json:"hint,omitempty"`             //Optional. Additional hint text.
 }
 
 // DialogSelectOption is an option for the user to select from the menu


### PR DESCRIPTION
While it's not explicitly called out in their documentation, it is
supported (tested empirically), and it's shown in screenshots on
https://api.slack.com/best-practices/creating-useful-dialogs