### PR TITLE
more expressive incoming webhook errors

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -42,16 +42,16 @@ func (t SlackResponse) Err() error {
 
 // StatusCodeError represents an http response error.
 // type httpStatusCode interface { HTTPStatusCode() int } to handle it.
-type statusCodeError struct {
+type StatusCodeError struct {
 	Code   int
 	Status string
 }
 
-func (t statusCodeError) Error() string {
+func (t StatusCodeError) Error() string {
 	return fmt.Sprintf("slack server error: %s", t.Status)
 }
 
-func (t statusCodeError) HTTPStatusCode() int {
+func (t StatusCodeError) HTTPStatusCode() int {
 	return t.Code
 }
 
@@ -274,7 +274,7 @@ func checkStatusCode(resp *http.Response, d debug) error {
 	// Slack seems to send an HTML body along with 5xx error codes. Don't parse it.
 	if resp.StatusCode != http.StatusOK {
 		logResponse(resp, d)
-		return statusCodeError{Code: resp.StatusCode, Status: resp.Status}
+		return StatusCodeError{Code: resp.StatusCode, Status: resp.Status}
 	}
 
 	return nil

--- a/webhooks.go
+++ b/webhooks.go
@@ -30,9 +30,5 @@ func PostWebhook(url string, msg *WebhookMessage) error {
 		return errors.Wrap(err, "failed to post webhook")
 	}
 
-	if response.StatusCode != http.StatusOK {
-		return statusCodeError{Code: response.StatusCode, Status: response.Status}
-	}
-
-	return nil
+	return checkStatusCode(response, discard{})
 }

--- a/webhooks_test.go
+++ b/webhooks_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestPostWebhook_OK(t *testing.T) {
@@ -61,5 +62,32 @@ func TestPostWebhook_NotOK(t *testing.T) {
 
 	if err == nil {
 		t.Errorf("Expected to receive error")
+	}
+	if scerr, ok := err.(StatusCodeError); !ok {
+		t.Errorf("Expected error of type StatusCodeError, got %#v", err)
+	} else if scerr.Code != http.StatusInternalServerError {
+		t.Errorf("Expected %d, got %d", http.StatusInternalServerError, scerr.Code)
+	}
+}
+
+func TestPostWebhook_RateLimited(t *testing.T) {
+	once.Do(startServer)
+
+	http.HandleFunc("/webhook3", func(rw http.ResponseWriter, r *http.Request) {
+		rw.Header().Add("Retry-After", "60")
+		rw.WriteHeader(http.StatusTooManyRequests)
+	})
+
+	url := "http://" + serverAddr + "/webhook3"
+
+	err := PostWebhook(url, &WebhookMessage{})
+
+	if err == nil {
+		t.Errorf("Expected to receive error")
+	}
+	if rlerr, ok := err.(*RateLimitedError); !ok {
+		t.Errorf("Expected error of type RateLimitedError, got %#v", err)
+	} else if rlerr.RetryAfter != 60*time.Second {
+		t.Errorf("Expected retry after %s, got %s", 60*time.Second, rlerr.RetryAfter)
 	}
 }

--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -118,7 +118,7 @@ func (rtm *RTM) connect(connectionCount int, useRTMStart bool) (*Info, *websocke
 		}
 
 		switch actual := err.(type) {
-		case statusCodeError:
+		case StatusCodeError:
 			if actual.Code == http.StatusNotFound {
 				rtm.Debugf("invalid auth when connecting with RTM: %s", err)
 				rtm.IncomingEvents <- RTMEvent{"invalid_auth", &InvalidAuthEvent{}}


### PR DESCRIPTION
- Export StatusCodeError so that library consumers can check for
  errors of this type and condition on status codes
- Return RateLimitedError from PostWebhook() so that consumers can
  implement retry logic.