### PR TITLE
files.list: support for cursor based pagination

### DIFF
--- a/files.go
+++ b/files.go
@@ -133,11 +133,21 @@ type GetFilesParameters struct {
 	Page          int
 }
 
+// ListFilesParameters contains all the parameters necessary (including the optional ones) for a ListFiles() request
+type ListFilesParameters struct {
+	Limit   int
+	User    string
+	Channel string
+	Types   string
+	Cursor  string
+}
+
 type fileResponseFull struct {
 	File     `json:"file"`
 	Paging   `json:"paging"`
-	Comments []Comment `json:"comments"`
-	Files    []File    `json:"files"`
+	Comments []Comment        `json:"comments"`
+	Files    []File           `json:"files"`
+	Metadata ResponseMetadata `json:"response_metadata"`
 
 	SlackResponse
 }
@@ -194,6 +204,40 @@ func (api *Client) GetFile(downloadURL string, writer io.Writer) error {
 // GetFiles retrieves all files according to the parameters given
 func (api *Client) GetFiles(params GetFilesParameters) ([]File, *Paging, error) {
 	return api.GetFilesContext(context.Background(), params)
+}
+
+// ListFiles retrieves all files according to the parameters given. Uses cursor based pagination.
+func (api *Client) ListFiles(params ListFilesParameters) ([]File, *ListFilesParameters, error) {
+	return api.ListFilesContext(context.Background(), params)
+}
+
+// ListFilesContext retrieves all files according to the parameters given with a custom context. Uses cursor based pagination.
+func (api *Client) ListFilesContext(ctx context.Context, params ListFilesParameters) ([]File, *ListFilesParameters, error) {
+	values := url.Values{
+		"token": {api.token},
+	}
+
+	if params.User != DEFAULT_FILES_USER {
+		values.Add("user", params.User)
+	}
+	if params.Channel != DEFAULT_FILES_CHANNEL {
+		values.Add("channel", params.Channel)
+	}
+	if params.Limit != DEFAULT_FILES_COUNT {
+		values.Add("limit", strconv.Itoa(params.Limit))
+	}
+	if params.Cursor != "" {
+		values.Add("cursor", params.Cursor)
+	}
+
+	response, err := api.fileRequest(ctx, "files.list", values)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	params.Cursor = response.Metadata.Cursor
+
+	return response.Files, &params, nil
 }
 
 // GetFilesContext retrieves all files according to the parameters given with a custom context


### PR DESCRIPTION
I have a slack workspace with ~6500 files uploaded to it. When trying to page through all 6500 with count/page based pagination, I noticed that after page 100 I would only get the first page of results back. After filing a support ticket with slack, they steered me to cursor based pagination for this endpoint. I didn't want to break the existing GetFiles/GetFilesContext api, so added ListFiles/ListFilesContext instead.

With these changes I'm able to page through all of my files without issue.