### PR TITLE
Fix Blocks marshalling

### DIFF
--- a/block_conv.go
+++ b/block_conv.go
@@ -12,7 +12,7 @@ type sumtype struct {
 
 // MarshalJSON implements the Marshaller interface for Blocks so that any JSON
 // marshalling is delegated and proper type determination can be made before marshal
-func (b *Blocks) MarshalJSON() ([]byte, error) {
+func (b Blocks) MarshalJSON() ([]byte, error) {
 	bytes, err := json.Marshal(b.BlockSet)
 	if err != nil {
 		return nil, err

--- a/examples/blocks/blocks.go
+++ b/examples/blocks/blocks.go
@@ -37,6 +37,9 @@ func main() {
 	exampleSix()
 	fmt.Println("--- End Example Six ---")
 
+	fmt.Println("--- Begin Example Unmarshalling ---")
+	unmarshalExample()
+	fmt.Println("--- End Example Unmarshalling ---")
 }
 
 // approvalRequest mocks the simple "Approval" template located on block kit builder website


### PR DESCRIPTION
Custom marshalling was provided for `*Blocks` instead of `Blocks`, which means that a `Message` containing blocks was marshalled with an extraneous `blocks` value.

Cf `examples/blocks`:

```
--- Begin Example One ---
{
    "replace_original": false,
    "delete_original": false,
    "blocks": {
        "blocks": [
            {
                "type": "section",
                "text": {
                    "type": "mrkdwn",
                    "text": "You have a new request:\n*\u003cfakeLink.toEmployeeProfile.com|Fred Enriquez - New device request\u003e*"

...
```

This commit fixes `Block`'s marshalling.

After the commit, `examples/blocks` prints:

```
--- Begin Example One ---
{
    "replace_original": false,
    "delete_original": false,
    "blocks": [
        {
            "type": "section",
            "text": {
                "type": "mrkdwn",
                "text": "You have a new request:\n*\u003cfakeLink.toEmployeeProfile.com|Fred Enriquez - New device request\u003e*"
...
```
