### PR TITLE
Fix WithStyle method on ButtonBlockElement

### DIFF
--- a/block_element.go
+++ b/block_element.go
@@ -120,7 +120,7 @@ func (s ButtonBlockElement) ElementType() MessageElementType {
 }
 
 // add styling to button object
-func (s ButtonBlockElement) WithStyle(style Style) {
+func (s *ButtonBlockElement) WithStyle(style Style) {
 	s.Style = style
 }
 


### PR DESCRIPTION
Signature for `WithStyle` method looks like:
```go
func (s ButtonBlockElement) WithStyle(style Style)
```

This prevents us from changing style on ButtonBlockElement after defining it and makes method pretty much useless.
Fix is to define this method on pointer to ButtonBlockElement.