### PR TITLE
add parse to webhook message

### DIFF
--- a/webhooks.go
+++ b/webhooks.go
@@ -9,13 +9,14 @@ import (
 )
 
 type WebhookMessage struct {
-	Username         string       `json:"username,omitempty"`
-	IconEmoji        string       `json:"icon_emoji,omitempty"`
-	IconURL          string       `json:"icon_url,omitempty"`
-	Channel          string       `json:"channel,omitempty"`
-	ThreadTimestamp  string       `json:"thread_ts,omitempty"`
-	Text             string       `json:"text,omitempty"`
-	Attachments      []Attachment `json:"attachments,omitempty"`
+	Username        string       `json:"username,omitempty"`
+	IconEmoji       string       `json:"icon_emoji,omitempty"`
+	IconURL         string       `json:"icon_url,omitempty"`
+	Channel         string       `json:"channel,omitempty"`
+	ThreadTimestamp string       `json:"thread_ts,omitempty"`
+	Text            string       `json:"text,omitempty"`
+	Attachments     []Attachment `json:"attachments,omitempty"`
+	Parse           string       `json:"parse,omitempty"`
 }
 
 func PostWebhook(url string, msg *WebhookMessage) error {


### PR DESCRIPTION
The webhook API supports the `parse` field described here: https://api.slack.com/docs/message-formatting, e.g.

```go
package main

import (
	"os"

	"github.com/nlopes/slack"
)

func main() {
	swhURL := os.Getenv("SLACK_WEBHOOK_URL")

	slack.PostWebhook(swhURL, &slack.WebhookMessage{
		Username: "test",
		Channel:  "#test",
		Text:     "this is a url: http://www.google.com",
	})
	slack.PostWebhook(swhURL, &slack.WebhookMessage{
		Username: "test",
		Channel:  "#test",
		Text:     "this is a url: http://www.google.com",
		Parse:    "none",
	})
}
```
has the result:

![image](https://user-images.githubusercontent.com/72655/56387767-079ceb80-61da-11e9-990a-deb0504858dc.png)

