### PR TITLE
refactor to ease testing

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,38 +2,52 @@
 
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "UT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:43dd08a10854b2056e615d1b1d22ac94559d822e1f8b6fcc92c1a1057e85188e"
   name = "github.com/gorilla/websocket"
   packages = ["."]
+  pruneopts = "UT"
   revision = "ea4d1f681babbce9545c9c5f3d5194a789c89f5b"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
   name = "github.com/pkg/errors"
   packages = ["."]
-  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
-  version = "v0.8.0"
+  pruneopts = "UT"
+  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
+  version = "v0.8.1"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:18752d0b95816a1b777505a97f71c7467a8445b8ffb55631a7bf779f6ba4fa83"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
+  pruneopts = "UT"
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "596fa546322c2a1e9708a10c9f39aca2e04792b477fab86fb2899fbaab776070"
+  input-imports = [
+    "github.com/gorilla/websocket",
+    "github.com/pkg/errors",
+    "github.com/stretchr/testify/assert",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,5 +1,3 @@
-ignored = ["github.com/lusis/slack-test"]
-
 [[constraint]]
   name = "github.com/gorilla/websocket"
   version = "1.2.0"
@@ -10,7 +8,7 @@ ignored = ["github.com/lusis/slack-test"]
 
 [[constraint]]
   name = "github.com/pkg/errors"
-  version = "0.8.0"
+  version = "0.8.1"
 
 [prune]
   go-tests = true

--- a/admin.go
+++ b/admin.go
@@ -2,29 +2,19 @@ package slack
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 	"strings"
 )
 
