### PR TITLE
handle tokens_revoked event

### DIFF
--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -113,6 +113,17 @@ type PinAddedEvent pinEvent
 // PinRemovedEvent An item was unpinned from a channel - https://api.slack.com/events/pin_removed
 type PinRemovedEvent pinEvent
 
+type tokens struct {
+	Oauth []string `json:"oauth"`
+	Bot   []string `json:"bot"`
+}
+
+// TokensRevokedEvent APP's API tokes are revoked - https://api.slack.com/events/tokens_revoked
+type TokensRevokedEvent struct {
+	Type   string `json:"type"`
+	Tokens tokens `json:"tokens"`
+}
+
 // JSONTime exists so that we can have a String method converting the date
 type JSONTime int64
 
@@ -233,6 +244,8 @@ const (
 	PinAdded = "pin_added"
 	// PinRemoved An item was unpinned from a channel
 	PinRemoved = "pin_removed"
+	// TokensRevoked APP's API tokes are revoked
+	TokensRevoked = "tokens_revoked"
 )
 
 // EventsAPIInnerEventMapping maps INNER Event API events to their corresponding struct
@@ -248,4 +261,5 @@ var EventsAPIInnerEventMapping = map[string]interface{}{
 	MemberJoinedChannel:   MemberJoinedChannelEvent{},
 	PinAdded:              PinAddedEvent{},
 	PinRemoved:            PinRemovedEvent{},
+	TokensRevoked:         TokensRevokedEvent{},
 }

--- a/slackevents/inner_events_test.go
+++ b/slackevents/inner_events_test.go
@@ -200,3 +200,36 @@ func TestPinRemoved(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestTokensRevoked(t *testing.T) {
+	rawE := []byte(`
+	{
+		"type": "tokens_revoked",
+		"tokens": {
+				"oauth": [
+						"OUXXXXXXXX"
+				],
+				"bot": [
+						"BUXXXXXXXX"
+				]
+		}
+	}
+`)
+	tre := TokensRevokedEvent{}
+	err := json.Unmarshal(rawE, &tre)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if tre.Type != "tokens_revoked" {
+		t.Fail()
+	}
+
+	if len(tre.Tokens.Bot) != 1 || tre.Tokens.Bot[0] != "BUXXXXXXXX" {
+		t.Fail()
+	}
+
+	if len(tre.Tokens.Oauth) != 1 || tre.Tokens.Oauth[0] != "OUXXXXXXXX" {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
## Summary

Implemented support for [token_revoked](https://api.slack.com/events/tokens_revoked) inner event. This event is necessary for managing access tokens among different teams.

## Typical Use-Case

For a slack app with a bot user, the app maintains access tokens for bot user permission to the team that installed the app.

When a team revoked the tokens (usually also uninstalled app), slack app should also remove the `BotID, AccessToken` pair in the maintained token list.
