### PR TITLE
Block fixes pt.1

### DIFF
--- a/block.go
+++ b/block.go
@@ -30,12 +30,22 @@ type Blocks struct {
 
 // BlockAction is the action callback sent when a block is interacted with
 type BlockAction struct {
-	ActionID string          `json:"action_id"`
-	BlockID  string          `json:"block_id"`
-	Text     TextBlockObject `json:"text"`
-	Value    string          `json:"value"`
-	Type     actionType      `json:"type"`
-	ActionTs string          `json:"action_ts"`
+	ActionID             string            `json:"action_id"`
+	BlockID              string            `json:"block_id"`
+	Type                 actionType        `json:"type"`
+	Text                 TextBlockObject   `json:"text"`
+	Value                string            `json:"value"`
+	ActionTs             string            `json:"action_ts"`
+	SelectedOption       OptionBlockObject `json:"selected_option"`
+	SelectedUser         string            `json:"selected_user"`
+	SelectedChannel      string            `json:"selected_channel"`
+	SelectedConversation string            `json:"selected_conversation"`
+	SelectedDate         string            `json:"selected_date"`
+	InitialOption        OptionBlockObject `json:"initial_option"`
+	InitialUser          string            `json:"initial_user"`
+	InitialChannel       string            `json:"initial_channel"`
+	InitialConversation  string            `json:"initial_conversation"`
+	InitialDate          string            `json:"initial_date"`
 }
 
 // actionType returns the type of the action

--- a/block_conv.go
+++ b/block_conv.go
@@ -124,7 +124,7 @@ func (b *BlockElements) UnmarshalJSON(data []byte) error {
 			blockElement = &OverflowBlockElement{}
 		case "datepicker":
 			blockElement = &DatePickerBlockElement{}
-		case "static_select":
+		case "static_select", "external_select", "users_select", "conversations_select", "channels_select":
 			blockElement = &SelectBlockElement{}
 		default:
 			return errors.New("unsupported block element type")

--- a/interactions.go
+++ b/interactions.go
@@ -22,6 +22,7 @@ const (
 	InteractionTypeDialogSuggestion   = InteractionType("dialog_suggestion")
 	InteractionTypeInteractionMessage = InteractionType("interactive_message")
 	InteractionTypeMessageAction      = InteractionType("message_action")
+	InteractionTypeBlockActions       = InteractionType("block_actions")
 )
 
 // InteractionCallback is sent from slack when a user interactions with a button or dialog.


### PR DESCRIPTION
## Summary
- When originally adding the dynamic unmarshalling method for block elements, I only included `static_select`, but there are a number of other select menus that need to be supported. This PR adds them.
- Also currently unable to properly unmarshal the callback from `block_actions` type interaction callbacks because of a lot of missing fields.
- Added new interaction type for convenience in handling interaction callbacks.

Assume there are probably more fixes to come, will keep an eye out.