-type adminResponse struct {
-	OK    bool   `json:"ok"`
-	Error string `json:"error"`
-}
-
-func adminRequest(ctx context.Context, client httpClient, method string, teamName string, values url.Values, d debug) (*adminResponse, error) {
-	adminResponse := &adminResponse{}
-	err := parseAdminResponse(ctx, client, method, teamName, values, adminResponse, d)
+func (api *Client) adminRequest(ctx context.Context, method string, teamName string, values url.Values) error {
+	resp := &SlackResponse{}
+	err := parseAdminResponse(ctx, api.httpclient, method, teamName, values, resp, api)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	if !adminResponse.OK {
-		return nil, errors.New(adminResponse.Error)
-	}
-
-	return adminResponse, nil
+	return resp.Err()
 }
 
 // DisableUser disabled a user account, given a user ID
@@ -41,9 +31,8 @@ func (api *Client) DisableUserContext(ctx context.Context, teamName string, uid 
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest(ctx, api.httpclient, "setInactive", teamName, values, api)
-	if err != nil {
-		return fmt.Errorf("Failed to disable user with id '%s': %s", uid, err)
+	if err := api.adminRequest(ctx, "setInactive", teamName, values); err != nil {
+		return fmt.Errorf("failed to disable user with id '%s': %s", uid, err)
 	}
 
 	return nil
@@ -68,7 +57,7 @@ func (api *Client) InviteGuestContext(ctx context.Context, teamName, channel, fi
 		"_attempts":        {"1"},
 	}
 
-	_, err := adminRequest(ctx, api.httpclient, "invite", teamName, values, api)
+	err := api.adminRequest(ctx, "invite", teamName, values)
 	if err != nil {
 		return fmt.Errorf("Failed to invite single-channel guest: %s", err)
 	}
@@ -95,7 +84,7 @@ func (api *Client) InviteRestrictedContext(ctx context.Context, teamName, channe
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest(ctx, api.httpclient, "invite", teamName, values, api)
+	err := api.adminRequest(ctx, "invite", teamName, values)
 	if err != nil {
 		return fmt.Errorf("Failed to restricted account: %s", err)
 	}
@@ -119,7 +108,7 @@ func (api *Client) InviteToTeamContext(ctx context.Context, teamName, firstName,
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest(ctx, api.httpclient, "invite", teamName, values, api)
+	err := api.adminRequest(ctx, "invite", teamName, values)
 	if err != nil {
 		return fmt.Errorf("Failed to invite to team: %s", err)
 	}
@@ -141,7 +130,7 @@ func (api *Client) SetRegularContext(ctx context.Context, teamName, user string)
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest(ctx, api.httpclient, "setRegular", teamName, values, api)
+	err := api.adminRequest(ctx, "setRegular", teamName, values)
 	if err != nil {
 		return fmt.Errorf("Failed to change the user (%s) to a regular user: %s", user, err)
 	}
@@ -163,7 +152,7 @@ func (api *Client) SendSSOBindingEmailContext(ctx context.Context, teamName, use
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest(ctx, api.httpclient, "sendSSOBind", teamName, values, api)
+	err := api.adminRequest(ctx, "sendSSOBind", teamName, values)
 	if err != nil {
 		return fmt.Errorf("Failed to send SSO binding email for user (%s): %s", user, err)
 	}
@@ -186,7 +175,7 @@ func (api *Client) SetUltraRestrictedContext(ctx context.Context, teamName, uid,
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest(ctx, api.httpclient, "setUltraRestricted", teamName, values, api)
+	err := api.adminRequest(ctx, "setUltraRestricted", teamName, values)
 	if err != nil {
 		return fmt.Errorf("Failed to ultra-restrict account: %s", err)
 	}
@@ -209,9 +198,9 @@ func (api *Client) SetRestrictedContext(ctx context.Context, teamName, uid strin
 		"channels":   {strings.Join(channelIds, ",")},
 	}
 
-	_, err := adminRequest(ctx, api.httpclient, "setRestricted", teamName, values, api)
+	err := api.adminRequest(ctx, "setRestricted", teamName, values)
 	if err != nil {
-		return fmt.Errorf("Failed to restrict account: %s", err)
+		return fmt.Errorf("failed to restrict account: %s", err)
 	}
 
 	return nil

--- a/auth.go
+++ b/auth.go
@@ -12,9 +12,9 @@ type AuthRevokeResponse struct {
 }
 
 // authRequest sends the actual request, and unmarshals the response
-func authRequest(ctx context.Context, client httpClient, path string, values url.Values, d debug) (*AuthRevokeResponse, error) {
+func (api *Client) authRequest(ctx context.Context, path string, values url.Values) (*AuthRevokeResponse, error) {
 	response := &AuthRevokeResponse{}
-	err := postSlackMethod(ctx, client, path, values, response, d)
+	err := api.postMethod(ctx, path, values, response)
 	if err != nil {
 		return nil, err
 	}
@@ -36,5 +36,5 @@ func (api *Client) SendAuthRevokeContext(ctx context.Context, token string) (*Au
 		"token": {token},
 	}
 
-	return authRequest(ctx, api.httpclient, "auth.revoke", values, api)
+	return api.authRequest(ctx, "auth.revoke", values)
 }

--- a/bots.go
+++ b/bots.go
@@ -2,7 +2,6 @@ package slack
 
 import (
 	"context"
-	"errors"
 	"net/url"
 )
 
@@ -19,15 +18,17 @@ type botResponseFull struct {
 	SlackResponse
 }
 
-func botRequest(ctx context.Context, client httpClient, path string, values url.Values, d debug) (*botResponseFull, error) {
+func (api *Client) botRequest(ctx context.Context, path string, values url.Values) (*botResponseFull, error) {
 	response := &botResponseFull{}
-	err := postSlackMethod(ctx, client, path, values, response, d)
+	err := api.postMethod(ctx, path, values, response)
 	if err != nil {
 		return nil, err
 	}
-	if !response.Ok {
-		return nil, errors.New(response.Error)
+
+	if err := response.Err(); err != nil {
+		return nil, err
 	}
+
 	return response, nil
 }
 
@@ -43,7 +44,7 @@ func (api *Client) GetBotInfoContext(ctx context.Context, bot string) (*Bot, err
 		"bot":   {bot},
 	}
 
-	response, err := botRequest(ctx, api.httpclient, "bots.info", values, api)
+	response, err := api.botRequest(ctx, "bots.info", values)
 	if err != nil {
 		return nil, err
 	}

--- a/bots_test.go
+++ b/bots_test.go
@@ -24,8 +24,7 @@ func TestGetBotInfo(t *testing.T) {
 	http.HandleFunc("/bots.info", getBotInfo)
 
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	bot, err := api.GetBotInfo("B02875YLA")
 	if err != nil {

--- a/channels.go
+++ b/channels.go
@@ -2,7 +2,6 @@ package slack
 
 import (
 	"context"
-	"errors"
 	"net/url"
 	"strconv"
 )
@@ -26,15 +25,17 @@ type Channel struct {
 	Locale    string `json:"locale"`
 }
 
-func channelRequest(ctx context.Context, client httpClient, path string, values url.Values, d debug) (*channelResponseFull, error) {
+func (api *Client) channelRequest(ctx context.Context, path string, values url.Values) (*channelResponseFull, error) {
 	response := &channelResponseFull{}
-	err := postForm(ctx, client, APIURL+path, values, response, d)
+	err := postForm(ctx, api.httpclient, api.endpoint+path, values, response, api)
 	if err != nil {
 		return nil, err
 	}
-	if !response.Ok {
-		return nil, errors.New(response.Error)
+
+	if err := response.Err(); err != nil {
+		return nil, err
 	}
+
 	return response, nil
 }
 
@@ -75,7 +76,7 @@ func (api *Client) ArchiveChannelContext(ctx context.Context, channelID string) 
 		"channel": {channelID},
 	}
 
-	_, err = channelRequest(ctx, api.httpclient, "channels.archive", values, api)
+	_, err = api.channelRequest(ctx, "channels.archive", values)
 	return err
 }
 
@@ -93,7 +94,7 @@ func (api *Client) UnarchiveChannelContext(ctx context.Context, channelID string
 		"channel": {channelID},
 	}
 
-	_, err = channelRequest(ctx, api.httpclient, "channels.unarchive", values, api)
+	_, err = api.channelRequest(ctx, "channels.unarchive", values)
 	return err
 }
 
@@ -111,7 +112,7 @@ func (api *Client) CreateChannelContext(ctx context.Context, channelName string)
 		"name":  {channelName},
 	}
 
-	response, err := channelRequest(ctx, api.httpclient, "channels.create", values, api)
+	response, err := api.channelRequest(ctx, "channels.create", values)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +157,7 @@ func (api *Client) GetChannelHistoryContext(ctx context.Context, channelID strin
 		}
 	}
 
-	response, err := channelRequest(ctx, api.httpclient, "channels.history", values, api)
+	response, err := api.channelRequest(ctx, "channels.history", values)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +179,7 @@ func (api *Client) GetChannelInfoContext(ctx context.Context, channelID string) 
 		"include_locale": {strconv.FormatBool(true)},
 	}
 
-	response, err := channelRequest(ctx, api.httpclient, "channels.info", values, api)
+	response, err := api.channelRequest(ctx, "channels.info", values)
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +201,7 @@ func (api *Client) InviteUserToChannelContext(ctx context.Context, channelID, us
 		"user":    {user},
 	}
 
-	response, err := channelRequest(ctx, api.httpclient, "channels.invite", values, api)
+	response, err := api.channelRequest(ctx, "channels.invite", values)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +222,7 @@ func (api *Client) JoinChannelContext(ctx context.Context, channelName string) (
 		"name":  {channelName},
 	}
 
-	response, err := channelRequest(ctx, api.httpclient, "channels.join", values, api)
+	response, err := api.channelRequest(ctx, "channels.join", values)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +243,7 @@ func (api *Client) LeaveChannelContext(ctx context.Context, channelID string) (b
 		"channel": {channelID},
 	}
 
-	response, err := channelRequest(ctx, api.httpclient, "channels.leave", values, api)
+	response, err := api.channelRequest(ctx, "channels.leave", values)
 	if err != nil {
 		return false, err
 	}
@@ -265,7 +266,7 @@ func (api *Client) KickUserFromChannelContext(ctx context.Context, channelID, us
 		"user":    {user},
 	}
 
-	_, err = channelRequest(ctx, api.httpclient, "channels.kick", values, api)
+	_, err = api.channelRequest(ctx, "channels.kick", values)
 	return err
 }
 
@@ -293,7 +294,7 @@ func (api *Client) GetChannelsContext(ctx context.Context, excludeArchived bool,
 		}
 	}
 
-	response, err := channelRequest(ctx, api.httpclient, "channels.list", config.values, api)
+	response, err := api.channelRequest(ctx, "channels.list", config.values)
 	if err != nil {
 		return nil, err
 	}
@@ -320,7 +321,7 @@ func (api *Client) SetChannelReadMarkContext(ctx context.Context, channelID, ts 
 		"ts":      {ts},
 	}
 
-	_, err = channelRequest(ctx, api.httpclient, "channels.mark", values, api)
+	_, err = api.channelRequest(ctx, "channels.mark", values)
 	return err
 }
 
@@ -341,7 +342,7 @@ func (api *Client) RenameChannelContext(ctx context.Context, channelID, name str
 
 	// XXX: the created entry in this call returns a string instead of a number
 	// so I may have to do some workaround to solve it.
-	response, err := channelRequest(ctx, api.httpclient, "channels.rename", values, api)
+	response, err := api.channelRequest(ctx, "channels.rename", values)
 	if err != nil {
 		return nil, err
 	}
@@ -363,7 +364,7 @@ func (api *Client) SetChannelPurposeContext(ctx context.Context, channelID, purp
 		"purpose": {purpose},
 	}
 
-	response, err := channelRequest(ctx, api.httpclient, "channels.setPurpose", values, api)
+	response, err := api.channelRequest(ctx, "channels.setPurpose", values)
 	if err != nil {
 		return "", err
 	}
@@ -385,7 +386,7 @@ func (api *Client) SetChannelTopicContext(ctx context.Context, channelID, topic 
 		"topic":   {topic},
 	}
 
-	response, err := channelRequest(ctx, api.httpclient, "channels.setTopic", values, api)
+	response, err := api.channelRequest(ctx, "channels.setTopic", values)
 	if err != nil {
 		return "", err
 	}
@@ -406,7 +407,7 @@ func (api *Client) GetChannelRepliesContext(ctx context.Context, channelID, thre
 		"channel":   {channelID},
 		"thread_ts": {thread_ts},
 	}
-	response, err := channelRequest(ctx, api.httpclient, "channels.replies", values, api)
+	response, err := api.channelRequest(ctx, "channels.replies", values)
 	if err != nil {
 		return nil, err
 	}

--- a/chat.go
+++ b/chat.go
@@ -162,7 +162,7 @@ func (api *Client) SendMessageContext(ctx context.Context, channelID string, opt
 		response chatResponseFull
 	)
 
-	if config, err = applyMsgOptions(api.token, channelID, options...); err != nil {
+	if config, err = applyMsgOptions(api.token, channelID, api.endpoint, options...); err != nil {
 		return "", "", "", err
 	}
 
@@ -176,14 +176,15 @@ func (api *Client) SendMessageContext(ctx context.Context, channelID string, opt
 // UnsafeApplyMsgOptions utility function for debugging/testing chat requests.
 // NOTE: USE AT YOUR OWN RISK: No issues relating to the use of this function
 // will be supported by the library.
-func UnsafeApplyMsgOptions(token, channel string, options ...MsgOption) (string, url.Values, error) {
-	config, err := applyMsgOptions(token, channel, options...)
+func UnsafeApplyMsgOptions(token, channel, apiurl string, options ...MsgOption) (string, url.Values, error) {
+	config, err := applyMsgOptions(token, channel, apiurl, options...)
 	return config.endpoint, config.values, err
 }
 
-func applyMsgOptions(token, channel string, options ...MsgOption) (sendConfig, error) {
+func applyMsgOptions(token, channel, apiurl string, options ...MsgOption) (sendConfig, error) {
 	config := sendConfig{
-		endpoint: APIURL + string(chatPostMessage),
+		apiurl:   apiurl,
+		endpoint: apiurl + string(chatPostMessage),
 		values: url.Values{
 			"token":   {token},
 			"channel": {channel},
@@ -211,6 +212,7 @@ const (
 )
 
 type sendConfig struct {
+	apiurl   string
 	endpoint string
 	values   url.Values
 }
@@ -221,7 +223,7 @@ type MsgOption func(*sendConfig) error
 // MsgOptionPost posts a messages, this is the default.
 func MsgOptionPost() MsgOption {
 	return func(config *sendConfig) error {
-		config.endpoint = APIURL + string(chatPostMessage)
+		config.endpoint = config.apiurl + string(chatPostMessage)
 		config.values.Del("ts")
 		return nil
 	}
@@ -230,7 +232,7 @@ func MsgOptionPost() MsgOption {
 // MsgOptionPostEphemeral - posts an ephemeral message to the provided user.
 func MsgOptionPostEphemeral(userID string) MsgOption {
 	return func(config *sendConfig) error {
-		config.endpoint = APIURL + string(chatPostEphemeral)
+		config.endpoint = config.apiurl + string(chatPostEphemeral)
 		MsgOptionUser(userID)(config)
 		config.values.Del("ts")
 
@@ -241,7 +243,7 @@ func MsgOptionPostEphemeral(userID string) MsgOption {
 // MsgOptionMeMessage posts a "me message" type from the calling user
 func MsgOptionMeMessage() MsgOption {
 	return func(config *sendConfig) error {
-		config.endpoint = APIURL + string(chatMeMessage)
+		config.endpoint = config.apiurl + string(chatMeMessage)
 		return nil
 	}
 }
@@ -249,7 +251,7 @@ func MsgOptionMeMessage() MsgOption {
 // MsgOptionUpdate updates a message based on the timestamp.
 func MsgOptionUpdate(timestamp string) MsgOption {
 	return func(config *sendConfig) error {
-		config.endpoint = APIURL + string(chatUpdate)
+		config.endpoint = config.apiurl + string(chatUpdate)
 		config.values.Add("ts", timestamp)
 		return nil
 	}
@@ -258,7 +260,7 @@ func MsgOptionUpdate(timestamp string) MsgOption {
 // MsgOptionDelete deletes a message based on the timestamp.
 func MsgOptionDelete(timestamp string) MsgOption {
 	return func(config *sendConfig) error {
-		config.endpoint = APIURL + string(chatDelete)
+		config.endpoint = config.apiurl + string(chatDelete)
 		config.values.Add("ts", timestamp)
 		return nil
 	}
@@ -267,7 +269,7 @@ func MsgOptionDelete(timestamp string) MsgOption {
 // MsgOptionUnfurl unfurls a message based on the timestamp.
 func MsgOptionUnfurl(timestamp string, unfurls map[string]Attachment) MsgOption {
 	return func(config *sendConfig) error {
-		config.endpoint = APIURL + string(chatUnfurl)
+		config.endpoint = config.apiurl + string(chatUnfurl)
 		config.values.Add("ts", timestamp)
 		unfurlsStr, err := json.Marshal(unfurls)
 		if err == nil {
@@ -530,7 +532,7 @@ func (api *Client) GetPermalinkContext(ctx context.Context, params *PermalinkPar
 		Permalink string `json:"permalink"`
 		SlackResponse
 	}{}
-	err := getSlackMethod(ctx, api.httpclient, "chat.getPermalink", values, &response, api)
+	err := api.getMethod(ctx, "chat.getPermalink", values, &response)
 	if err != nil {
 		return "", err
 	}

--- a/chat_test.go
+++ b/chat_test.go
@@ -17,8 +17,7 @@ func postMessageInvalidChannelHandler(rw http.ResponseWriter, r *http.Request) {
 func TestPostMessageInvalidChannel(t *testing.T) {
 	http.HandleFunc("/chat.postMessage", postMessageInvalidChannelHandler)
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	_, _, err := api.PostMessage("CXXXXXXXX", MsgOptionText("hello", false))
 	if err == nil {
 		t.Errorf("Expected error: channel_not_found; instead succeeded")
@@ -55,8 +54,7 @@ func TestGetPermalink(t *testing.T) {
 	})
 
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	pp := PermalinkParameters{Channel: channel, Ts: timeStamp}
 	pl, err := api.GetPermalink(&pp)
 

--- a/conversation.go
+++ b/conversation.go
@@ -2,7 +2,6 @@ package slack
 
 import (
 	"context"
-	"errors"
 	"net/url"
 	"strconv"
 	"strings"
@@ -100,13 +99,15 @@ func (api *Client) GetUsersInConversationContext(ctx context.Context, params *Ge
 		ResponseMetaData responseMetaData `json:"response_metadata"`
 		SlackResponse
 	}{}
-	err := postSlackMethod(ctx, api.httpclient, "conversations.members", values, &response, api)
+	err := api.postMethod(ctx, "conversations.members", values, &response)
 	if err != nil {
 		return nil, "", err
 	}
-	if !response.Ok {
-		return nil, "", errors.New(response.Error)
+
+	if err := response.Err(); err != nil {
+		return nil, "", err
 	}
+
 	return response.Members, response.ResponseMetaData.NextCursor, nil
 }
 
@@ -140,7 +141,7 @@ func (api *Client) GetConversationsForUserContext(ctx context.Context, params *G
 		ResponseMetaData responseMetaData `json:"response_metadata"`
 		SlackResponse
 	}{}
-	err = postSlackMethod(ctx, api.httpclient, "users.conversations", values, &response, api)
+	err = api.postMethod(ctx, "users.conversations", values, &response)
 	if err != nil {
 		return nil, "", err
 	}
@@ -160,7 +161,7 @@ func (api *Client) ArchiveConversationContext(ctx context.Context, channelID str
 		"channel": {channelID},
 	}
 	response := SlackResponse{}
-	err := postSlackMethod(ctx, api.httpclient, "conversations.archive", values, &response, api)
+	err := api.postMethod(ctx, "conversations.archive", values, &response)
 	if err != nil {
 		return err
 	}
@@ -180,7 +181,7 @@ func (api *Client) UnArchiveConversationContext(ctx context.Context, channelID s
 		"channel": {channelID},
 	}
 	response := SlackResponse{}
-	err := postSlackMethod(ctx, api.httpclient, "conversations.unarchive", values, &response, api)
+	err := api.postMethod(ctx, "conversations.unarchive", values, &response)
 	if err != nil {
 		return err
 	}
@@ -204,7 +205,7 @@ func (api *Client) SetTopicOfConversationContext(ctx context.Context, channelID,
 		SlackResponse
 		Channel *Channel `json:"channel"`
 	}{}
-	err := postSlackMethod(ctx, api.httpclient, "conversations.setTopic", values, &response, api)
+	err := api.postMethod(ctx, "conversations.setTopic", values, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +229,7 @@ func (api *Client) SetPurposeOfConversationContext(ctx context.Context, channelI
 		SlackResponse
 		Channel *Channel `json:"channel"`
 	}{}
-	err := postSlackMethod(ctx, api.httpclient, "conversations.setPurpose", values, &response, api)
+	err := api.postMethod(ctx, "conversations.setPurpose", values, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +253,7 @@ func (api *Client) RenameConversationContext(ctx context.Context, channelID, cha
 		SlackResponse
 		Channel *Channel `json:"channel"`
 	}{}
-	err := postSlackMethod(ctx, api.httpclient, "conversations.rename", values, &response, api)
+	err := api.postMethod(ctx, "conversations.rename", values, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -276,7 +277,7 @@ func (api *Client) InviteUsersToConversationContext(ctx context.Context, channel
 		SlackResponse
 		Channel *Channel `json:"channel"`
 	}{}
-	err := postSlackMethod(ctx, api.httpclient, "conversations.invite", values, &response, api)
+	err := api.postMethod(ctx, "conversations.invite", values, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -297,7 +298,7 @@ func (api *Client) KickUserFromConversationContext(ctx context.Context, channelI
 		"user":    {user},
 	}
 	response := SlackResponse{}
-	err := postSlackMethod(ctx, api.httpclient, "conversations.kick", values, &response, api)
+	err := api.postMethod(ctx, "conversations.kick", values, &response)
 	if err != nil {
 		return err
 	}
@@ -322,7 +323,7 @@ func (api *Client) CloseConversationContext(ctx context.Context, channelID strin
 		AlreadyClosed bool `json:"already_closed"`
 	}{}
 
-	err = postSlackMethod(ctx, api.httpclient, "conversations.close", values, &response, api)
+	err = api.postMethod(ctx, "conversations.close", values, &response)
 	if err != nil {
 		return false, false, err
 	}
@@ -342,13 +343,12 @@ func (api *Client) CreateConversationContext(ctx context.Context, channelName st
 		"name":       {channelName},
 		"is_private": {strconv.FormatBool(isPrivate)},
 	}
-	response, err := channelRequest(
-		ctx, api.httpclient, "conversations.create", values, api)
+	response, err := api.channelRequest(ctx, "conversations.create", values)
 	if err != nil {
 		return nil, err
 	}
 
-	return &response.Channel, response.Err()
+	return &response.Channel, nil
 }
 
 // GetConversationInfo retrieves information about a conversation
@@ -363,8 +363,7 @@ func (api *Client) GetConversationInfoContext(ctx context.Context, channelID str
 		"channel":        {channelID},
 		"include_locale": {strconv.FormatBool(includeLocale)},
 	}
-	response, err := channelRequest(
-		ctx, api.httpclient, "conversations.info", values, api)
+	response, err := api.channelRequest(ctx, "conversations.info", values)
 	if err != nil {
 		return nil, err
 	}
@@ -384,7 +383,7 @@ func (api *Client) LeaveConversationContext(ctx context.Context, channelID strin
 		"channel": {channelID},
 	}
 
-	response, err := channelRequest(ctx, api.httpclient, "conversations.leave", values, api)
+	response, err := api.channelRequest(ctx, "conversations.leave", values)
 	if err != nil {
 		return false, err
 	}
@@ -440,7 +439,7 @@ func (api *Client) GetConversationRepliesContext(ctx context.Context, params *Ge
 		Messages []Message `json:"messages"`
 	}{}
 
-	err = postSlackMethod(ctx, api.httpclient, "conversations.replies", values, &response, api)
+	err = api.postMethod(ctx, "conversations.replies", values, &response)
 	if err != nil {
 		return nil, false, "", err
 	}
@@ -480,7 +479,7 @@ func (api *Client) GetConversationsContext(ctx context.Context, params *GetConve
 		ResponseMetaData responseMetaData `json:"response_metadata"`
 		SlackResponse
 	}{}
-	err = postSlackMethod(ctx, api.httpclient, "conversations.list", values, &response, api)
+	err = api.postMethod(ctx, "conversations.list", values, &response)
 	if err != nil {
 		return nil, "", err
 	}
@@ -517,7 +516,7 @@ func (api *Client) OpenConversationContext(ctx context.Context, params *OpenConv
 		AlreadyOpen bool     `json:"already_open"`
 		SlackResponse
 	}{}
-	err := postSlackMethod(ctx, api.httpclient, "conversations.open", values, &response, api)
+	err := api.postMethod(ctx, "conversations.open", values, &response)
 	if err != nil {
 		return nil, false, false, err
 	}
@@ -541,7 +540,7 @@ func (api *Client) JoinConversationContext(ctx context.Context, channelID string
 		} `json:"response_metadata"`
 		SlackResponse
 	}{}
-	err := postSlackMethod(ctx, api.httpclient, "conversations.join", values, &response, api)
+	err := api.postMethod(ctx, "conversations.join", values, &response)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -603,7 +602,7 @@ func (api *Client) GetConversationHistoryContext(ctx context.Context, params *Ge
 
 	response := GetConversationHistoryResponse{}
 
-	err := postSlackMethod(ctx, api.httpclient, "conversations.history", values, &response, api)
+	err := api.postMethod(ctx, "conversations.history", values, &response)
 	if err != nil {
 		return nil, err
 	}

--- a/conversation_test.go
+++ b/conversation_test.go
@@ -222,8 +222,7 @@ func getUsersInConversation(rw http.ResponseWriter, r *http.Request) {
 func TestGetUsersInConversation(t *testing.T) {
 	http.HandleFunc("/conversations.members", getUsersInConversation)
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	params := GetUsersInConversationParameters{
 		ChannelID: "CXXXXXXXX",
 	}
@@ -243,8 +242,7 @@ func TestGetUsersInConversation(t *testing.T) {
 func TestArchiveConversation(t *testing.T) {
 	http.HandleFunc("/conversations.archive", okJSONHandler)
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	err := api.ArchiveConversation("CXXXXXXXX")
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
@@ -255,8 +253,7 @@ func TestArchiveConversation(t *testing.T) {
 func TestUnArchiveConversation(t *testing.T) {
 	http.HandleFunc("/conversations.unarchive", okJSONHandler)
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	err := api.UnArchiveConversation("CXXXXXXXX")
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
@@ -291,8 +288,7 @@ func okChannelJsonHandler(rw http.ResponseWriter, r *http.Request) {
 func TestSetTopicOfConversation(t *testing.T) {
 	http.HandleFunc("/conversations.setTopic", okChannelJsonHandler)
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	inputChannel := getTestChannel()
 	channel, err := api.SetTopicOfConversation("CXXXXXXXX", inputChannel.Topic.Value)
 	if err != nil {
@@ -307,8 +303,7 @@ func TestSetTopicOfConversation(t *testing.T) {
 func TestSetPurposeOfConversation(t *testing.T) {
 	http.HandleFunc("/conversations.setPurpose", okChannelJsonHandler)
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	inputChannel := getTestChannel()
 	channel, err := api.SetPurposeOfConversation("CXXXXXXXX", inputChannel.Purpose.Value)
 	if err != nil {
@@ -323,8 +318,7 @@ func TestSetPurposeOfConversation(t *testing.T) {
 func TestRenameConversation(t *testing.T) {
 	http.HandleFunc("/conversations.rename", okChannelJsonHandler)
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	inputChannel := getTestChannel()
 	channel, err := api.RenameConversation("CXXXXXXXX", inputChannel.Name)
 	if err != nil {
@@ -339,8 +333,7 @@ func TestRenameConversation(t *testing.T) {
 func TestInviteUsersToConversation(t *testing.T) {
 	http.HandleFunc("/conversations.invite", okChannelJsonHandler)
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	users := []string{"UXXXXXXX1", "UXXXXXXX2"}
 	channel, err := api.InviteUsersToConversation("CXXXXXXXX", users...)
 	if err != nil {
@@ -356,8 +349,7 @@ func TestInviteUsersToConversation(t *testing.T) {
 func TestKickUserFromConversation(t *testing.T) {
 	http.HandleFunc("/conversations.kick", okJSONHandler)
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	err := api.KickUserFromConversation("CXXXXXXXX", "UXXXXXXXX")
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
@@ -379,8 +371,7 @@ func closeConversationHandler(rw http.ResponseWriter, r *http.Request) {
 func TestCloseConversation(t *testing.T) {
 	http.HandleFunc("/conversations.close", closeConversationHandler)
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	_, _, err := api.CloseConversation("CXXXXXXXX")
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
@@ -391,8 +382,7 @@ func TestCloseConversation(t *testing.T) {
 func TestCreateConversation(t *testing.T) {
 	http.HandleFunc("/conversations.create", okChannelJsonHandler)
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	channel, err := api.CreateConversation("CXXXXXXXX", false)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
@@ -407,8 +397,7 @@ func TestCreateConversation(t *testing.T) {
 func TestGetConversationInfo(t *testing.T) {
 	http.HandleFunc("/conversations.info", okChannelJsonHandler)
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	channel, err := api.GetConversationInfo("CXXXXXXXX", false)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
@@ -433,8 +422,7 @@ func leaveConversationHandler(rw http.ResponseWriter, r *http.Request) {
 func TestLeaveConversation(t *testing.T) {
 	http.HandleFunc("/conversations.leave", leaveConversationHandler)
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	_, err := api.LeaveConversation("CXXXXXXXX")
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
@@ -460,8 +448,7 @@ func getConversationRepliesHander(rw http.ResponseWriter, r *http.Request) {
 func TestGetConversationReplies(t *testing.T) {
 	http.HandleFunc("/conversations.replies", getConversationRepliesHander)
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	params := GetConversationRepliesParameters{
 		ChannelID: "CXXXXXXXX",
 		Timestamp: "1234567890.123456",
@@ -490,8 +477,7 @@ func getConversationsHander(rw http.ResponseWriter, r *http.Request) {
 func TestGetConversations(t *testing.T) {
 	http.HandleFunc("/conversations.list", getConversationsHander)
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	params := GetConversationsParameters{}
 	_, _, err := api.GetConversations(&params)
 	if err != nil {
@@ -515,8 +501,7 @@ func openConversationHandler(rw http.ResponseWriter, r *http.Request) {
 func TestOpenConversation(t *testing.T) {
 	http.HandleFunc("/conversations.open", openConversationHandler)
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	params := OpenConversationParameters{ChannelID: "CXXXXXXXX"}
 	_, _, _, err := api.OpenConversation(&params)
 	if err != nil {
@@ -542,8 +527,7 @@ func joinConversationHandler(rw http.ResponseWriter, r *http.Request) {
 func TestJoinConversation(t *testing.T) {
 	http.HandleFunc("/conversations.join", joinConversationHandler)
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	_, _, _, err := api.JoinConversation("CXXXXXXXX")
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
@@ -561,8 +545,7 @@ func getConversationHistoryHandler(rw http.ResponseWriter, r *http.Request) {
 func TestGetConversationHistory(t *testing.T) {
 	http.HandleFunc("/conversations.history", getConversationHistoryHandler)
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	params := GetConversationHistoryParameters{ChannelID: "CXXXXXXXX"}
 	_, err := api.GetConversationHistory(&params)
 	if err != nil {

--- a/dialog.go
+++ b/dialog.go
@@ -102,7 +102,7 @@ func (api *Client) OpenDialogContext(ctx context.Context, triggerID string, dial
 	}
 
 	response := &DialogOpenResponse{}
-	endpoint := APIURL + "dialog.open"
+	endpoint := api.endpoint + "dialog.open"
 	if err := postJSON(ctx, api.httpclient, endpoint, api.token, encoded, response, api); err != nil {
 		return err
 	}

--- a/dialog_test.go
+++ b/dialog_test.go
@@ -286,8 +286,7 @@ func openDialogHandler(rw http.ResponseWriter, r *http.Request) {
 func TestOpenDialog(t *testing.T) {
 	http.HandleFunc("/dialog.open", openDialogHandler)
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	dialog, err := unmarshalDialog()
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)

--- a/dnd.go
+++ b/dnd.go
@@ -2,7 +2,6 @@ package slack
 
 import (
 	"context"
-	"errors"
 	"net/url"
 	"strconv"
 	"strings"
@@ -36,16 +35,14 @@ type dndTeamInfoResponse struct {
 	SlackResponse
 }
 
-func dndRequest(ctx context.Context, client httpClient, path string, values url.Values, d debug) (*dndResponseFull, error) {
+func (api *Client) dndRequest(ctx context.Context, path string, values url.Values) (*dndResponseFull, error) {
 	response := &dndResponseFull{}
-	err := postSlackMethod(ctx, client, path, values, response, d)
+	err := api.postMethod(ctx, path, values, response)
 	if err != nil {
 		return nil, err
 	}
-	if !response.Ok {
-		return nil, errors.New(response.Error)
-	}
-	return response, nil
+
+	return response, response.Err()
 }
 
 // EndDND ends the user's scheduled Do Not Disturb session
@@ -61,7 +58,7 @@ func (api *Client) EndDNDContext(ctx context.Context) error {
 
 	response := &SlackResponse{}
 
-	if err := postSlackMethod(ctx, api.httpclient, "dnd.endDnd", values, response, api); err != nil {
+	if err := api.postMethod(ctx, "dnd.endDnd", values, response); err != nil {
 		return err
 	}
 
@@ -79,7 +76,7 @@ func (api *Client) EndSnoozeContext(ctx context.Context) (*DNDStatus, error) {
 		"token": {api.token},
 	}
 
-	response, err := dndRequest(ctx, api.httpclient, "dnd.endSnooze", values, api)
+	response, err := api.dndRequest(ctx, "dnd.endSnooze", values)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +97,7 @@ func (api *Client) GetDNDInfoContext(ctx context.Context, user *string) (*DNDSta
 		values.Set("user", *user)
 	}
 
-	response, err := dndRequest(ctx, api.httpclient, "dnd.info", values, api)
+	response, err := api.dndRequest(ctx, "dnd.info", values)
 	if err != nil {
 		return nil, err
 	}
@@ -120,13 +117,14 @@ func (api *Client) GetDNDTeamInfoContext(ctx context.Context, users []string) (m
 	}
 	response := &dndTeamInfoResponse{}
 
-	if err := postSlackMethod(ctx, api.httpclient, "dnd.teamInfo", values, response, api); err != nil {
+	if err := api.postMethod(ctx, "dnd.teamInfo", values, response); err != nil {
 		return nil, err
 	}
 
 	if response.Err() != nil {
 		return nil, response.Err()
 	}
+
 	return response.Users, nil
 }
 
@@ -137,7 +135,7 @@ func (api *Client) SetSnooze(minutes int) (*DNDStatus, error) {
 	return api.SetSnoozeContext(context.Background(), minutes)
 }
 
-// SetSnooze adjusts the snooze duration for a user's Do Not Disturb settings with a custom context.
+// SetSnoozeContext adjusts the snooze duration for a user's Do Not Disturb settings with a custom context.
 // For more information see the SetSnooze docs
 func (api *Client) SetSnoozeContext(ctx context.Context, minutes int) (*DNDStatus, error) {
 	values := url.Values{
@@ -145,7 +143,7 @@ func (api *Client) SetSnoozeContext(ctx context.Context, minutes int) (*DNDStatu
 		"num_minutes": {strconv.Itoa(minutes)},
 	}
 
-	response, err := dndRequest(ctx, api.httpclient, "dnd.setSnooze", values, api)
+	response, err := api.dndRequest(ctx, "dnd.setSnooze", values)
 	if err != nil {
 		return nil, err
 	}

--- a/dnd_test.go
+++ b/dnd_test.go
@@ -12,8 +12,7 @@ func TestSlack_EndDND(t *testing.T) {
 		w.Write([]byte(`{ "ok": true }`))
 	})
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	err := api.EndDND()
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
@@ -36,8 +35,7 @@ func TestSlack_EndSnooze(t *testing.T) {
 		SnoozeInfo:         SnoozeInfo{SnoozeEnabled: false},
 	}
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	snoozeState, err := api.EndSnooze()
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
@@ -72,8 +70,7 @@ func TestSlack_GetDNDInfo(t *testing.T) {
 		},
 	}
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	userDNDInfoResponse, err := api.GetDNDInfo(nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
@@ -116,8 +113,7 @@ func TestSlack_GetDNDTeamInfo(t *testing.T) {
 		},
 	}
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	usersDNDInfoResponse, err := api.GetDNDTeamInfo(nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
@@ -146,8 +142,7 @@ func TestSlack_SetSnooze(t *testing.T) {
 		},
 	}
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	snoozeResponse, err := api.SetSnooze(60)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)

--- a/emoji.go
+++ b/emoji.go
@@ -2,7 +2,6 @@ package slack
 
 import (
 	"context"
-	"errors"
 	"net/url"
 )
 
@@ -23,12 +22,14 @@ func (api *Client) GetEmojiContext(ctx context.Context) (map[string]string, erro
 	}
 	response := &emojiResponseFull{}
 
-	err := postSlackMethod(ctx, api.httpclient, "emoji.list", values, response, api)
+	err := api.postMethod(ctx, "emoji.list", values, response)
 	if err != nil {
 		return nil, err
 	}
-	if !response.Ok {
-		return nil, errors.New(response.Error)
+
+	if response.Err() != nil {
+		return nil, response.Err()
 	}
+
 	return response.Emoji, nil
 }

--- a/emoji_test.go
+++ b/emoji_test.go
@@ -20,8 +20,7 @@ func TestGetEmoji(t *testing.T) {
 	http.HandleFunc("/emoji.list", getEmojiHandler)
 
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	emojisResponse := map[string]string{
 		"bowtie":   "https://my.slack.com/emoji/bowtie/46ec6f2bb0.png",
 		"squirrel": "https://my.slack.com/emoji/squirrel/f35f40c0e0.png",

--- a/files.go
+++ b/files.go
@@ -155,9 +155,9 @@ func NewGetFilesParameters() GetFilesParameters {
 	}
 }
 
-func fileRequest(ctx context.Context, client httpClient, path string, values url.Values, d debug) (*fileResponseFull, error) {
+func (api *Client) fileRequest(ctx context.Context, path string, values url.Values) (*fileResponseFull, error) {
 	response := &fileResponseFull{}
-	err := postForm(ctx, client, APIURL+path, values, response, d)
+	err := api.postMethod(ctx, path, values, response)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +179,7 @@ func (api *Client) GetFileInfoContext(ctx context.Context, fileID string, count,
 		"page":  {strconv.Itoa(page)},
 	}
 
-	response, err := fileRequest(ctx, api.httpclient, "files.info", values, api)
+	response, err := api.fileRequest(ctx, "files.info", values)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -223,7 +223,7 @@ func (api *Client) GetFilesContext(ctx context.Context, params GetFilesParameter
 		values.Add("page", strconv.Itoa(params.Page))
 	}
 
-	response, err := fileRequest(ctx, api.httpclient, "files.list", values, api)
+	response, err := api.fileRequest(ctx, "files.list", values)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -270,11 +270,11 @@ func (api *Client) UploadFileContext(ctx context.Context, params FileUploadParam
 	}
 	if params.Content != "" {
 		values.Add("content", params.Content)
-		err = postForm(ctx, api.httpclient, APIURL+"files.upload", values, response, api)
+		err = api.postMethod(ctx, "files.upload", values, response)
 	} else if params.File != "" {
-		err = postLocalWithMultipartResponse(ctx, api.httpclient, "files.upload", params.File, "file", values, response, api)
+		err = postLocalWithMultipartResponse(ctx, api.httpclient, api.endpoint+"files.upload", params.File, "file", values, response, api)
 	} else if params.Reader != nil {
-		err = postWithMultipartResponse(ctx, api.httpclient, "files.upload", params.Filename, "file", values, params.Reader, response, api)
+		err = postWithMultipartResponse(ctx, api.httpclient, api.endpoint+"files.upload", params.Filename, "file", values, params.Reader, response, api)
 	}
 	if err != nil {
 		return nil, err
@@ -299,7 +299,7 @@ func (api *Client) DeleteFileCommentContext(ctx context.Context, fileID, comment
 		"file":  {fileID},
 		"id":    {commentID},
 	}
-	_, err = fileRequest(ctx, api.httpclient, "files.comments.delete", values, api)
+	_, err = api.fileRequest(ctx, "files.comments.delete", values)
 	return err
 }
 
@@ -315,7 +315,7 @@ func (api *Client) DeleteFileContext(ctx context.Context, fileID string) (err er
 		"file":  {fileID},
 	}
 
-	_, err = fileRequest(ctx, api.httpclient, "files.delete", values, api)
+	_, err = api.fileRequest(ctx, "files.delete", values)
 	return err
 }
 
@@ -331,7 +331,7 @@ func (api *Client) RevokeFilePublicURLContext(ctx context.Context, fileID string
 		"file":  {fileID},
 	}
 
-	response, err := fileRequest(ctx, api.httpclient, "files.revokePublicURL", values, api)
+	response, err := api.fileRequest(ctx, "files.revokePublicURL", values)
 	if err != nil {
 		return nil, err
 	}
@@ -350,7 +350,7 @@ func (api *Client) ShareFilePublicURLContext(ctx context.Context, fileID string)
 		"file":  {fileID},
 	}
 
-	response, err := fileRequest(ctx, api.httpclient, "files.sharedPublicURL", values, api)
+	response, err := api.fileRequest(ctx, "files.sharedPublicURL", values)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/files_test.go
+++ b/files_test.go
@@ -48,8 +48,8 @@ func (m *mockHTTPClient) Do(*http.Request) (*http.Response, error) {
 }
 
 func TestSlack_GetFile(t *testing.T) {
-	APIURL = "http://" + serverAddr + "/"
 	api := &Client{
+		endpoint:   "http://" + serverAddr + "/",
 		token:      "testing-token",
 		httpclient: &mockHTTPClient{},
 	}
@@ -84,8 +84,7 @@ func TestSlack_GetFile(t *testing.T) {
 
 func TestSlack_DeleteFileComment(t *testing.T) {
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	tests := []struct {
 		title       string
 		body        url.Values
@@ -168,8 +167,7 @@ func TestUploadFile(t *testing.T) {
 	http.HandleFunc("/auth.test", authTestHandler)
 	http.HandleFunc("/files.upload", uploadFileHandler)
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	params := FileUploadParameters{
 		Filename: "test.txt", Content: "test content",
 		Channels: []string{"CXXXXXXXX"}}
@@ -197,8 +195,7 @@ func TestUploadFile(t *testing.T) {
 
 func TestUploadFileWithoutFilename(t *testing.T) {
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	reader := bytes.NewBufferString("test reader")
 	params := FileUploadParameters{

--- a/groups.go
+++ b/groups.go
@@ -27,9 +27,9 @@ type groupResponseFull struct {
 	SlackResponse
 }
 
-func groupRequest(ctx context.Context, client httpClient, path string, values url.Values, d debug) (*groupResponseFull, error) {
+func (api *Client) groupRequest(ctx context.Context, path string, values url.Values) (*groupResponseFull, error) {
 	response := &groupResponseFull{}
-	err := postForm(ctx, client, APIURL+path, values, response, d)
+	err := api.postMethod(ctx, path, values, response)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func (api *Client) ArchiveGroupContext(ctx context.Context, group string) error 
 		"channel": {group},
 	}
 
-	_, err := groupRequest(ctx, api.httpclient, "groups.archive", values, api)
+	_, err := api.groupRequest(ctx, "groups.archive", values)
 	return err
 }
 
@@ -65,7 +65,7 @@ func (api *Client) UnarchiveGroupContext(ctx context.Context, group string) erro
 		"channel": {group},
 	}
 
-	_, err := groupRequest(ctx, api.httpclient, "groups.unarchive", values, api)
+	_, err := api.groupRequest(ctx, "groups.unarchive", values)
 	return err
 }
 
@@ -81,7 +81,7 @@ func (api *Client) CreateGroupContext(ctx context.Context, group string) (*Group
 		"name":  {group},
 	}
 
-	response, err := groupRequest(ctx, api.httpclient, "groups.create", values, api)
+	response, err := api.groupRequest(ctx, "groups.create", values)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (api *Client) CreateChildGroupContext(ctx context.Context, group string) (*
 		"channel": {group},
 	}
 
-	response, err := groupRequest(ctx, api.httpclient, "groups.createChild", values, api)
+	response, err := api.groupRequest(ctx, "groups.createChild", values)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +148,7 @@ func (api *Client) GetGroupHistoryContext(ctx context.Context, group string, par
 		}
 	}
 
-	response, err := groupRequest(ctx, api.httpclient, "groups.history", values, api)
+	response, err := api.groupRequest(ctx, "groups.history", values)
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +168,7 @@ func (api *Client) InviteUserToGroupContext(ctx context.Context, group, user str
 		"user":    {user},
 	}
 
-	response, err := groupRequest(ctx, api.httpclient, "groups.invite", values, api)
+	response, err := api.groupRequest(ctx, "groups.invite", values)
 	if err != nil {
 		return nil, false, err
 	}
@@ -187,7 +187,7 @@ func (api *Client) LeaveGroupContext(ctx context.Context, group string) (err err
 		"channel": {group},
 	}
 
-	_, err = groupRequest(ctx, api.httpclient, "groups.leave", values, api)
+	_, err = api.groupRequest(ctx, "groups.leave", values)
 	return err
 }
 
@@ -204,7 +204,7 @@ func (api *Client) KickUserFromGroupContext(ctx context.Context, group, user str
 		"user":    {user},
 	}
 
-	_, err = groupRequest(ctx, api.httpclient, "groups.kick", values, api)
+	_, err = api.groupRequest(ctx, "groups.kick", values)
 	return err
 }
 
@@ -222,7 +222,7 @@ func (api *Client) GetGroupsContext(ctx context.Context, excludeArchived bool) (
 		values.Add("exclude_archived", "1")
 	}
 
-	response, err := groupRequest(ctx, api.httpclient, "groups.list", values, api)
+	response, err := api.groupRequest(ctx, "groups.list", values)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ func (api *Client) GetGroupInfoContext(ctx context.Context, group string) (*Grou
 		"include_locale": {strconv.FormatBool(true)},
 	}
 
-	response, err := groupRequest(ctx, api.httpclient, "groups.info", values, api)
+	response, err := api.groupRequest(ctx, "groups.info", values)
 	if err != nil {
 		return nil, err
 	}
@@ -267,7 +267,7 @@ func (api *Client) SetGroupReadMarkContext(ctx context.Context, group, ts string
 		"ts":      {ts},
 	}
 
-	_, err = groupRequest(ctx, api.httpclient, "groups.mark", values, api)
+	_, err = api.groupRequest(ctx, "groups.mark", values)
 	return err
 }
 
@@ -283,7 +283,7 @@ func (api *Client) OpenGroupContext(ctx context.Context, group string) (bool, bo
 		"channel": {group},
 	}
 
-	response, err := groupRequest(ctx, api.httpclient, "groups.open", values, api)
+	response, err := api.groupRequest(ctx, "groups.open", values)
 	if err != nil {
 		return false, false, err
 	}
@@ -307,7 +307,7 @@ func (api *Client) RenameGroupContext(ctx context.Context, group, name string) (
 
 	// XXX: the created entry in this call returns a string instead of a number
 	// so I may have to do some workaround to solve it.
-	response, err := groupRequest(ctx, api.httpclient, "groups.rename", values, api)
+	response, err := api.groupRequest(ctx, "groups.rename", values)
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +327,7 @@ func (api *Client) SetGroupPurposeContext(ctx context.Context, group, purpose st
 		"purpose": {purpose},
 	}
 
-	response, err := groupRequest(ctx, api.httpclient, "groups.setPurpose", values, api)
+	response, err := api.groupRequest(ctx, "groups.setPurpose", values)
 	if err != nil {
 		return "", err
 	}
@@ -347,7 +347,7 @@ func (api *Client) SetGroupTopicContext(ctx context.Context, group, topic string
 		"topic":   {topic},
 	}
 
-	response, err := groupRequest(ctx, api.httpclient, "groups.setTopic", values, api)
+	response, err := api.groupRequest(ctx, "groups.setTopic", values)
 	if err != nil {
 		return "", err
 	}

--- a/im.go
+++ b/im.go
@@ -26,9 +26,9 @@ type IM struct {
 	IsUserDeleted bool `json:"is_user_deleted"`
 }
 
-func imRequest(ctx context.Context, client httpClient, path string, values url.Values, d debug) (*imResponseFull, error) {
+func (api *Client) imRequest(ctx context.Context, path string, values url.Values) (*imResponseFull, error) {
 	response := &imResponseFull{}
-	err := postSlackMethod(ctx, client, path, values, response, d)
+	err := api.postMethod(ctx, path, values, response)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func (api *Client) CloseIMChannelContext(ctx context.Context, channel string) (b
 		"channel": {channel},
 	}
 
-	response, err := imRequest(ctx, api.httpclient, "im.close", values, api)
+	response, err := api.imRequest(ctx, "im.close", values)
 	if err != nil {
 		return false, false, err
 	}
@@ -69,7 +69,7 @@ func (api *Client) OpenIMChannelContext(ctx context.Context, user string) (bool,
 		"user":  {user},
 	}
 
-	response, err := imRequest(ctx, api.httpclient, "im.open", values, api)
+	response, err := api.imRequest(ctx, "im.open", values)
 	if err != nil {
 		return false, false, "", err
 	}
@@ -89,7 +89,7 @@ func (api *Client) MarkIMChannelContext(ctx context.Context, channel, ts string)
 		"ts":      {ts},
 	}
 
-	_, err := imRequest(ctx, api.httpclient, "im.mark", values, api)
+	_, err := api.imRequest(ctx, "im.mark", values)
 	return err
 }
 
@@ -128,7 +128,7 @@ func (api *Client) GetIMHistoryContext(ctx context.Context, channel string, para
 		}
 	}
 
-	response, err := imRequest(ctx, api.httpclient, "im.history", values, api)
+	response, err := api.imRequest(ctx, "im.history", values)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +146,7 @@ func (api *Client) GetIMChannelsContext(ctx context.Context) ([]IM, error) {
 		"token": {api.token},
 	}
 
-	response, err := imRequest(ctx, api.httpclient, "im.list", values, api)
+	response, err := api.imRequest(ctx, "im.list", values)
 	if err != nil {
 		return nil, err
 	}

--- a/misc.go
+++ b/misc.go
@@ -48,21 +48,20 @@ type statusCodeError struct {
 }
 
 func (t statusCodeError) Error() string {
-	// TODO: this is a bad error string, should clean it up with a breaking changes
-	// merger.
-	return fmt.Sprintf("Slack server error: %s.", t.Status)
+	return fmt.Sprintf("slack server error: %s", t.Status)
 }
 
 func (t statusCodeError) HTTPStatusCode() int {
 	return t.Code
 }
 
+// RateLimitedError represents the rate limit respond from slack
 type RateLimitedError struct {
 	RetryAfter time.Duration
 }
 
 func (e *RateLimitedError) Error() string {
-	return fmt.Sprintf("Slack rate limit exceeded, retry after %s", e.RetryAfter)
+	return fmt.Sprintf("slack rate limit exceeded, retry after %s", e.RetryAfter)
 }
 
 func fileUploadReq(ctx context.Context, path string, values url.Values, r io.Reader) (*http.Request, error) {
@@ -154,7 +153,7 @@ func postWithMultipartResponse(ctx context.Context, client httpClient, path, nam
 			return
 		}
 	}()
-	req, err := fileUploadReq(ctx, APIURL+path, values, pipeReader)
+	req, err := fileUploadReq(ctx, path, values, pipeReader)
 	if err != nil {
 		return err
 	}
@@ -217,16 +216,6 @@ func postForm(ctx context.Context, client httpClient, endpoint string, values ur
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	return doPost(ctx, client, req, intf, d)
-}
-
-// post to a slack web method.
-func postSlackMethod(ctx context.Context, client httpClient, path string, values url.Values, intf interface{}, d debug) error {
-	return postForm(ctx, client, APIURL+path, values, intf, d)
-}
-
-// get a slack web method.
-func getSlackMethod(ctx context.Context, client httpClient, path string, values url.Values, intf interface{}, d debug) error {
-	return getResource(ctx, client, APIURL+path, values, intf, d)
 }
 
 func getResource(ctx context.Context, client httpClient, endpoint string, values url.Values, intf interface{}, d debug) error {

--- a/misc_test.go
+++ b/misc_test.go
@@ -36,12 +36,12 @@ func setParseResponseHandler() {
 func TestParseResponse(t *testing.T) {
 	parseResponseOnce.Do(setParseResponseHandler)
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
+	APIURL := "http://" + serverAddr + "/"
 	values := url.Values{
 		"token": {validToken},
 	}
 	responsePartial := &SlackResponse{}
-	err := postSlackMethod(context.Background(), http.DefaultClient, "parseResponse", values, responsePartial, discard{})
+	err := postForm(context.Background(), http.DefaultClient, APIURL+"parseResponse", values, responsePartial, discard{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -50,10 +50,10 @@ func TestParseResponse(t *testing.T) {
 func TestParseResponseNoToken(t *testing.T) {
 	parseResponseOnce.Do(setParseResponseHandler)
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
+	APIURL := "http://" + serverAddr + "/"
 	values := url.Values{}
 	responsePartial := &SlackResponse{}
-	err := postSlackMethod(context.Background(), http.DefaultClient, "parseResponse", values, responsePartial, discard{})
+	err := postForm(context.Background(), http.DefaultClient, APIURL+"parseResponse", values, responsePartial, discard{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 		return
@@ -68,12 +68,12 @@ func TestParseResponseNoToken(t *testing.T) {
 func TestParseResponseInvalidToken(t *testing.T) {
 	parseResponseOnce.Do(setParseResponseHandler)
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
+	APIURL := "http://" + serverAddr + "/"
 	values := url.Values{
 		"token": {"whatever"},
 	}
 	responsePartial := &SlackResponse{}
-	err := postSlackMethod(context.Background(), http.DefaultClient, "parseResponse", values, responsePartial, discard{})
+	err := postForm(context.Background(), http.DefaultClient, APIURL+"parseResponse", values, responsePartial, discard{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 		return

--- a/oauth.go
+++ b/oauth.go
@@ -57,7 +57,7 @@ func GetOAuthResponseContext(ctx context.Context, client httpClient, clientID, c
 		"redirect_uri":  {redirectURI},
 	}
 	response := &OAuthResponse{}
-	if err = postSlackMethod(ctx, client, "oauth.access", values, response, discard{}); err != nil {
+	if err = postForm(ctx, client, APIURL+"oauth.access", values, response, discard{}); err != nil {
 		return nil, err
 	}
 	return response, response.Err()

--- a/pins.go
+++ b/pins.go
@@ -34,7 +34,7 @@ func (api *Client) AddPinContext(ctx context.Context, channel string, item ItemR
 	}
 
 	response := &SlackResponse{}
-	if err := postSlackMethod(ctx, api.httpclient, "pins.add", values, response, api); err != nil {
+	if err := api.postMethod(ctx, "pins.add", values, response); err != nil {
 		return err
 	}
 
@@ -63,7 +63,7 @@ func (api *Client) RemovePinContext(ctx context.Context, channel string, item It
 	}
 
 	response := &SlackResponse{}
-	if err := postSlackMethod(ctx, api.httpclient, "pins.remove", values, response, api); err != nil {
+	if err := api.postMethod(ctx, "pins.remove", values, response); err != nil {
 		return err
 	}
 
@@ -83,7 +83,7 @@ func (api *Client) ListPinsContext(ctx context.Context, channel string) ([]Item,
 	}
 
 	response := &listPinsResponseFull{}
-	err := postSlackMethod(ctx, api.httpclient, "pins.list", values, response, api)
+	err := api.postMethod(ctx, "pins.list", values, response)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pins_test.go
+++ b/pins_test.go
@@ -38,8 +38,7 @@ func (rh *pinsHandler) handler(w http.ResponseWriter, r *http.Request) {
 
 func TestSlack_AddPin(t *testing.T) {
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	tests := []struct {
 		channel    string
 		ref        ItemRef
@@ -86,8 +85,7 @@ func TestSlack_AddPin(t *testing.T) {
 
 func TestSlack_RemovePin(t *testing.T) {
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	tests := []struct {
 		channel    string
 		ref        ItemRef
@@ -134,8 +132,7 @@ func TestSlack_RemovePin(t *testing.T) {
 
 func TestSlack_ListPins(t *testing.T) {
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	rh := newPinsHandler()
 	http.HandleFunc("/pins.list", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
 	rh.response = `{"ok": true,

--- a/reactions.go
+++ b/reactions.go
@@ -2,7 +2,6 @@ package slack
 
 import (
 	"context"
-	"errors"
 	"net/url"
 	"strconv"
 )
@@ -155,7 +154,7 @@ func (api *Client) AddReactionContext(ctx context.Context, name string, item Ite
 	}
 
 	response := &SlackResponse{}
-	if err := postSlackMethod(ctx, api.httpclient, "reactions.add", values, response, api); err != nil {
+	if err := api.postMethod(ctx, "reactions.add", values, response); err != nil {
 		return err
 	}
 
@@ -189,7 +188,7 @@ func (api *Client) RemoveReactionContext(ctx context.Context, name string, item 
 	}
 
 	response := &SlackResponse{}
-	if err := postSlackMethod(ctx, api.httpclient, "reactions.remove", values, response, api); err != nil {
+	if err := api.postMethod(ctx, "reactions.remove", values, response); err != nil {
 		return err
 	}
 
@@ -223,12 +222,14 @@ func (api *Client) GetReactionsContext(ctx context.Context, item ItemRef, params
 	}
 
 	response := &getReactionsResponseFull{}
-	if err := postSlackMethod(ctx, api.httpclient, "reactions.get", values, response, api); err != nil {
+	if err := api.postMethod(ctx, "reactions.get", values, response); err != nil {
 		return nil, err
 	}
-	if !response.Ok {
-		return nil, errors.New(response.Error)
+
+	if err := response.Err(); err != nil {
+		return nil, err
 	}
+
 	return response.extractReactions(), nil
 }
 
@@ -256,12 +257,14 @@ func (api *Client) ListReactionsContext(ctx context.Context, params ListReaction
 	}
 
 	response := &listReactionsResponseFull{}
-	err := postSlackMethod(ctx, api.httpclient, "reactions.list", values, response, api)
+	err := api.postMethod(ctx, "reactions.list", values, response)
 	if err != nil {
 		return nil, nil, err
 	}
-	if !response.Ok {
-		return nil, nil, errors.New(response.Error)
+
+	if err := response.Err(); err != nil {
+		return nil, nil, err
 	}
+
 	return response.extractReactedItems(), &response.Paging, nil
 }

--- a/reactions_test.go
+++ b/reactions_test.go
@@ -41,8 +41,7 @@ func (rh *reactionsHandler) handler(w http.ResponseWriter, r *http.Request) {
 
 func TestSlack_AddReaction(t *testing.T) {
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	tests := []struct {
 		name       string
 		ref        ItemRef
@@ -90,8 +89,7 @@ func TestSlack_AddReaction(t *testing.T) {
 
 func TestSlack_RemoveReaction(t *testing.T) {
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	tests := []struct {
 		name       string
 		ref        ItemRef
@@ -139,8 +137,7 @@ func TestSlack_RemoveReaction(t *testing.T) {
 
 func TestSlack_GetReactions(t *testing.T) {
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	tests := []struct {
 		ref           ItemRef
 		params        GetReactionsParameters
@@ -254,8 +251,7 @@ func TestSlack_GetReactions(t *testing.T) {
 
 func TestSlack_ListReactions(t *testing.T) {
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	rh := newReactionsHandler()
 	http.HandleFunc("/reactions.list", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
 	rh.response = `{"ok": true,

--- a/reminders.go
+++ b/reminders.go
@@ -23,7 +23,7 @@ type reminderResp struct {
 
 func (api *Client) doReminder(ctx context.Context, path string, values url.Values) (*Reminder, error) {
 	response := &reminderResp{}
-	if err := postSlackMethod(ctx, api.httpclient, path, values, response, api); err != nil {
+	if err := api.postMethod(ctx, path, values, response); err != nil {
 		return nil, err
 	}
 	return &response.Reminder, response.Err()
@@ -68,7 +68,7 @@ func (api *Client) DeleteReminder(id string) error {
 		"reminder": {id},
 	}
 	response := &SlackResponse{}
-	if err := postSlackMethod(context.Background(), api.httpclient, "reminders.delete", values, response, api); err != nil {
+	if err := api.postMethod(context.Background(), "reminders.delete", values, response); err != nil {
 		return err
 	}
 	return response.Err()

--- a/reminders_test.go
+++ b/reminders_test.go
@@ -39,8 +39,7 @@ func (rh *remindersHandler) handler(w http.ResponseWriter, r *http.Request) {
 
 func TestSlack_AddReminder(t *testing.T) {
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	tests := []struct {
 		chanID     string
 		userID     string
@@ -121,8 +120,7 @@ func TestSlack_AddReminder(t *testing.T) {
 
 func TestSlack_DeleteReminder(t *testing.T) {
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	tests := []struct {
 		reminder   string
 		wantParams map[string]string

--- a/rtm.go
+++ b/rtm.go
@@ -38,7 +38,7 @@ func (api *Client) StartRTM() (info *Info, websocketURL string, err error) {
 // To have a fully managed Websocket connection, use `NewRTM`, and call `ManageConnection()` on it.
 func (api *Client) StartRTMContext(ctx context.Context) (info *Info, websocketURL string, err error) {
 	response := &infoResponseFull{}
-	err = postSlackMethod(ctx, api.httpclient, "rtm.start", url.Values{"token": {api.token}}, response, api)
+	err = api.postMethod(ctx, "rtm.start", url.Values{"token": {api.token}}, response)
 	if err != nil {
 		return nil, "", err
 	}
@@ -63,7 +63,7 @@ func (api *Client) ConnectRTM() (info *Info, websocketURL string, err error) {
 // To have a fully managed Websocket connection, use `NewRTM`, and call `ManageConnection()` on it.
 func (api *Client) ConnectRTMContext(ctx context.Context) (info *Info, websocketURL string, err error) {
 	response := &infoResponseFull{}
-	err = postSlackMethod(ctx, api.httpclient, "rtm.connect", url.Values{"token": {api.token}}, response, api)
+	err = api.postMethod(ctx, "rtm.connect", url.Values{"token": {api.token}}, response)
 	if err != nil {
 		api.Debugf("Failed to connect to RTM: %s", err)
 		return nil, "", err

--- a/search.go
+++ b/search.go
@@ -103,7 +103,7 @@ func (api *Client) _search(ctx context.Context, path, query string, params Searc
 	}
 
 	response = &searchResponseFull{}
-	err := postSlackMethod(ctx, api.httpclient, path, values, response, api)
+	err := api.postMethod(ctx, path, values, response)
 	if err != nil {
 		return nil, err
 	}

--- a/slack.go
+++ b/slack.go
@@ -9,11 +9,12 @@ import (
 	"os"
 )
 
-// APIURL added as a var so that we can change this for testing purposes
-var APIURL = "https://slack.com/api/"
-
-// WEBAPIURLFormat ...
-const WEBAPIURLFormat = "https://%s.slack.com/api/users.admin.%s?t=%d"
+const (
+	// APIURL of the slack api.
+	APIURL = "https://slack.com/api/"
+	// WEBAPIURLFormat ...
+	WEBAPIURLFormat = "https://%s.slack.com/api/users.admin.%s?t=%d"
+)
 
 // httpClient defines the minimal interface needed for an http.Client to be implemented.
 type httpClient interface {
@@ -50,6 +51,7 @@ type authTestResponseFull struct {
 // Client for the slack api.
 type Client struct {
 	token      string
+	endpoint   string
 	debug      bool
 	log        ilogger
 	httpclient httpClient
@@ -79,10 +81,16 @@ func OptionLog(l logger) func(*Client) {
 	}
 }
 
+// OptionAPIURL set the url for the client. only useful for testing.
+func OptionAPIURL(u string) func(*Client) {
+	return func(c *Client) { c.endpoint = u }
+}
+
 // New builds a slack client from the provided token and options.
 func New(token string, options ...Option) *Client {
 	s := &Client{
 		token:      token,
+		endpoint:   APIURL,
 		httpclient: &http.Client{},
 		log:        log.New(os.Stderr, "nlopes/slack", log.LstdFlags|log.Lshortfile),
 	}
@@ -103,7 +111,7 @@ func (api *Client) AuthTest() (response *AuthTestResponse, error error) {
 func (api *Client) AuthTestContext(ctx context.Context) (response *AuthTestResponse, err error) {
 	api.Debugf("Challenging auth...")
 	responseFull := &authTestResponseFull{}
-	err = postSlackMethod(ctx, api.httpclient, "auth.test", url.Values{"token": {api.token}}, responseFull, api)
+	err = api.postMethod(ctx, "auth.test", url.Values{"token": {api.token}}, responseFull)
 	if err != nil {
 		return nil, err
 	}
@@ -128,4 +136,14 @@ func (api *Client) Debugln(v ...interface{}) {
 // Debug returns if debug is enabled.
 func (api *Client) Debug() bool {
 	return api.debug
+}
+
+// post to a slack web method.
+func (api *Client) postMethod(ctx context.Context, path string, values url.Values, intf interface{}) error {
+	return postForm(ctx, api.httpclient, api.endpoint+path, values, intf, api)
+}
+
+// get a slack web method.
+func (api *Client) getMethod(ctx context.Context, path string, values url.Values, intf interface{}) error {
+	return getResource(ctx, api.httpclient, api.endpoint+path, values, intf, api)
 }

--- a/slacktest/Makefile
+++ b/slacktest/Makefile
@@ -1,0 +1,33 @@
+EXAMPLES := $(shell find examples/ -maxdepth 1 -type d -exec sh -c 'echo $(basename {})' \;)
+EXLIST := $(subst examples/,,$(EXAMPLES))
+
+ifeq ($(TRAVIS_BUILD_DIR),)
+	GOPATH := $(GOPATH)
+else
+	GOPATH := $(GOPATH):$(TRAVIS_BUILD_DIR)
+endif
+
+all: chmod clean lint test coverage $(EXLIST)
+
+# this chmod is a side effect of some windows-development related issues
+chmod:
+	chmod +x script/*
+
+lint:
+	@script/lint
+
+test:
+	@script/test
+
+coverage:
+	@script/coverage
+
+$(EXLIST):
+	@echo $@
+	@go test -v ./examples/$@
+	@gocov test ./examples/$@ | gocov report
+
+clean:
+	@rm -rf bin/ pkg/
+
+.PHONY: all chmod clean lint test coverage $(EXLIST)

--- a/slacktest/README.md
+++ b/slacktest/README.md
@@ -1,0 +1,5 @@
+# slacktest
+
+code in this package was shamelessly copied from https://github.com/lusis/slack-test.
+since we were unable to get a response from the maintainer and its lack of license
+have left us in an odd state. but wanted to move it here for maintenance purposes.

--- a/slacktest/data.go
+++ b/slacktest/data.go
@@ -1,0 +1,178 @@
+package slacktest
+
+import (
+	"fmt"
+
+	slack "github.com/nlopes/slack"
+)
+
+const defaultBotName = "TestSlackBot"
+const defaultBotID = "U023BECGF"
+const defaultTeamID = "T024BE7LD"
+const defaultNonBotUserID = "W012A3CDE"
+const defaultNonBotUserName = "Egon Spengler"
+const defaultTeamName = "SlackTest Team"
+const defaultTeamDomain = "testdomain"
+
+var defaultCreatedTs = nowAsJSONTime()
+
+var defaultTeam = &slack.Team{
+	ID:     defaultTeamID,
+	Name:   defaultTeamName,
+	Domain: defaultTeamDomain,
+}
+
+var defaultBotInfo = &slack.UserDetails{
+	ID:             defaultBotID,
+	Name:           defaultBotName,
+	Created:        defaultCreatedTs,
+	ManualPresence: "true",
+	Prefs:          slack.UserPrefs{},
+}
+
+var okWebResponse = slack.SlackResponse{
+	Ok: true,
+}
+
+var defaultChannelsListJSON = fmt.Sprintf(`
+	{
+		"ok": true,
+		"channels": [%s, %s]
+	}
+	`, defaultGeneralChannelJSON, defaultExtraChannelJSON)
+
+var defaultGroupsListJSON = fmt.Sprintf(`
+		{
+			"ok": true,
+			"groups": [%s]
+		}
+		`, defaultGroupJSON)
+
+var defaultUsersInfoJSON = fmt.Sprintf(`
+	{
+		"ok":true,
+		%s
+	}
+	`, defaultNonBotUser)
+
+var defaultGeneralChannelJSON = fmt.Sprintf(`
+	{
+        "id": "C024BE91L",
+        "name": "general",
+        "is_channel": true,
+        "created": %d,
+        "creator": "%s",
+        "is_archived": false,
+        "is_general": true,
+
+        "members": [
+            "W012A3CDE"
+        ],
+
+        "topic": {
+            "value": "Fun times",
+            "creator": "%s",
+            "last_set": %d
+        },
+        "purpose": {
+            "value": "This channel is for fun",
+            "creator": "%s",
+            "last_set": %d
+        },
+
+        "is_member": true
+    }
+`, nowAsJSONTime(), defaultNonBotUserID, defaultNonBotUserID, nowAsJSONTime(), defaultNonBotUserID, nowAsJSONTime())
+
+var defaultExtraChannelJSON = fmt.Sprintf(`
+	{
+        "id": "C024BE92L",
+        "name": "bot-playground",
+        "is_channel": true,
+        "created": %d,
+        "creator": "%s",
+        "is_archived": false,
+        "is_general": true,
+
+        "members": [
+            "W012A3CDE"
+        ],
+
+        "topic": {
+            "value": "Fun times",
+            "creator": "%s",
+            "last_set": %d
+        },
+        "purpose": {
+            "value": "This channel is for fun",
+            "creator": "%s",
+            "last_set": %d
+        },
+
+        "is_member": true
+    }
+`, nowAsJSONTime(), defaultNonBotUserID, defaultNonBotUserID, nowAsJSONTime(), defaultNonBotUserID, nowAsJSONTime())
+
+var defaultGroupJSON = fmt.Sprintf(`{
+    "id": "G024BE91L",
+    "name": "secretplans",
+    "is_group": true,
+    "created": %d,
+    "creator": "%s",
+    "is_archived": false,
+    "members": [
+        "W012A3CDE"
+    ],
+    "topic": {
+        "value": "Secret plans on hold",
+        "creator": "%s",
+        "last_set": %d
+    },
+    "purpose": {
+        "value": "Discuss secret plans that no-one else should know",
+        "creator": "%s",
+        "last_set": %d
+    }
+}`, nowAsJSONTime(), defaultNonBotUserID, defaultNonBotUserID, nowAsJSONTime(), defaultNonBotUserID, nowAsJSONTime())
+
+var defaultNonBotUser = fmt.Sprintf(`
+		"user": {
+			"id": "%s",
+			"team_id": "%s",
+			"name": "spengler",
+			"deleted": false,
+			"color": "9f69e7",
+			"real_name": "%s",
+			"tz": "America/Los_Angeles",
+			"tz_label": "Pacific Daylight Time",
+			"tz_offset": -25200,
+			"profile": {
+				"avatar_hash": "ge3b51ca72de",
+				"status_text": "Print is dead",
+				"status_emoji": ":books:",
+				"real_name": "%s",
+				"display_name": "spengler",
+				"real_name_normalized": "%s",
+				"display_name_normalized": "spengler",
+				"email": "spengler@ghostbusters.example.com",
+				"image_24": "https://localhost.localdomain/avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+				"image_32": "https://localhost.localdomain/avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+				"image_48": "https://localhost.localdomain/avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+				"image_72": "https://localhost.localdomain/avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+				"image_192": "https://localhost.localdomain/avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+				"image_512": "https://localhost.localdomain/avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+				"team": "%s"
+			},
+			"is_admin": true,
+			"is_owner": false,
+			"is_primary_owner": false,
+			"is_restricted": false,
+			"is_ultra_restricted": false,
+			"is_bot": false,
+			"is_stranger": false,
+			"updated": 1502138686,
+			"is_app_user": false,
+			"has_2fa": false,
+			"locale": "en-US"
+		}
+	`, defaultNonBotUserID, defaultTeamID, defaultNonBotUserName, defaultNonBotUserName, defaultNonBotUserName, defaultTeamID)

--- a/slacktest/errors.go
+++ b/slacktest/errors.go
@@ -1,0 +1,14 @@
+package slacktest
+
+import (
+	"github.com/nlopes/slack/internal/errorsx"
+)
+
+const (
+	// ErrEmptyServerToHub is the error when attempting an empty server address to the hub
+	ErrEmptyServerToHub = errorsx.String("Unable to add an empty server address to hub")
+	// ErrPassedEmptyServerAddr is the error when being passed an empty server address
+	ErrPassedEmptyServerAddr = errorsx.String("Passed an empty server address")
+	// ErrNoQueuesRegisteredForServer is the error when there are no queues for a server in the hub
+	ErrNoQueuesRegisteredForServer = errorsx.String("No queues registered for server")
+)

--- a/slacktest/funcs.go
+++ b/slacktest/funcs.go
@@ -1,0 +1,139 @@
+package slacktest
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	websocket "github.com/gorilla/websocket"
+	slack "github.com/nlopes/slack"
+)
+
+func queueForWebsocket(s, hubname string) {
+	channel, err := getHubForServer(hubname)
+	if err != nil {
+		log.Printf("Unable to get server's channels: %s", err.Error())
+	}
+	seenOutboundMessages.Lock()
+	seenOutboundMessages.messages = append(seenOutboundMessages.messages, s)
+	seenOutboundMessages.Unlock()
+	channel.sent <- s
+
+}
+
+func handlePendingMessages(c *websocket.Conn, hubname string) {
+	channel, err := getHubForServer(hubname)
+	if err != nil {
+		log.Printf("Unable to get server's channels: %s", err.Error())
+		return
+	}
+	for m := range channel.sent {
+		err := c.WriteMessage(websocket.TextMessage, []byte(m))
+		if err != nil {
+			log.Printf("error writing message to websocket: %s", err.Error())
+			continue
+		}
+	}
+}
+
+func postProcessMessage(m, hubname string) {
+	channel, err := getHubForServer(hubname)
+	if err != nil {
+		log.Printf("Unable to get server's channels: %s", err.Error())
+		return
+	}
+	seenInboundMessages.Lock()
+	seenInboundMessages.messages = append(seenInboundMessages.messages, m)
+	seenInboundMessages.Unlock()
+	// send to firehose
+	channel.seen <- m
+}
+
+func newHub() *hub {
+	h := &hub{}
+	c := make(map[string]*messageChannels)
+	h.serverChannels = c
+	return h
+}
+
+func addServerToHub(s *Server, channels *messageChannels) error {
+	if s.ServerAddr == "" {
+		return ErrEmptyServerToHub
+	}
+	masterHub.Lock()
+	masterHub.serverChannels[s.ServerAddr] = channels
+	masterHub.Unlock()
+	return nil
+}
+
+func getHubForServer(serverAddr string) (*messageChannels, error) {
+	if serverAddr == "" {
+		return &messageChannels{}, ErrPassedEmptyServerAddr
+	}
+	masterHub.RLock()
+	defer masterHub.RUnlock()
+	channels, ok := masterHub.serverChannels[serverAddr]
+	if !ok {
+		return &messageChannels{}, ErrNoQueuesRegisteredForServer
+	}
+	return channels, nil
+}
+
+// BotNameFromContext returns the botname from a provided context
+func BotNameFromContext(ctx context.Context) string {
+	botname, ok := ctx.Value(ServerBotNameContextKey).(string)
+	if !ok {
+		return defaultBotName
+	}
+	return botname
+}
+
+// BotIDFromContext returns the bot userid from a provided context
+func BotIDFromContext(ctx context.Context) string {
+	botname, ok := ctx.Value(ServerBotIDContextKey).(string)
+	if !ok {
+		return defaultBotID
+	}
+	return botname
+}
+
+// generate a full rtminfo response for initial rtm connections
+func generateRTMInfo(ctx context.Context, wsurl string) *fullInfoSlackResponse {
+	rtmInfo := slack.Info{
+		URL:  wsurl,
+		Team: defaultTeam,
+		User: defaultBotInfo,
+	}
+	rtmInfo.User.ID = BotIDFromContext(ctx)
+	rtmInfo.User.Name = BotNameFromContext(ctx)
+	return &fullInfoSlackResponse{
+		rtmInfo,
+		okWebResponse,
+	}
+}
+
+func nowAsJSONTime() slack.JSONTime {
+	return slack.JSONTime(time.Now().Unix())
+}
+
+func defaultBotInfoJSON(ctx context.Context) string {
+	botid := BotIDFromContext(ctx)
+	botname := BotNameFromContext(ctx)
+	return fmt.Sprintf(`
+		{
+			"ok":true,
+			"bot":{
+					"id": "%s",
+					"app_id": "A4H1JB4AZ",
+					"deleted": false,
+					"name": "%s",
+					"icons": {
+						"image_36": "https://localhost.localdomain/img36.png",
+						"image_48": "https://localhost.localdomain/img48.png",
+						"image_72": "https://localhost.localdomain/img72.png"
+					}
+				}
+		}
+		`, botid, botname)
+}

--- a/slacktest/funcs_test.go
+++ b/slacktest/funcs_test.go
@@ -1,0 +1,60 @@
+package slacktest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateDefaultRTMInfo(t *testing.T) {
+	wsurl := "ws://127.0.0.1:5555/ws"
+	ctx := context.TODO()
+	info := generateRTMInfo(ctx, wsurl)
+	assert.Equal(t, wsurl, info.URL)
+	assert.True(t, info.Ok)
+	assert.Equal(t, defaultBotID, info.User.ID)
+	assert.Equal(t, defaultBotName, info.User.Name)
+	assert.Equal(t, defaultTeamID, info.Team.ID)
+	assert.Equal(t, defaultTeamName, info.Team.Name)
+	assert.Equal(t, defaultTeamDomain, info.Team.Domain)
+}
+
+func TestCustomDefaultRTMInfo(t *testing.T) {
+	wsurl := "ws://127.0.0.1:5555/ws"
+	ctx := context.TODO()
+	ctx = context.WithValue(ctx, ServerBotIDContextKey, "U1234567890")
+	ctx = context.WithValue(ctx, ServerBotNameContextKey, "SomeTestBotThing")
+	info := generateRTMInfo(ctx, wsurl)
+	assert.Equal(t, wsurl, info.URL)
+	assert.True(t, info.Ok)
+	assert.Equal(t, "U1234567890", info.User.ID)
+	assert.Equal(t, "SomeTestBotThing", info.User.Name)
+	assert.Equal(t, defaultTeamID, info.Team.ID)
+	assert.Equal(t, defaultTeamName, info.Team.Name)
+	assert.Equal(t, defaultTeamDomain, info.Team.Domain)
+}
+
+func TestGetHubMissingServerAddr(t *testing.T) {
+	mc, err := getHubForServer("")
+	assert.Nil(t, mc.seen, "seen should be nil")
+	assert.Nil(t, mc.sent, "sent should be nil")
+	assert.Nil(t, mc.posted, "posted should be nil")
+	assert.Error(t, err, "should return an error")
+	assert.EqualError(t, err, ErrPassedEmptyServerAddr.Error())
+}
+
+func TestGetHubNoQueuesForServer(t *testing.T) {
+	mc, err := getHubForServer("foo")
+	assert.Nil(t, mc.seen, "seen should be nil")
+	assert.Nil(t, mc.sent, "sent should be nil")
+	assert.Nil(t, mc.posted, "posted should be nil")
+	assert.Error(t, err, "should return an error")
+	assert.EqualError(t, err, ErrNoQueuesRegisteredForServer.Error())
+}
+
+func TestUnableToAddToHub(t *testing.T) {
+	err := addServerToHub(&Server{}, &messageChannels{})
+	assert.Error(t, err, "should return and error")
+	assert.EqualError(t, err, ErrEmptyServerToHub.Error())
+}

--- a/slacktest/handlers.go
+++ b/slacktest/handlers.go
@@ -1,0 +1,223 @@
+package slacktest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"time"
+
+	websocket "github.com/gorilla/websocket"
+	slack "github.com/nlopes/slack"
+)
+
+func contextHandler(server *Server, next http.HandlerFunc) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), ServerURLContextKey, server.GetAPIURL())
+		ctx = context.WithValue(ctx, ServerWSContextKey, server.GetWSURL())
+		ctx = context.WithValue(ctx, ServerBotNameContextKey, server.BotName)
+		ctx = context.WithValue(ctx, ServerBotChannelsContextKey, server.GetChannels())
+		ctx = context.WithValue(ctx, ServerBotGroupsContextKey, server.GetGroups())
+		ctx = context.WithValue(ctx, ServerBotHubNameContextKey, server.ServerAddr)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func usersInfoHandler(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte(defaultUsersInfoJSON))
+}
+
+func botsInfoHandler(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte(defaultBotInfoJSON(r.Context())))
+}
+
+// handle channels.list
+func listChannelsHandler(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte(defaultChannelsListJSON))
+}
+
+// handle groups.list
+func listGroupsHandler(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte(defaultGroupsListJSON))
+}
+
+// handle chat.postMessage
+func postMessageHandler(w http.ResponseWriter, r *http.Request) {
+	serverAddr := r.Context().Value(ServerBotHubNameContextKey).(string)
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		msg := fmt.Sprintf("error reading body: %s", err.Error())
+		log.Printf(msg)
+		http.Error(w, msg, http.StatusInternalServerError)
+		return
+	}
+	values, vErr := url.ParseQuery(string(data))
+	if vErr != nil {
+		msg := fmt.Sprintf("Unable to decode query params: %s", vErr.Error())
+		log.Printf(msg)
+		http.Error(w, msg, http.StatusInternalServerError)
+		return
+	}
+
+	ts := time.Now().Unix()
+	resp := fmt.Sprintf(`{"channel":"%s","ts":"%d", "text":"%s", "ok": true}`, values.Get("channel"), ts, values.Get("text"))
+	m := slack.Message{}
+	m.Type = "message"
+	m.Channel = values.Get("channel")
+	m.Timestamp = fmt.Sprintf("%d", ts)
+	m.Text = values.Get("text")
+	if values.Get("as_user") != "true" {
+		m.User = defaultNonBotUserID
+		m.Username = defaultNonBotUserName
+	} else {
+		m.User = BotIDFromContext(r.Context())
+		m.Username = BotNameFromContext(r.Context())
+	}
+	attachments := values.Get("attachments")
+	if attachments != "" {
+		decoded, err := url.QueryUnescape(attachments)
+		if err != nil {
+			msg := fmt.Sprintf("Unable to decode attachments: %s", err.Error())
+			log.Printf(msg)
+			http.Error(w, msg, http.StatusInternalServerError)
+			return
+		}
+		var attaches []slack.Attachment
+		aJErr := json.Unmarshal([]byte(decoded), &attaches)
+		if aJErr != nil {
+			msg := fmt.Sprintf("Unable to decode attachments string to json: %s", aJErr.Error())
+			log.Printf(msg)
+			http.Error(w, msg, http.StatusInternalServerError)
+			return
+		}
+		m.Attachments = attaches
+	}
+	jsonMessage, jsonErr := json.Marshal(m)
+	if jsonErr != nil {
+		msg := fmt.Sprintf("Unable to marshal message: %s", jsonErr.Error())
+		log.Printf(msg)
+		http.Error(w, msg, http.StatusInternalServerError)
+		return
+	}
+	go queueForWebsocket(string(jsonMessage), serverAddr)
+	_, _ = w.Write([]byte(resp))
+}
+
+func rtmConnectHandler(w http.ResponseWriter, r *http.Request) {
+	_, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		msg := fmt.Sprintf("Error reading body: %s", err.Error())
+		log.Printf(msg)
+		http.Error(w, msg, http.StatusInternalServerError)
+		return
+	}
+	wsurl := r.Context().Value(ServerWSContextKey).(string)
+	if wsurl == "" {
+		msg := "missing webservice url from context"
+		log.Printf(msg)
+		http.Error(w, msg, http.StatusInternalServerError)
+		return
+	}
+
+	fullresponse := generateRTMInfo(r.Context(), wsurl)
+	j, jErr := json.Marshal(fullresponse)
+	if jErr != nil {
+		msg := fmt.Sprintf("Unable to marshal response: %s", jErr.Error())
+		log.Printf("Error: %s", msg)
+		http.Error(w, msg, http.StatusInternalServerError)
+		return
+	}
+	_, wErr := w.Write(j)
+	if wErr != nil {
+		log.Printf("Error writing response: %s", wErr.Error())
+	}
+}
+
+func rtmStartHandler(w http.ResponseWriter, r *http.Request) {
+	_, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		msg := fmt.Sprintf("Error reading body: %s", err.Error())
+		log.Printf(msg)
+		http.Error(w, msg, http.StatusInternalServerError)
+		return
+	}
+	wsurl := r.Context().Value(ServerWSContextKey).(string)
+	if wsurl == "" {
+		msg := "missing webservice url from context"
+		log.Printf(msg)
+		http.Error(w, msg, http.StatusInternalServerError)
+		return
+	}
+
+	fullresponse := generateRTMInfo(r.Context(), wsurl)
+	j, jErr := json.Marshal(fullresponse)
+	if jErr != nil {
+		msg := fmt.Sprintf("Unable to marshal response: %s", jErr.Error())
+		log.Printf("Error: %s", msg)
+		http.Error(w, msg, http.StatusInternalServerError)
+		return
+	}
+	_, wErr := w.Write(j)
+	if wErr != nil {
+		log.Printf("Error writing response: %s", wErr.Error())
+	}
+}
+
+func wsHandler(w http.ResponseWriter, r *http.Request) {
+	upgrader := websocket.Upgrader{
+		ReadBufferSize:  1024,
+		WriteBufferSize: 1024,
+		CheckOrigin: func(r *http.Request) bool {
+			return true
+		},
+	}
+	c, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		msg := fmt.Sprintf("Unable to upgrade to ws connection: %s", err.Error())
+		log.Print(msg)
+		http.Error(w, msg, http.StatusInternalServerError)
+		return
+	}
+	defer func() { _ = c.Close() }()
+	serverAddr := r.Context().Value(ServerBotHubNameContextKey).(string)
+	go handlePendingMessages(c, serverAddr)
+	for {
+		mt, messageBytes, err := c.ReadMessage()
+		if err != nil {
+			log.Printf("read error: %s", err.Error())
+			continue
+		}
+		message := string(messageBytes)
+		evt := &slack.Event{}
+		if err := json.Unmarshal(messageBytes, evt); err != nil {
+			log.Printf("Error unmarshalling message: %s", err.Error())
+			log.Printf("failed message: %s", string(message))
+			continue
+		}
+		if evt.Type == "ping" {
+			p := &slack.Ping{}
+			jErr := json.Unmarshal(messageBytes, p)
+			if jErr != nil {
+				log.Printf("Unable to decode ping event: %s", jErr.Error())
+				continue
+			}
+			//log.Print("responding to slack ping")
+			pong := &slack.Pong{
+				ReplyTo: p.ID,
+				Type:    "pong",
+			}
+			j, _ := json.Marshal(pong)
+			wErr := c.WriteMessage(mt, j)
+			if wErr != nil {
+				log.Printf("error writing pong back to socket: %s", wErr.Error())
+				continue
+			}
+			continue
+		} else {
+			go postProcessMessage(message, serverAddr)
+		}
+	}
+}

--- a/slacktest/handlers_test.go
+++ b/slacktest/handlers_test.go
@@ -1,0 +1,96 @@
+package slacktest
+
+import (
+	"testing"
+
+	slack "github.com/nlopes/slack"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPostMessageHandler(t *testing.T) {
+	s := NewTestServer()
+	go s.Start()
+
+	client := slack.New("ABCDEFG", slack.OptionAPIURL(s.GetAPIURL()))
+	channel, tstamp, err := client.PostMessage("foo", slack.MsgOptionText("some text", false), slack.MsgOptionPostMessageParameters(slack.PostMessageParameters{}))
+	assert.NoError(t, err, "should not error out")
+	assert.Equal(t, "foo", channel, "channel should be correct")
+	assert.NotEmpty(t, tstamp, "timestamp should not be empty")
+}
+
+func TestServerListChannels(t *testing.T) {
+	s := NewTestServer()
+	go s.Start()
+
+	client := slack.New("ABCDEFG", slack.OptionAPIURL(s.GetAPIURL()))
+	channels, err := client.GetChannels(true)
+	assert.NoError(t, err)
+	assert.Len(t, channels, 2)
+	assert.Equal(t, "C024BE91L", channels[0].ID)
+	assert.Equal(t, "C024BE92L", channels[1].ID)
+	for _, channel := range channels {
+		assert.Equal(t, "W012A3CDE", channel.Creator)
+	}
+}
+
+func TestUserInfoHandler(t *testing.T) {
+	s := NewTestServer()
+	go s.Start()
+
+	client := slack.New("ABCDEFG", slack.OptionAPIURL(s.GetAPIURL()))
+	user, err := client.GetUserInfo("123456")
+	assert.NoError(t, err)
+	assert.Equal(t, "W012A3CDE", user.ID)
+	assert.Equal(t, "spengler", user.Name)
+	assert.True(t, user.IsAdmin)
+}
+
+func TestBotInfoHandler(t *testing.T) {
+	s := NewTestServer()
+	go s.Start()
+
+	client := slack.New("ABCDEFG", slack.OptionAPIURL(s.GetAPIURL()))
+	bot, err := client.GetBotInfo(s.BotID)
+	assert.NoError(t, err)
+	assert.Equal(t, s.BotID, bot.ID)
+	assert.Equal(t, s.BotName, bot.Name)
+	assert.False(t, bot.Deleted)
+}
+
+func TestListGroupsHandler(t *testing.T) {
+	s := NewTestServer()
+	go s.Start()
+
+	client := slack.New("ABCDEFG", slack.OptionAPIURL(s.GetAPIURL()))
+	groups, err := client.GetGroups(true)
+	assert.NoError(t, err)
+	if !assert.Len(t, groups, 1, "should have one group") {
+		t.FailNow()
+	}
+	mygroup := groups[0]
+	assert.Equal(t, "G024BE91L", mygroup.ID, "id should match")
+	assert.Equal(t, "secretplans", mygroup.Name, "name should match")
+	assert.True(t, mygroup.IsGroup, "should be a group")
+}
+
+func TestListChannelsHandler(t *testing.T) {
+	s := NewTestServer()
+	go s.Start()
+
+	client := slack.New("ABCDEFG", slack.OptionAPIURL(s.GetAPIURL()))
+	channels, err := client.GetChannels(true)
+	assert.NoError(t, err)
+	if !assert.Len(t, channels, 2, "should have two channels") {
+		t.FailNow()
+	}
+	generalChan := channels[0]
+	otherChan := channels[1]
+	assert.Equal(t, "C024BE91L", generalChan.ID, "id should match")
+	assert.Equal(t, "general", generalChan.Name, "name should match")
+	assert.Equal(t, "Fun times", generalChan.Topic.Value)
+	assert.True(t, generalChan.IsMember, "should be in channel")
+	assert.Equal(t, "C024BE92L", otherChan.ID, "id should match")
+	assert.Equal(t, "bot-playground", otherChan.Name, "name should match")
+	assert.Equal(t, "Fun times", otherChan.Topic.Value)
+	assert.True(t, otherChan.IsMember, "should be in channel")
+}

--- a/slacktest/rtm_test.go
+++ b/slacktest/rtm_test.go
@@ -1,0 +1,126 @@
+package slacktest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nlopes/slack"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRTMInfo(t *testing.T) {
+	maxWait := 10 * time.Millisecond
+	s := NewTestServer()
+	go s.Start()
+
+	api := slack.New("ABCDEFG", slack.OptionAPIURL(s.GetAPIURL()))
+	rtm := api.NewRTM()
+	go rtm.ManageConnection()
+	messageChan := make(chan (*slack.ConnectedEvent), 1)
+	go func() {
+		for msg := range rtm.IncomingEvents {
+			switch ev := msg.Data.(type) {
+			case *slack.ConnectedEvent:
+				messageChan <- ev
+			}
+		}
+	}()
+	select {
+	case m := <-messageChan:
+		assert.Equal(t, s.BotID, m.Info.User.ID, "bot id did not match")
+		assert.Equal(t, s.BotName, m.Info.User.Name, "bot name did not match")
+		break
+	case <-time.After(maxWait):
+		assert.FailNow(t, "did not get connected event in time")
+
+	}
+}
+
+func TestRTMPing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping timered test")
+	}
+	maxWait := 45 * time.Second
+	s := NewTestServer()
+	go s.Start()
+
+	api := slack.New("ABCDEFG", slack.OptionAPIURL(s.GetAPIURL()))
+	rtm := api.NewRTM()
+	go rtm.ManageConnection()
+	messageChan := make(chan (*slack.LatencyReport), 1)
+	go func() {
+		for msg := range rtm.IncomingEvents {
+			switch ev := msg.Data.(type) {
+			case *slack.LatencyReport:
+				messageChan <- ev
+			}
+		}
+	}()
+	select {
+	case m := <-messageChan:
+		assert.NotEmpty(t, m.Value, "latency report should value a value")
+		assert.True(t, m.Value > 0, "latency report should be greater than 0")
+		break
+	case <-time.After(maxWait):
+		assert.FailNow(t, "did not get latency report in time")
+
+	}
+}
+
+func TestRTMDirectMessage(t *testing.T) {
+	maxWait := 5 * time.Second
+	s := NewTestServer()
+	go s.Start()
+
+	api := slack.New("ABCDEFG", slack.OptionAPIURL(s.GetAPIURL()))
+	rtm := api.NewRTM()
+	go rtm.ManageConnection()
+	messageChan := make(chan (*slack.MessageEvent), 1)
+	go func() {
+		for msg := range rtm.IncomingEvents {
+			switch ev := msg.Data.(type) {
+			case *slack.MessageEvent:
+				messageChan <- ev
+			}
+		}
+	}()
+	s.SendDirectMessageToBot("some text")
+	select {
+	case m := <-messageChan:
+		assert.Equal(t, defaultNonBotUserID, m.User)
+		assert.Equal(t, "D024BE91L", m.Channel)
+		assert.Equal(t, "some text", m.Text)
+		break
+	case <-time.After(maxWait):
+		assert.FailNow(t, "did not get direct message in time")
+	}
+}
+
+func TestRTMChannelMessage(t *testing.T) {
+	maxWait := 5 * time.Second
+	s := NewTestServer()
+	go s.Start()
+
+	api := slack.New("ABCDEFG", slack.OptionAPIURL(s.GetAPIURL()))
+	rtm := api.NewRTM()
+	go rtm.ManageConnection()
+	messageChan := make(chan (*slack.MessageEvent), 1)
+	go func() {
+		for msg := range rtm.IncomingEvents {
+			switch ev := msg.Data.(type) {
+			case *slack.MessageEvent:
+				messageChan <- ev
+			}
+		}
+	}()
+	s.SendMessageToChannel("#foochan", "some text")
+	select {
+	case m := <-messageChan:
+		assert.Equal(t, "#foochan", m.Channel)
+		assert.Equal(t, "some text", m.Text)
+		break
+	case <-time.After(maxWait):
+		assert.FailNow(t, "did not get channel message in time")
+	}
+
+}

--- a/slacktest/server.go
+++ b/slacktest/server.go
@@ -1,0 +1,309 @@
+package slacktest
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/nlopes/slack"
+)
+
+func newMessageChannels() *messageChannels {
+	sent := make(chan (string))
+	seen := make(chan (string))
+	mc := messageChannels{
+		seen: seen,
+		sent: sent,
+	}
+	return &mc
+}
+
+// Customize the server's responses.
+type Customize interface {
+	Handle(pattern string, handler http.HandlerFunc)
+}
+
+type binder func(Customize)
+
+// NewTestServer returns a slacktest.Server ready to be started
+func NewTestServer(custom ...binder) *Server {
+	serverChans := newMessageChannels()
+	seenInboundMessages = &messageCollection{}
+	seenOutboundMessages = &messageCollection{}
+	channels := &serverChannels{}
+	groups := &serverGroups{}
+	s := &Server{
+		mux: http.NewServeMux(),
+	}
+
+	s.mux.Handle("/ws", contextHandler(s, wsHandler))
+	s.mux.Handle("/rtm.start", contextHandler(s, rtmStartHandler))
+	s.mux.Handle("/rtm.connect", contextHandler(s, rtmConnectHandler))
+	s.mux.Handle("/chat.postMessage", contextHandler(s, postMessageHandler))
+	s.mux.Handle("/channels.list", contextHandler(s, listChannelsHandler))
+	s.mux.Handle("/groups.list", contextHandler(s, listGroupsHandler))
+	s.mux.Handle("/users.info", contextHandler(s, usersInfoHandler))
+	s.mux.Handle("/bots.info", contextHandler(s, botsInfoHandler))
+
+	for _, c := range custom {
+		c(s)
+	}
+
+	httpserver := httptest.NewUnstartedServer(s.mux)
+	addr := httpserver.Listener.Addr().String()
+
+	s.ServerAddr = addr
+	s.server = httpserver
+	s.BotName = defaultBotName
+	s.BotID = defaultBotID
+	s.SeenFeed = serverChans.seen
+	s.channels = channels
+	s.groups = groups
+
+	addErr := addServerToHub(s, serverChans)
+	if addErr != nil {
+		log.Printf("Unable to add server to hub: %s", addErr.Error())
+	}
+
+	return s
+}
+
+// Handle allow for customizing endpoints
+func (sts *Server) Handle(pattern string, handler http.HandlerFunc) {
+	sts.mux.Handle(pattern, contextHandler(sts, handler))
+}
+
+// GetChannels returns all the fake channels registered
+func (sts *Server) GetChannels() []slack.Channel {
+	sts.channels.RLock()
+	defer sts.channels.RUnlock()
+	return sts.channels.channels
+}
+
+// GetGroups returns all the fake groups registered
+func (sts *Server) GetGroups() []slack.Group {
+	return sts.groups.channels
+}
+
+/*
+// These are placeholders for now
+// AddChannel adds a new fake channel
+func (sts *Server) AddChannel(c slack.Channel) {
+	sts.channels.Lock()
+	sts.channels.channels = append(sts.channels.channels, c)
+	sts.channels.Unlock()
+}
+
+// AddGroup adds a new fake group
+func (sts *Server) AddGroup(c slack.Group) {
+	sts.groups.Lock()
+	sts.groups.channels = append(sts.groups.channels, c)
+	sts.groups.Unlock()
+}
+*/
+
+// GetSeenInboundMessages returns all messages seen via websocket excluding pings
+func (sts *Server) GetSeenInboundMessages() []string {
+	seenInboundMessages.RLock()
+	m := seenInboundMessages.messages
+	seenInboundMessages.RUnlock()
+	return m
+}
+
+// GetSeenOutboundMessages returns all messages seen via websocket excluding pings
+func (sts *Server) GetSeenOutboundMessages() []string {
+	seenOutboundMessages.RLock()
+	m := seenOutboundMessages.messages
+	seenOutboundMessages.RUnlock()
+	return m
+}
+
+// SawOutgoingMessage checks if a message was sent to connected websocket clients
+func (sts *Server) SawOutgoingMessage(msg string) bool {
+	seenOutboundMessages.RLock()
+	defer seenOutboundMessages.RUnlock()
+	for _, m := range seenOutboundMessages.messages {
+		evt := &slack.MessageEvent{}
+		jErr := json.Unmarshal([]byte(m), evt)
+		if jErr != nil {
+			continue
+		}
+		if evt.Text == msg {
+			return true
+		}
+	}
+	return false
+}
+
+// SawMessage checks if an incoming message was seen
+func (sts *Server) SawMessage(msg string) bool {
+	seenInboundMessages.RLock()
+	defer seenInboundMessages.RUnlock()
+	for _, m := range seenInboundMessages.messages {
+		evt := &slack.MessageEvent{}
+		jErr := json.Unmarshal([]byte(m), evt)
+		if jErr != nil {
+			// This event isn't a message event so we'll skip it
+			continue
+		}
+		if evt.Text == msg {
+			return true
+		}
+	}
+	return false
+}
+
+// GetAPIURL returns the api url you can pass to slack.SLACK_API
+func (sts *Server) GetAPIURL() string {
+	return "http://" + sts.ServerAddr + "/"
+}
+
+// GetWSURL returns the websocket url
+func (sts *Server) GetWSURL() string {
+	return "ws://" + sts.ServerAddr + "/ws"
+}
+
+// Stop stops the test server
+func (sts *Server) Stop() {
+	sts.server.Close()
+}
+
+// Start starts the test server
+func (sts *Server) Start() {
+	log.Print("starting server")
+	sts.server.Start()
+}
+
+// SendMessageToBot sends a message addressed to the Bot
+func (sts *Server) SendMessageToBot(channel, msg string) {
+	m := slack.Message{}
+	m.Type = slack.TYPE_MESSAGE
+	m.Channel = channel
+	m.User = defaultNonBotUserID
+	m.Text = fmt.Sprintf("<@%s> %s", sts.BotID, msg)
+	m.Timestamp = fmt.Sprintf("%d", time.Now().Unix())
+	j, jErr := json.Marshal(m)
+	if jErr != nil {
+		log.Printf("Unable to marshal message for bot: %s", jErr.Error())
+		return
+	}
+	go queueForWebsocket(string(j), sts.ServerAddr)
+}
+
+// SendDirectMessageToBot sends a direct message to the bot
+func (sts *Server) SendDirectMessageToBot(msg string) {
+	m := slack.Message{}
+	m.Type = slack.TYPE_MESSAGE
+	m.Channel = "D024BE91L"
+	m.User = defaultNonBotUserID
+	m.Text = msg
+	m.Timestamp = fmt.Sprintf("%d", time.Now().Unix())
+	j, jErr := json.Marshal(m)
+	if jErr != nil {
+		log.Printf("Unable to marshal private message for bot: %s", jErr.Error())
+		return
+	}
+	go queueForWebsocket(string(j), sts.ServerAddr)
+}
+
+// SendMessageToChannel sends a message to a channel
+func (sts *Server) SendMessageToChannel(channel, msg string) {
+	m := slack.Message{}
+	m.Type = slack.TYPE_MESSAGE
+	m.Channel = channel
+	m.Text = msg
+	m.User = defaultNonBotUserID
+	m.Timestamp = fmt.Sprintf("%d", time.Now().Unix())
+	j, jErr := json.Marshal(m)
+	if jErr != nil {
+		log.Printf("Unable to marshal message for channel: %s", jErr.Error())
+		return
+	}
+	stringMsg := string(j)
+	go queueForWebsocket(stringMsg, sts.ServerAddr)
+}
+
+// SendToWebsocket send `s` as is to connected clients.
+// This is useful for sending your own custom json to the websocket
+func (sts *Server) SendToWebsocket(s string) {
+	go queueForWebsocket(s, sts.ServerAddr)
+}
+
+// SetBotName sets a custom botname
+func (sts *Server) SetBotName(b string) {
+	sts.BotName = b
+}
+
+// SendBotChannelInvite invites the bot to a channel
+func (sts *Server) SendBotChannelInvite() {
+	joinMsg := `
+	{
+			"type":"channel_joined",
+			"channel":
+					{
+							"id": "C024BE92L",
+							"name": "bot-playground",
+							"is_channel": true,
+							"created": 1360782804,
+							"creator": "W012A3CDE",
+							"is_archived": false,
+							"is_general": true,
+							"members": [
+									"W012A3CDE"
+							],
+							"topic": {
+									"value": "Fun times",
+									"creator": "W012A3CDE",
+									"last_set": 1360782804
+							},
+							"purpose": {
+									"value": "This channel is for fun",
+									"creator": "W012A3CDE",
+									"last_set": 1360782804
+							},
+							"is_member": true
+					}
+	}`
+	sts.SendToWebsocket(joinMsg)
+}
+
+// SendBotGroupInvite invites the bot to a channel
+func (sts *Server) SendBotGroupInvite() {
+	joinMsg := `
+	{
+			"type":"group_joined",
+			"channel":
+			{
+				"id": "G024BE91L",
+				"name": "secretplans",
+				"is_group": true,
+				"created": 1360782804,
+				"creator": "W012A3CDE",
+				"is_archived": false,
+				"members": [
+					"W012A3CDE"
+				],
+				"topic": {
+					"value": "Secret plans on hold",
+					"creator": "W012A3CDE",
+					"last_set": 1360782804
+				},
+				"purpose": {
+					"value": "Discuss secret plans that no-one else should know",
+					"creator": "W012A3CDE",
+					"last_set": 1360782804
+				}
+			}
+	}`
+	sts.SendToWebsocket(joinMsg)
+}
+
+// GetTestRTMInstance will give you an RTM instance in the context of the current fake server
+func (sts *Server) GetTestRTMInstance() *slack.RTM {
+	api := slack.New("ABCEFG", slack.OptionAPIURL(sts.GetAPIURL()))
+	rtm := api.NewRTM()
+	return rtm
+}

--- a/slacktest/server_test.go
+++ b/slacktest/server_test.go
@@ -1,0 +1,175 @@
+package slacktest
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/nlopes/slack"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultNewServer(t *testing.T) {
+	s := NewTestServer()
+	assert.Equal(t, defaultBotID, s.BotID)
+	assert.Equal(t, defaultBotName, s.BotName)
+	assert.NotEmpty(t, s.ServerAddr)
+	s.Stop()
+}
+
+func TestCustomNewServer(t *testing.T) {
+	s := NewTestServer()
+	s.SetBotName("BobsBot")
+	assert.Equal(t, "BobsBot", s.BotName)
+}
+
+func TestServerSendMessageToChannel(t *testing.T) {
+	s := NewTestServer()
+	go s.Start()
+	s.SendMessageToChannel("C123456789", "some text")
+	time.Sleep(2 * time.Second)
+	assert.True(t, s.SawOutgoingMessage("some texT"))
+	s.Stop()
+}
+
+func TestServerSendMessageToBot(t *testing.T) {
+	s := NewTestServer()
+	go s.Start()
+	s.SendMessageToBot("C123456789", "some text")
+	expectedMsg := fmt.Sprintf("<@%s> %s", s.BotID, "some text")
+	time.Sleep(2 * time.Second)
+	assert.True(t, s.SawOutgoingMessage(expectedMsg))
+	s.Stop()
+}
+
+func TestBotDirectMessageBotHandler(t *testing.T) {
+	s := NewTestServer()
+	go s.Start()
+	s.SendDirectMessageToBot("some text")
+	expectedMsg := fmt.Sprintf("some text")
+	time.Sleep(2)
+	assert.True(t, s.SawOutgoingMessage(expectedMsg))
+	s.Stop()
+}
+
+func TestGetSeenOutboundMessages(t *testing.T) {
+	maxWait := 5 * time.Second
+	s := NewTestServer()
+	go s.Start()
+
+	s.SendMessageToChannel("foo", "should see this message")
+	time.Sleep(maxWait)
+	seenOutbound := s.GetSeenOutboundMessages()
+	assert.True(t, len(seenOutbound) > 0)
+	hadMessage := false
+	for _, msg := range seenOutbound {
+		var m = slack.Message{}
+		jerr := json.Unmarshal([]byte(msg), &m)
+		assert.NoError(t, jerr, "messages should decode as slack.Message")
+		if m.Text == "should see this message" {
+			hadMessage = true
+			break
+		}
+	}
+	assert.True(t, hadMessage, "did not see my sent message")
+}
+
+func TestGetSeenInboundMessages(t *testing.T) {
+	maxWait := 5 * time.Second
+	s := NewTestServer()
+	go s.Start()
+
+	api := slack.New("ABCDEFG", slack.OptionAPIURL(s.GetAPIURL()))
+	rtm := api.NewRTM()
+	go rtm.ManageConnection()
+	rtm.SendMessage(&slack.OutgoingMessage{
+		Channel: "foo",
+		Text:    "should see this inbound message",
+	})
+	time.Sleep(maxWait)
+	seenInbound := s.GetSeenInboundMessages()
+	assert.True(t, len(seenInbound) > 0)
+	hadMessage := false
+	for _, msg := range seenInbound {
+		var m = slack.Message{}
+		jerr := json.Unmarshal([]byte(msg), &m)
+		assert.NoError(t, jerr, "messages should decode as slack.Message")
+		if m.Text == "should see this inbound message" {
+			hadMessage = true
+			break
+		}
+	}
+	assert.True(t, hadMessage, "did not see my sent message")
+	assert.True(t, s.SawMessage("should see this inbound message"))
+}
+
+func TestSendChannelInvite(t *testing.T) {
+	maxWait := 5 * time.Second
+	s := NewTestServer()
+	go s.Start()
+	rtm := s.GetTestRTMInstance()
+	go rtm.ManageConnection()
+	evChan := make(chan (slack.Channel), 1)
+	go func() {
+		for msg := range rtm.IncomingEvents {
+			switch ev := msg.Data.(type) {
+			case *slack.ChannelJoinedEvent:
+				evChan <- ev.Channel
+			}
+		}
+	}()
+	s.SendBotChannelInvite()
+	time.Sleep(maxWait)
+	select {
+	case m := <-evChan:
+		assert.Equal(t, "C024BE92L", m.ID, "channel id should match")
+		assert.Equal(t, "Fun times", m.Topic.Value, "topic should match")
+		s.Stop()
+		break
+	case <-time.After(maxWait):
+		assert.FailNow(t, "did not get channel joined event in time")
+	}
+
+}
+
+func TestSendGroupInvite(t *testing.T) {
+	maxWait := 5 * time.Second
+	s := NewTestServer()
+	go s.Start()
+	rtm := s.GetTestRTMInstance()
+	go rtm.ManageConnection()
+	evChan := make(chan (slack.Channel), 1)
+	go func() {
+		for msg := range rtm.IncomingEvents {
+			switch ev := msg.Data.(type) {
+			case *slack.GroupJoinedEvent:
+				evChan <- ev.Channel
+			}
+		}
+	}()
+	s.SendBotGroupInvite()
+	time.Sleep(maxWait)
+	select {
+	case m := <-evChan:
+		assert.Equal(t, "G024BE91L", m.ID, "channel id should match")
+		assert.Equal(t, "Secret plans on hold", m.Topic.Value, "topic should match")
+		s.Stop()
+		break
+	case <-time.After(maxWait):
+		assert.FailNow(t, "did not get group joined event in time")
+	}
+
+}
+
+func TestServerSawMessage(t *testing.T) {
+	s := NewTestServer()
+	go s.Start()
+	assert.False(t, s.SawMessage("foo"), "should not have seen any message")
+}
+
+func TestServerSawOutgoingMessage(t *testing.T) {
+	s := NewTestServer()
+	go s.Start()
+	assert.False(t, s.SawOutgoingMessage("foo"), "should not have seen any message")
+}

--- a/slacktest/types.go
+++ b/slacktest/types.go
@@ -1,0 +1,81 @@
+package slacktest
+
+import (
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+
+	"github.com/nlopes/slack"
+)
+
+type contextKey string
+
+// ServerURLContextKey is the context key to store the server's url
+const ServerURLContextKey contextKey = "__SERVER_URL__"
+
+// ServerWSContextKey is the context key to store the server's ws url
+const ServerWSContextKey contextKey = "__SERVER_WS_URL__"
+
+// ServerBotNameContextKey is the bot name
+const ServerBotNameContextKey contextKey = "__SERVER_BOTNAME__"
+
+// ServerBotIDContextKey is the bot userid
+const ServerBotIDContextKey contextKey = "__SERVER_BOTID__"
+
+// ServerBotChannelsContextKey is the list of channels associated with the fake server
+const ServerBotChannelsContextKey contextKey = "__SERVER_CHANNELS__"
+
+// ServerBotGroupsContextKey is the list of channels associated with the fake server
+const ServerBotGroupsContextKey contextKey = "__SERVER_GROUPS__"
+
+// ServerBotHubNameContextKey is the context key for passing along the server name registered in the hub
+const ServerBotHubNameContextKey contextKey = "__SERVER_HUBNAME__"
+
+var seenInboundMessages *messageCollection
+var seenOutboundMessages *messageCollection
+
+var masterHub = newHub()
+
+type hub struct {
+	sync.RWMutex
+	serverChannels map[string]*messageChannels
+}
+
+type messageChannels struct {
+	seen   chan (string)
+	sent   chan (string)
+	posted chan (slack.Message)
+}
+type messageCollection struct {
+	sync.RWMutex
+	messages []string
+}
+
+type serverChannels struct {
+	sync.RWMutex
+	channels []slack.Channel
+}
+
+type serverGroups struct {
+	sync.RWMutex
+	channels []slack.Group
+}
+
+// Server represents a Slack Test server
+type Server struct {
+	server     *httptest.Server
+	mux        *http.ServeMux
+	Logger     *log.Logger
+	BotName    string
+	BotID      string
+	ServerAddr string
+	SeenFeed   chan (string)
+	channels   *serverChannels
+	groups     *serverGroups
+}
+
+type fullInfoSlackResponse struct {
+	slack.Info
+	slack.SlackResponse
+}

--- a/stars.go
+++ b/stars.go
@@ -2,7 +2,6 @@ package slack
 
 import (
 	"context"
-	"errors"
 	"net/url"
 	"strconv"
 )
@@ -58,7 +57,7 @@ func (api *Client) AddStarContext(ctx context.Context, channel string, item Item
 	}
 
 	response := &SlackResponse{}
-	if err := postSlackMethod(ctx, api.httpclient, "stars.add", values, response, api); err != nil {
+	if err := api.postMethod(ctx, "stars.add", values, response); err != nil {
 		return err
 	}
 
@@ -87,7 +86,7 @@ func (api *Client) RemoveStarContext(ctx context.Context, channel string, item I
 	}
 
 	response := &SlackResponse{}
-	if err := postSlackMethod(ctx, api.httpclient, "stars.remove", values, response, api); err != nil {
+	if err := api.postMethod(ctx, "stars.remove", values, response); err != nil {
 		return err
 	}
 
@@ -115,13 +114,15 @@ func (api *Client) ListStarsContext(ctx context.Context, params StarsParameters)
 	}
 
 	response := &listResponseFull{}
-	err := postSlackMethod(ctx, api.httpclient, "stars.list", values, response, api)
+	err := api.postMethod(ctx, "stars.list", values, response)
 	if err != nil {
 		return nil, nil, err
 	}
-	if !response.Ok {
-		return nil, nil, errors.New(response.Error)
+
+	if err := response.Err(); err != nil {
+		return nil, nil, err
 	}
+
 	return response.Items, &response.Paging, nil
 }
 

--- a/stars_test.go
+++ b/stars_test.go
@@ -39,8 +39,7 @@ func (sh *starsHandler) handler(w http.ResponseWriter, r *http.Request) {
 
 func TestSlack_AddStar(t *testing.T) {
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	tests := []struct {
 		channel    string
 		ref        ItemRef
@@ -87,8 +86,7 @@ func TestSlack_AddStar(t *testing.T) {
 
 func TestSlack_RemoveStar(t *testing.T) {
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	tests := []struct {
 		channel    string
 		ref        ItemRef
@@ -135,8 +133,7 @@ func TestSlack_RemoveStar(t *testing.T) {
 
 func TestSlack_ListStars(t *testing.T) {
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	rh := newStarsHandler()
 	http.HandleFunc("/stars.list", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
 	rh.response = `{"ok": true,

--- a/team.go
+++ b/team.go
@@ -66,9 +66,9 @@ func NewAccessLogParameters() AccessLogParameters {
 	}
 }
 
-func teamRequest(ctx context.Context, client httpClient, path string, values url.Values, d debug) (*TeamResponse, error) {
+func (api *Client) teamRequest(ctx context.Context, path string, values url.Values) (*TeamResponse, error) {
 	response := &TeamResponse{}
-	err := postSlackMethod(ctx, client, path, values, response, d)
+	err := api.postMethod(ctx, path, values, response)
 	if err != nil {
 		return nil, err
 	}
@@ -76,9 +76,9 @@ func teamRequest(ctx context.Context, client httpClient, path string, values url
 	return response, response.Err()
 }
 
-func billableInfoRequest(ctx context.Context, client httpClient, path string, values url.Values, d debug) (map[string]BillingActive, error) {
+func (api *Client) billableInfoRequest(ctx context.Context, path string, values url.Values) (map[string]BillingActive, error) {
 	response := &BillableInfoResponse{}
-	err := postSlackMethod(ctx, client, path, values, response, d)
+	err := api.postMethod(ctx, path, values, response)
 	if err != nil {
 		return nil, err
 	}
@@ -86,9 +86,9 @@ func billableInfoRequest(ctx context.Context, client httpClient, path string, va
 	return response.BillableInfo, response.Err()
 }
 
-func accessLogsRequest(ctx context.Context, client httpClient, path string, values url.Values, d debug) (*LoginResponse, error) {
+func (api *Client) accessLogsRequest(ctx context.Context, path string, values url.Values) (*LoginResponse, error) {
 	response := &LoginResponse{}
-	err := postSlackMethod(ctx, client, path, values, response, d)
+	err := api.postMethod(ctx, path, values, response)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (api *Client) GetTeamInfoContext(ctx context.Context) (*TeamInfo, error) {
 		"token": {api.token},
 	}
 
-	response, err := teamRequest(ctx, api.httpclient, "team.info", values, api)
+	response, err := api.teamRequest(ctx, "team.info", values)
 	if err != nil {
 		return nil, err
 	}
@@ -130,24 +130,26 @@ func (api *Client) GetAccessLogsContext(ctx context.Context, params AccessLogPar
 		values.Add("page", strconv.Itoa(params.Page))
 	}
 
-	response, err := accessLogsRequest(ctx, api.httpclient, "team.accessLogs", values, api)
+	response, err := api.accessLogsRequest(ctx, "team.accessLogs", values)
 	if err != nil {
 		return nil, nil, err
 	}
 	return response.Logins, &response.Paging, nil
 }
 
+// GetBillableInfo ...
 func (api *Client) GetBillableInfo(user string) (map[string]BillingActive, error) {
 	return api.GetBillableInfoContext(context.Background(), user)
 }
 
+// GetBillableInfoContext ...
 func (api *Client) GetBillableInfoContext(ctx context.Context, user string) (map[string]BillingActive, error) {
 	values := url.Values{
 		"token": {api.token},
 		"user":  {user},
 	}
 
-	return billableInfoRequest(ctx, api.httpclient, "team.billableInfo", values, api)
+	return api.billableInfoRequest(ctx, "team.billableInfo", values)
 }
 
 // GetBillableInfoForTeam returns the billing_active status of all users on the team.
@@ -161,5 +163,5 @@ func (api *Client) GetBillableInfoForTeamContext(ctx context.Context) (map[strin
 		"token": {api.token},
 	}
 
-	return billableInfoRequest(ctx, api.httpclient, "team.billableInfo", values, api)
+	return api.billableInfoRequest(ctx, "team.billableInfo", values)
 }

--- a/team_test.go
+++ b/team_test.go
@@ -31,8 +31,7 @@ func TestGetTeamInfo(t *testing.T) {
 	http.HandleFunc("/team.info", getTeamInfo)
 
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	teamInfo, err := api.GetTeamInfo()
 	if err != nil {
@@ -95,8 +94,7 @@ func TestGetAccessLogs(t *testing.T) {
 	http.HandleFunc("/team.accessLogs", getTeamAccessLogs)
 
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	logins, paging, err := api.GetAccessLogs(NewAccessLogParameters())
 	if err != nil {

--- a/usergroups.go
+++ b/usergroups.go
@@ -40,9 +40,9 @@ type userGroupResponseFull struct {
 	SlackResponse
 }
 
-func userGroupRequest(ctx context.Context, client httpClient, path string, values url.Values, d debug) (*userGroupResponseFull, error) {
+func (api *Client) userGroupRequest(ctx context.Context, path string, values url.Values) (*userGroupResponseFull, error) {
 	response := &userGroupResponseFull{}
-	err := postSlackMethod(ctx, client, path, values, response, d)
+	err := api.postMethod(ctx, path, values, response)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (api *Client) CreateUserGroupContext(ctx context.Context, userGroup UserGro
 		values["channels"] = []string{strings.Join(userGroup.Prefs.Channels, ",")}
 	}
 
-	response, err := userGroupRequest(ctx, api.httpclient, "usergroups.create", values, api)
+	response, err := api.userGroupRequest(ctx, "usergroups.create", values)
 	if err != nil {
 		return UserGroup{}, err
 	}
@@ -93,7 +93,7 @@ func (api *Client) DisableUserGroupContext(ctx context.Context, userGroup string
 		"usergroup": {userGroup},
 	}
 
-	response, err := userGroupRequest(ctx, api.httpclient, "usergroups.disable", values, api)
+	response, err := api.userGroupRequest(ctx, "usergroups.disable", values)
 	if err != nil {
 		return UserGroup{}, err
 	}
@@ -112,7 +112,7 @@ func (api *Client) EnableUserGroupContext(ctx context.Context, userGroup string)
 		"usergroup": {userGroup},
 	}
 
-	response, err := userGroupRequest(ctx, api.httpclient, "usergroups.enable", values, api)
+	response, err := api.userGroupRequest(ctx, "usergroups.enable", values)
 	if err != nil {
 		return UserGroup{}, err
 	}
@@ -176,7 +176,7 @@ func (api *Client) GetUserGroupsContext(ctx context.Context, options ...GetUserG
 		values.Add("include_users", "true")
 	}
 
-	response, err := userGroupRequest(ctx, api.httpclient, "usergroups.list", values, api)
+	response, err := api.userGroupRequest(ctx, "usergroups.list", values)
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +207,7 @@ func (api *Client) UpdateUserGroupContext(ctx context.Context, userGroup UserGro
 		values["description"] = []string{userGroup.Description}
 	}
 
-	response, err := userGroupRequest(ctx, api.httpclient, "usergroups.update", values, api)
+	response, err := api.userGroupRequest(ctx, "usergroups.update", values)
 	if err != nil {
 		return UserGroup{}, err
 	}
@@ -226,7 +226,7 @@ func (api *Client) GetUserGroupMembersContext(ctx context.Context, userGroup str
 		"usergroup": {userGroup},
 	}
 
-	response, err := userGroupRequest(ctx, api.httpclient, "usergroups.users.list", values, api)
+	response, err := api.userGroupRequest(ctx, "usergroups.users.list", values)
 	if err != nil {
 		return []string{}, err
 	}
@@ -246,7 +246,7 @@ func (api *Client) UpdateUserGroupMembersContext(ctx context.Context, userGroup 
 		"users":     {members},
 	}
 
-	response, err := userGroupRequest(ctx, api.httpclient, "usergroups.users.update", values, api)
+	response, err := api.userGroupRequest(ctx, "usergroups.users.update", values)
 	if err != nil {
 		return UserGroup{}, err
 	}

--- a/usergroups_test.go
+++ b/usergroups_test.go
@@ -61,8 +61,7 @@ func (ugh *userGroupsHandler) handler(w http.ResponseWriter, r *http.Request) {
 
 func TestCreateUserGroup(t *testing.T) {
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	tests := []struct {
 		userGroup  UserGroup
@@ -129,7 +128,7 @@ func getUserGroups(rw http.ResponseWriter, r *http.Request) {
 			},
             "users": [
                 "user1",
-                "user2"	
+                "user2"
             ],
             "user_count": 2
         }
@@ -142,8 +141,7 @@ func TestGetUserGroups(t *testing.T) {
 	http.HandleFunc("/usergroups.list", getUserGroups)
 
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	userGroups, err := api.GetUserGroups(GetUserGroupsOptionIncludeUsers(true))
 	if err != nil {

--- a/users.go
+++ b/users.go
@@ -3,7 +3,6 @@ package slack
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/url"
 	"strconv"
 )
@@ -201,9 +200,9 @@ func NewUserSetPhotoParams() UserSetPhotoParams {
 	}
 }
 
-func userRequest(ctx context.Context, client httpClient, path string, values url.Values, d debug) (*userResponseFull, error) {
+func (api *Client) userRequest(ctx context.Context, path string, values url.Values) (*userResponseFull, error) {
 	response := &userResponseFull{}
-	err := postForm(ctx, client, APIURL+path, values, response, d)
+	err := api.postMethod(ctx, path, values, response)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +222,7 @@ func (api *Client) GetUserPresenceContext(ctx context.Context, user string) (*Us
 		"user":  {user},
 	}
 
-	response, err := userRequest(ctx, api.httpclient, "users.getPresence", values, api)
+	response, err := api.userRequest(ctx, "users.getPresence", values)
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +242,7 @@ func (api *Client) GetUserInfoContext(ctx context.Context, user string) (*User, 
 		"include_locale": {strconv.FormatBool(true)},
 	}
 
-	response, err := userRequest(ctx, api.httpclient, "users.info", values, api)
+	response, err := api.userRequest(ctx, "users.info", values)
 	if err != nil {
 		return nil, err
 	}
@@ -322,7 +321,7 @@ func (t UserPagination) Next(ctx context.Context) (_ UserPagination, err error) 
 		"include_locale": {strconv.FormatBool(true)},
 	}
 
-	if resp, err = userRequest(ctx, t.c.httpclient, "users.list", values, t.c); err != nil {
+	if resp, err = t.c.userRequest(ctx, "users.list", values); err != nil {
 		return t, err
 	}
 
@@ -367,7 +366,7 @@ func (api *Client) GetUserByEmailContext(ctx context.Context, email string) (*Us
 		"token": {api.token},
 		"email": {email},
 	}
-	response, err := userRequest(ctx, api.httpclient, "users.lookupByEmail", values, api)
+	response, err := api.userRequest(ctx, "users.lookupByEmail", values)
 	if err != nil {
 		return nil, err
 	}
@@ -385,7 +384,7 @@ func (api *Client) SetUserAsActiveContext(ctx context.Context) (err error) {
 		"token": {api.token},
 	}
 
-	_, err = userRequest(ctx, api.httpclient, "users.setActive", values, api)
+	_, err = api.userRequest(ctx, "users.setActive", values)
 	return err
 }
 
@@ -401,7 +400,7 @@ func (api *Client) SetUserPresenceContext(ctx context.Context, presence string) 
 		"presence": {presence},
 	}
 
-	_, err := userRequest(ctx, api.httpclient, "users.setPresence", values, api)
+	_, err := api.userRequest(ctx, "users.setPresence", values)
 	return err
 }
 
@@ -417,13 +416,15 @@ func (api *Client) GetUserIdentityContext(ctx context.Context) (*UserIdentityRes
 	}
 	response := &UserIdentityResponse{}
 
-	err := postForm(ctx, api.httpclient, APIURL+"users.identity", values, response, api)
+	err := api.postMethod(ctx, "users.identity", values, response)
 	if err != nil {
 		return nil, err
 	}
-	if !response.Ok {
-		return nil, errors.New(response.Error)
+
+	if err := response.Err(); err != nil {
+		return nil, err
 	}
+
 	return response, nil
 }
 
@@ -448,7 +449,7 @@ func (api *Client) SetUserPhotoContext(ctx context.Context, image string, params
 		values.Add("crop_w", strconv.Itoa(params.CropW))
 	}
 
-	err := postLocalWithMultipartResponse(ctx, api.httpclient, "users.setPhoto", image, "image", values, response, api)
+	err := postLocalWithMultipartResponse(ctx, api.httpclient, api.endpoint+"users.setPhoto", image, "image", values, response, api)
 	if err != nil {
 		return err
 	}
@@ -468,7 +469,7 @@ func (api *Client) DeleteUserPhotoContext(ctx context.Context) error {
 		"token": {api.token},
 	}
 
-	err := postForm(ctx, api.httpclient, APIURL+"users.deletePhoto", values, response, api)
+	err := api.postMethod(ctx, "users.deletePhoto", values, response)
 	if err != nil {
 		return err
 	}
@@ -521,15 +522,11 @@ func (api *Client) SetUserCustomStatusContext(ctx context.Context, statusText, s
 	}
 
 	response := &userResponseFull{}
-	if err = postForm(ctx, api.httpclient, APIURL+"users.profile.set", values, response, api); err != nil {
+	if err = api.postMethod(ctx, "users.profile.set", values, response); err != nil {
 		return err
 	}
 
-	if !response.Ok {
-		return errors.New(response.Error)
-	}
-
-	return nil
+	return response.Err()
 }
 
 // UnsetUserCustomStatus removes the custom status message for the currently
@@ -562,12 +559,14 @@ func (api *Client) GetUserProfileContext(ctx context.Context, userID string, inc
 	}
 	resp := &getUserProfileResponse{}
 
-	err := postSlackMethod(ctx, api.httpclient, "users.profile.get", values, &resp, api)
+	err := api.postMethod(ctx, "users.profile.get", values, &resp)
 	if err != nil {
 		return nil, err
 	}
-	if !resp.Ok {
-		return nil, errors.New(resp.Error)
+
+	if err := resp.Err(); err != nil {
+		return nil, err
 	}
+
 	return resp.Profile, nil
 }

--- a/users_test.go
+++ b/users_test.go
@@ -182,8 +182,7 @@ func TestGetUserIdentity(t *testing.T) {
 	http.HandleFunc("/users.identity", getUserIdentity)
 
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	identity, err := api.GetUserIdentity()
 	if err != nil {
@@ -223,8 +222,7 @@ func TestGetUserInfo(t *testing.T) {
 	expectedUser := getTestUser()
 
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	user, err := api.GetUserInfo("UXXXXXXXX")
 	if err != nil {
@@ -241,8 +239,7 @@ func TestGetUserByEmail(t *testing.T) {
 	expectedUser := getTestUser()
 
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	user, err := api.GetUserByEmail("test@test.com")
 	if err != nil {
@@ -262,8 +259,7 @@ func TestUserCustomStatus(t *testing.T) {
 	http.HandleFunc("/users.profile.set", setUserProfile)
 
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	testSetUserCustomStatus(api, up, t)
 	testUnsetUserCustomStatus(api, up, t)
@@ -310,8 +306,7 @@ func TestGetUsers(t *testing.T) {
 	expectedUser := getTestUser()
 
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	users, err := api.GetUsers()
 	if err != nil {
@@ -362,8 +357,7 @@ func TestSetUserPhoto(t *testing.T) {
 	http.HandleFunc("/users.setPhoto", setUserPhotoHandler(fileContent, params))
 
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New(validToken)
+	api := New(validToken, OptionAPIURL("http://"+serverAddr+"/"))
 
 	err := api.SetUserPhoto(file.Name(), params)
 	if err != nil {
@@ -469,8 +463,7 @@ func getUserProfileHandler(rw http.ResponseWriter, r *http.Request) {
 func TestGetUserProfile(t *testing.T) {
 	http.HandleFunc("/users.profile.get", getUserProfileHandler)
 	once.Do(startServer)
-	APIURL = "http://" + serverAddr + "/"
-	api := New("testing-token")
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	profile, err := api.GetUserProfile("UXXXXXXXX", false)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)

--- a/vendor/github.com/pkg/errors/.travis.yml
+++ b/vendor/github.com/pkg/errors/.travis.yml
@@ -1,10 +1,14 @@
 language: go
 go_import_path: github.com/pkg/errors
 go:
-  - 1.4.3
-  - 1.5.4
-  - 1.6.2
-  - 1.7.1
+  - 1.4.x
+  - 1.5.x
+  - 1.6.x
+  - 1.7.x
+  - 1.8.x
+  - 1.9.x
+  - 1.10.x
+  - 1.11.x
   - tip
 
 script:

--- a/vendor/github.com/pkg/errors/README.md
+++ b/vendor/github.com/pkg/errors/README.md
@@ -1,4 +1,4 @@
-# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![AppVeyor](https://ci.appveyor.com/api/projects/status/b98mptawhudj53ep/branch/master?svg=true)](https://ci.appveyor.com/project/davecheney/errors/branch/master) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors)
+# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![AppVeyor](https://ci.appveyor.com/api/projects/status/b98mptawhudj53ep/branch/master?svg=true)](https://ci.appveyor.com/project/davecheney/errors/branch/master) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors) [![Sourcegraph](https://sourcegraph.com/github.com/pkg/errors/-/badge.svg)](https://sourcegraph.com/github.com/pkg/errors?badge)
 
 Package errors provides simple error handling primitives.
 
@@ -47,6 +47,6 @@ We welcome pull requests, bug fixes and issue reports. With that said, the bar f
 
 Before proposing a change, please discuss your change by raising an issue.
 
-## Licence
+## License
 
 BSD-2-Clause

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -6,7 +6,7 @@
 //             return err
 //     }
 //
-// which applied recursively up the call stack results in error reports
+// which when applied recursively up the call stack results in error reports
 // without context or debugging information. The errors package allows
 // programmers to add context to the failure path in their code in a way
 // that does not destroy the original value of the error.
@@ -15,16 +15,17 @@
 //
 // The errors.Wrap function returns a new error that adds context to the
 // original error by recording a stack trace at the point Wrap is called,
-// and the supplied message. For example
+// together with the supplied message. For example
 //
 //     _, err := ioutil.ReadAll(r)
 //     if err != nil {
 //             return errors.Wrap(err, "read failed")
 //     }
 //
-// If additional control is required the errors.WithStack and errors.WithMessage
-// functions destructure errors.Wrap into its component operations of annotating
-// an error with a stack trace and an a message, respectively.
+// If additional control is required, the errors.WithStack and
+// errors.WithMessage functions destructure errors.Wrap into its component
+// operations: annotating an error with a stack trace and with a message,
+// respectively.
 //
 // Retrieving the cause of an error
 //
@@ -38,7 +39,7 @@
 //     }
 //
 // can be inspected by errors.Cause. errors.Cause will recursively retrieve
-// the topmost error which does not implement causer, which is assumed to be
+// the topmost error that does not implement causer, which is assumed to be
 // the original cause. For example:
 //
 //     switch err := errors.Cause(err).(type) {
@@ -48,16 +49,16 @@
 //             // unknown error
 //     }
 //
-// causer interface is not exported by this package, but is considered a part
-// of stable public API.
+// Although the causer interface is not exported by this package, it is
+// considered a part of its stable public interface.
 //
 // Formatted printing of errors
 //
 // All error values returned from this package implement fmt.Formatter and can
-// be formatted by the fmt package. The following verbs are supported
+// be formatted by the fmt package. The following verbs are supported:
 //
 //     %s    print the error. If the error has a Cause it will be
-//           printed recursively
+//           printed recursively.
 //     %v    see %s
 //     %+v   extended format. Each Frame of the error's StackTrace will
 //           be printed in detail.
@@ -65,13 +66,13 @@
 // Retrieving the stack trace of an error or wrapper
 //
 // New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
-// invoked. This information can be retrieved with the following interface.
+// invoked. This information can be retrieved with the following interface:
 //
 //     type stackTracer interface {
 //             StackTrace() errors.StackTrace
 //     }
 //
-// Where errors.StackTrace is defined as
+// The returned errors.StackTrace type is defined as
 //
 //     type StackTrace []Frame
 //
@@ -85,8 +86,8 @@
 //             }
 //     }
 //
-// stackTracer interface is not exported by this package, but is considered a part
-// of stable public API.
+// Although the stackTracer interface is not exported by this package, it is
+// considered a part of its stable public interface.
 //
 // See the documentation for Frame.Format for more details.
 package errors
@@ -192,7 +193,7 @@ func Wrap(err error, message string) error {
 }
 
 // Wrapf returns an error annotating err with a stack trace
-// at the point Wrapf is call, and the format specifier.
+// at the point Wrapf is called, and the format specifier.
 // If err is nil, Wrapf returns nil.
 func Wrapf(err error, format string, args ...interface{}) error {
 	if err == nil {
@@ -217,6 +218,18 @@ func WithMessage(err error, message string) error {
 	return &withMessage{
 		cause: err,
 		msg:   message,
+	}
+}
+
+// WithMessagef annotates err with the format specifier.
+// If err is nil, WithMessagef returns nil.
+func WithMessagef(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
 	}
 }
 

--- a/vendor/github.com/pkg/errors/stack.go
+++ b/vendor/github.com/pkg/errors/stack.go
@@ -46,7 +46,8 @@ func (f Frame) line() int {
 //
 // Format accepts flags that alter the printing of some verbs, as follows:
 //
-//    %+s   path of source file relative to the compile time GOPATH
+//    %+s   function name and path of source file relative to the compile time
+//          GOPATH separated by \n\t (<funcname>\n\t<path>)
 //    %+v   equivalent to %+s:%d
 func (f Frame) Format(s fmt.State, verb rune) {
 	switch verb {
@@ -79,6 +80,14 @@ func (f Frame) Format(s fmt.State, verb rune) {
 // StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
 type StackTrace []Frame
 
+// Format formats the stack of Frames according to the fmt.Formatter interface.
+//
+//    %s	lists source files for each Frame in the stack
+//    %v	lists the source file and line number for each Frame in the stack
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+v   Prints filename, function, and line number for each Frame in the stack.
 func (st StackTrace) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':
@@ -135,44 +144,4 @@ func funcname(name string) string {
 	name = name[i+1:]
 	i = strings.Index(name, ".")
 	return name[i+1:]
-}
-
-func trimGOPATH(name, file string) string {
-	// Here we want to get the source file path relative to the compile time
-	// GOPATH. As of Go 1.6.x there is no direct way to know the compiled
-	// GOPATH at runtime, but we can infer the number of path segments in the
-	// GOPATH. We note that fn.Name() returns the function name qualified by
-	// the import path, which does not include the GOPATH. Thus we can trim
-	// segments from the beginning of the file path until the number of path
-	// separators remaining is one more than the number of path separators in
-	// the function name. For example, given:
-	//
-	//    GOPATH     /home/user
-	//    file       /home/user/src/pkg/sub/file.go
-	//    fn.Name()  pkg/sub.Type.Method
-	//
-	// We want to produce:
-	//
-	//    pkg/sub/file.go
-	//
-	// From this we can easily see that fn.Name() has one less path separator
-	// than our desired output. We count separators from the end of the file
-	// path until it finds two more than in the function name and then move
-	// one character forward to preserve the initial path segment without a
-	// leading separator.
-	const sep = "/"
-	goal := strings.Count(name, sep) + 2
-	i := len(file)
-	for n := 0; n < goal; n++ {
-		i = strings.LastIndex(file[:i], sep)
-		if i == -1 {
-			// not enough separators found, set i so that the slice expression
-			// below leaves file unmodified
-			i = -len(sep)
-			break
-		}
-	}
-	// get back to 0 or trim the leading separator
-	file = file[i+len(sep):]
-	return file
 }

--- a/websocket_internals.go
+++ b/websocket_internals.go
@@ -18,6 +18,7 @@ type ConnectedEvent struct {
 // ConnectionErrorEvent contains information about a connection error
 type ConnectionErrorEvent struct {
 	Attempt  int
+	Backoff  time.Duration // how long we'll wait before the next attempt
 	ErrorObj error
 }
 

--- a/websocket_managed_conn_test.go
+++ b/websocket_managed_conn_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	slacktest "github.com/lusis/slack-test"
 	"github.com/nlopes/slack"
+	"github.com/nlopes/slack/slacktest"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -55,15 +55,78 @@ func TestRTMDisconnect(t *testing.T) {
 	assert.True(t, disconnectedReceived, "Should have received a disconnected event from the RTM instance.")
 }
 
+// func TestRTMConnectRateLimit(t *testing.T) {
+// 	// Set up the test server.
+// 	testServer := slacktest.NewTestServer(
+// 		func(c slacktest.Customize) {
+// 			c.Handle("/rtm.connect", (w http.ResponseWriter, r *http.Request) {
+//
+// 			})
+// 		},
+// 	)
+// 	go testServer.Start()
+//
+// 	// Setup and start the RTM.
+// 	api := slack.New(testToken, slack.OptionAPIURL(testServer.GetAPIURL()))
+// 	rtm := api.NewRTM()
+// 	go rtm.ManageConnection()
+//
+// 	// Observe incoming messages.
+// 	done := make(chan struct{})
+// 	connectingReceived := false
+// 	connectedReceived := false
+// 	testMessageReceived := false
+// 	go func() {
+// 		for msg := range rtm.IncomingEvents {
+// 			switch ev := msg.Data.(type) {
+// 			case *slack.ConnectingEvent:
+// 				if connectingReceived {
+// 					t.Error("Received multiple connecting events.")
+// 					t.Fail()
+// 				}
+// 				connectingReceived = true
+// 			case *slack.ConnectedEvent:
+// 				if connectedReceived {
+// 					t.Error("Received multiple connected events.")
+// 					t.Fail()
+// 				}
+// 				connectedReceived = true
+// 			case *slack.MessageEvent:
+// 				if ev.Text == testMessage {
+// 					testMessageReceived = true
+// 					rtm.Disconnect()
+// 				}
+// 				t.Logf("Discarding message with content %+v", ev)
+// 			case *slack.DisconnectedEvent:
+// 				if ev.Intentional {
+// 					done <- struct{}{}
+// 					return
+// 				}
+// 			default:
+// 				t.Logf("Discarded event of type '%s' with content '%#v'", msg.Type, ev)
+// 			}
+// 		}
+// 	}()
+//
+// 	// Send a message and sleep for some time to make sure the message can be processed client-side.
+// 	testServer.SendDirectMessageToBot(testMessage)
+// 	<-done
+// 	testServer.Stop()
+//
+// 	// Verify that all expected events have been received by the RTM client.
+// 	assert.True(t, connectingReceived, "Should have received a connecting event from the RTM instance.")
+// 	assert.True(t, connectedReceived, "Should have received a connected event from the RTM instance.")
+// 	assert.True(t, testMessageReceived, "Should have received a test message from the server.")
+// }
+
 func TestRTMSingleConnect(t *testing.T) {
 	// Set up the test server.
 	testServer := slacktest.NewTestServer()
 	go testServer.Start()
 
 	// Setup and start the RTM.
-	slack.APIURL = testServer.GetAPIURL()
-	api := slack.New(testToken)
-	rtm := api.NewRTM(slack.RTMOptionUseStart(true))
+	api := slack.New(testToken, slack.OptionAPIURL(testServer.GetAPIURL()))
+	rtm := api.NewRTM()
 	go rtm.ManageConnection()
 
 	// Observe incoming messages.


### PR DESCRIPTION
lots of churn on this PR to pull some helper methods from package scoped to client scoped.

BREAKING:
- APIURL is now const, can no longer set it. use OptionAPIURL to
adjust the endpoint for a client.

WARNINGS:
- Take special care if you rely on File upload/download and
SetUserPhotoContext

- refactor internal api to support per client APIURL configuration
- adds a slacktest package (copied and modified from
lusis/slack-test)