### PR TITLE
Use int for MinQueryLength

### DIFF
--- a/block_element.go
+++ b/block_element.go
@@ -148,7 +148,7 @@ type SelectBlockElement struct {
 	InitialUser         string                    `json:"initial_user,omitempty"`
 	InitialConversation string                    `json:"initial_conversation,omitempty"`
 	InitialChannel      string                    `json:"initial_channel,omitempty"`
-	MinQueryLength      string                    `json:"min_query_length,omitempty"`
+	MinQueryLength      int                       `json:"min_query_length,omitempty"`
 	Confirm             *ConfirmationBlockObject  `json:"confirm,omitempty"`
 }
 


### PR DESCRIPTION
This updates `MinQueryLength` in the new Blocks implementation of a select menu to be an `int`. Using a string causes an `invalid_blocks error`, as the Slack API expects this to be an integer.