### PR TITLE
added enterprise id to auth test

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -41,6 +41,8 @@ type AuthTestResponse struct {
 	User   string `json:"user"`
 	TeamID string `json:"team_id"`
 	UserID string `json:"user_id"`
+	// EnterpriseID is only returned when an enterprise id present
+	EnterpriseID string `json:"enterprise_id,omitempty"`
 }
 
 type authTestResponseFull struct {


### PR DESCRIPTION
enterprise id is an optional argument from auth test to determine if
you're dealing with an enterprise org