### PR TITLE
Allow custom http client on webhooks

### DIFF
--- a/webhooks.go
+++ b/webhooks.go
@@ -20,13 +20,17 @@ type WebhookMessage struct {
 }
 
 func PostWebhook(url string, msg *WebhookMessage) error {
+	return PostWebhookCustomHTTP(url, http.DefaultClient, msg)
+}
+
+func PostWebhookCustomHTTP(url string, httpClient *http.Client, msg *WebhookMessage) error {
 	raw, err := json.Marshal(msg)
 
 	if err != nil {
 		return errors.Wrap(err, "marshal failed")
 	}
 
-	response, err := http.Post(url, "application/json", bytes.NewReader(raw))
+	response, err := httpClient.Post(url, "application/json", bytes.NewReader(raw))
 
 	if err != nil {
 		return errors.Wrap(err, "failed to post webhook")


### PR DESCRIPTION
This is just a convenience function to allow passing a custom `http.Client` without breaking backward compatibility which is quite useful for customising client parameters and testing your own functions.

There seems to have been some effort https://github.com/nlopes/slack/pull/230 into allow custom `http.Client` in the past, but webhooks were not covered by.

I hope this makes sense
