### PR TITLE
returns validation error msgs on dialog.open

### DIFF
--- a/dialog.go
+++ b/dialog.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"context"
 	"encoding/json"
+	"strings"
 )
 
 // InputType is the type of the dialog input type
@@ -105,6 +106,11 @@ func (api *Client) OpenDialogContext(ctx context.Context, triggerID string, dial
 	endpoint := api.endpoint + "dialog.open"
 	if err := postJSON(ctx, api.httpclient, endpoint, api.token, encoded, response, api); err != nil {
 		return err
+	}
+
+	if len(response.DialogResponseMetadata.Messages) > 0 {
+		response.Ok = false
+		response.Error += "\n" + strings.Join(response.DialogResponseMetadata.Messages, "\n")
 	}
 
 	return response.Err()


### PR DESCRIPTION
when opening a dialog model, slack validates the dialog definition
and returns specific error messages upon failure. these specific
error messages are now caught and bubbled up with the original
validation error.
https://api.slack.com/methods/dialog.open