### PR TITLE
Make label tag in OptionGroupBlockObject optional

### DIFF
--- a/block_object.go
+++ b/block_object.go
@@ -197,7 +197,7 @@ func (s OptionBlockObject) validateType() MessageObjectType {
 //
 // More Information: https://api.slack.com/reference/messaging/composition-objects#option-group
 type OptionGroupBlockObject struct {
-	Label   *TextBlockObject     `json:"label"`
+	Label   *TextBlockObject     `json:"label,omitempty"`
 	Options []*OptionBlockObject `json:"options"`
 }
 


### PR DESCRIPTION
## Summary
When populating an `external_select` menu's choices via the options callback, we need to respond with an array of options/single option without the `label` field. If we specify the omitempty encoding option here, we can reuse this struct for this response as well (fails to populate menu if `label` is encoded as `null`)

https://api.slack.com/reference/messaging/block-elements#external-select