### PR TITLE
Set correct values for parse key of MsgOptionParse()

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -412,9 +412,9 @@ func MsgOptionParse(b bool) MsgOption {
 	return func(c *sendConfig) error {
 		var v string
 		if b {
-			v = "1"
+			v = "full"
 		} else {
-			v = "0"
+			v = "none"
 		}
 		c.values.Set("parse", v)
 		return nil


### PR DESCRIPTION
## Background

- I've been using the `parse` param in `chat.postMessage` API to linkify channel and usernames
  - Reference: https://api.slack.com/docs/message-formatting#parsing_modes
  > In full parse mode, we will find and linkify URLs, channel names (starting with a '#') and usernames (starting with an '@').

- When using [`chat.postMessage` tester](https://api.slack.com/methods/chat.postMessage/test), it works accordingly. We can also confirm it via `curl`.

```sh
$ curl -X POST https://slack.com/api/chat.postMessage\?token\=<REDACTED>\&channel\=general&text\=Hello%20%40rbmrclo%2C%20say%20hello%20to%20%40everyone%20in%20%23general\&parse\=full
{
    "ok": true,
    "channel": "<REDACTED>",
    "ts": "1555912405.028300",
    "message": {
        "type": "message",
        "subtype": "bot_message",
        "text": "Hello <@REDACTED>, say hello to <!everyone> in <#<REDACTED>|general>",
        "ts": "1555912405.028300",
        "username": "Slack API Tester",
        "bot_id": "<REDACTED>"
    }
}
```

## Problem

- In the current implementation, the `parse` key is being given a value of `1` or `0`. 

https://github.com/nlopes/slack/blob/65ea2b979a7ffe628676bdb6b924e2498d66c1bf/chat.go#L411-L422

- However, based from the `chat.postMessage` [documentation](https://api.slack.com/methods/chat.postMessage), it only accepts the values `full` and `none`. Where `none` is the default. 

<img width="625" alt="Screen Shot 2019-04-22 at 2 01 29 PM" src="https://user-images.githubusercontent.com/2811885/56485589-26b3ba00-6507-11e9-99b9-da793215c474.png">

## Supporting Facts

- I've created https://github.com/rbmrclo/slack-parse which demonstrates how the `MsgOptionParse()` works. TL;DR: Here's the snippet:

```go
package main

import (
	"github.com/nlopes/slack"
)

var api = slack.New("TOKEN")

func main() {
  api.PostMessage("#general",
            slack.MsgOptionText("Hello @rbmrclo, say hi to @everyone in #general", false),
            slack.MsgOptionParse(true))

  api.PostMessage("#general",
            slack.MsgOptionText("Hello @rbmrclo, say hi to @everyone in #general", false),
            slack.MsgOptionPostMessageParameters(slack.PostMessageParameters{Parse: "none"}))

  api.PostMessage("#general",
            slack.MsgOptionText("Hello @rbmrclo, say hi to @everyone in #general", false),
            slack.MsgOptionPostMessageParameters(slack.PostMessageParameters{Parse: "full"}))
}
```

- Running the code would result to:

<img width="346" alt="Screen Shot 2019-04-22 at 1 36 04 PM" src="https://user-images.githubusercontent.com/2811885/56485672-8e6a0500-6507-11e9-9dd0-c71f5502e601.png">

## Conclusion

- To fully align how `MsgOptionParse()` should work based on the documentation from slack, we should give it a value of `full` or `none` where `none` is being the default.

Please review 🙏 