### PR TITLE
Add `auth.test` to supported APIs in the test server. 

### DIFF
--- a/slacktest/data.go
+++ b/slacktest/data.go
@@ -48,6 +48,17 @@ var defaultGroupsListJSON = fmt.Sprintf(`
 		}
 		`, defaultGroupJSON)
 
+var defaultAuthTestJSON = fmt.Sprintf(`
+	{
+		"ok": true,
+		"url": "https://localhost.localdomain/",
+		"team": "%s",
+		"user": "%s",
+		"team_id": "%s",
+		"user_id": "%s"
+	}
+`, defaultTeamName, defaultNonBotUserName, defaultTeamID, defaultNonBotUserID)
+
 var defaultUsersInfoJSON = fmt.Sprintf(`
 	{
 		"ok":true,

--- a/slacktest/handlers.go
+++ b/slacktest/handlers.go
@@ -26,7 +26,12 @@ func contextHandler(server *Server, next http.HandlerFunc) http.Handler {
 	})
 }
 
-func usersInfoHandler(w http.ResponseWriter, r *http.Request) {
+// handle auth.test
+func authTestHandler(w http.ResponseWriter, _ *http.Request) {
+	_, _ = w.Write([]byte(defaultAuthTestJSON))
+}
+
+func usersInfoHandler(w http.ResponseWriter, _ *http.Request) {
 	_, _ = w.Write([]byte(defaultUsersInfoJSON))
 }
 
@@ -35,12 +40,12 @@ func botsInfoHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // handle channels.list
-func listChannelsHandler(w http.ResponseWriter, r *http.Request) {
+func listChannelsHandler(w http.ResponseWriter, _ *http.Request) {
 	_, _ = w.Write([]byte(defaultChannelsListJSON))
 }
 
 // handle groups.list
-func listGroupsHandler(w http.ResponseWriter, r *http.Request) {
+func listGroupsHandler(w http.ResponseWriter, _ *http.Request) {
 	_, _ = w.Write([]byte(defaultGroupsListJSON))
 }
 

--- a/slacktest/handlers_test.go
+++ b/slacktest/handlers_test.go
@@ -7,6 +7,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestAuthTestHandler(t *testing.T) {
+	s := NewTestServer()
+	go s.Start()
+
+	client := slack.New("ABCDEFG", slack.OptionAPIURL(s.GetAPIURL()))
+	user, err := client.AuthTest()
+	assert.NoError(t, err, "should not error out")
+	assert.Equal(t, defaultTeamName, user.Team, "user ID should be correct")
+	assert.Equal(t, defaultTeamID, user.TeamID, "user ID should be correct")
+	assert.Equal(t, defaultNonBotUserID, user.UserID, "user ID should be correct")
+	assert.Equal(t, defaultNonBotUserName, user.User, "user ID should be correct")
+}
+
 func TestPostMessageHandler(t *testing.T) {
 	s := NewTestServer()
 	go s.Start()

--- a/slacktest/server.go
+++ b/slacktest/server.go
@@ -53,6 +53,7 @@ func NewTestServer(custom ...binder) *Server {
 	s.Handle("/groups.list", listGroupsHandler)
 	s.Handle("/users.info", usersInfoHandler)
 	s.Handle("/bots.info", botsInfoHandler)
+	s.Handle("/auth.test", authTestHandler)
 
 	httpserver := httptest.NewUnstartedServer(s.mux)
 	addr := httpserver.Listener.Addr().String()


### PR DESCRIPTION
I'm implementing a slack bot that makes use of the [auth.test](https://api.slack.com/methods/auth.test) API. For testing purposes in my own project (and perhaps the convenience of others), I've added support for that API call to the test server.

There are no behavioural changes to the core library, and I've added tests to cover the new handler in the style of the existing tests.

Please let me know if I've missed anything.