### PR TITLE
Specify omitempty encoding option for Blocks and BlockElements

### DIFF
--- a/block.go
+++ b/block.go
@@ -25,7 +25,7 @@ type Block interface {
 // Blocks is a convenience struct defined to allow dynamic unmarshalling of
 // the "blocks" value in Slack's JSON response, which varies depending on block type
 type Blocks struct {
-	BlockSet []Block `json:"blocks"`
+	BlockSet []Block `json:"blocks,omitempty"`
 }
 
 // BlockAction is the action callback sent when a block is interacted with

--- a/block_conv.go
+++ b/block_conv.go
@@ -26,7 +26,7 @@ func (b *Blocks) MarshalJSON() ([]byte, error) {
 func (b *Blocks) UnmarshalJSON(data []byte) error {
 	var raw []json.RawMessage
 
-	if string(data) == "{\"blocks\":null}" {
+	if string(data) == "{}" {
 		return nil
 	}
 
@@ -92,7 +92,7 @@ func (b *BlockElements) MarshalJSON() ([]byte, error) {
 func (b *BlockElements) UnmarshalJSON(data []byte) error {
 	var raw []json.RawMessage
 
-	if string(data) == "{\"elements\":null}" {
+	if string(data) == "{}" {
 		return nil
 	}
 

--- a/block_element.go
+++ b/block_element.go
@@ -59,7 +59,7 @@ func NewAccessory(element BlockElement) *Accessory {
 // BlockElements is a convenience struct defined to allow dynamic unmarshalling of
 // the "elements" value in Slack's JSON response, which varies depending on BlockElement type
 type BlockElements struct {
-	ElementSet []BlockElement `json:"elements"`
+	ElementSet []BlockElement `json:"elements,omitempty"`
 }
 
 // ImageBlockElement An element to insert an image - this element can be used


### PR DESCRIPTION
## Summary
https://github.com/nlopes/slack/pull/494 was merged to unblock the use of the new `Blocks` functionality, but still can use improvement in a number of areas. This is a preliminary update PR to address a marshalling issue present in original changes