### PR TITLE
Added authed_teams, one of the grid fields

### DIFF
--- a/slackevents/outer_events.go
+++ b/slackevents/outer_events.go
@@ -35,6 +35,7 @@ type EventsAPICallbackEvent struct {
 	APIAppID    string           `json:"api_app_id"`
 	InnerEvent  *json.RawMessage `json:"event"`
 	AuthedUsers []string         `json:"authed_users"`
+	AuthedTeams []string         `json:"authed_teams"`
 	EventID     string           `json:"event_id"`
 	EventTime   int              `json:"event_time"`
 }


### PR DESCRIPTION
This is a simple change to add the `authed_teams` field into the EventsAPICallbackEvent.

That is one of the fields documented here: https://api.slack.com/enterprise-grid#containment_grid 

While there are other grid fields, mostly not used, this particular field is one I need to try to determine the team to respond to when receiving a message from a workspace that is a member of a grid.

Let me know if you'd like me to add any of the other fields to *this* structure -- Since this is not full grid support, I didn't want to bother with the other structures . . and, since *I* don't need them, I didn't bother with the other fields of this one ;-)

Ciao!