### PR TITLE
Correct select dialog items' SelectedOptions type

### DIFF
--- a/dialog_select.go
+++ b/dialog_select.go
@@ -21,7 +21,7 @@ type DialogInputSelect struct {
 	DialogInput
 	Value           string               `json:"value,omitempty"`            //Optional.
 	DataSource      SelectDataSource     `json:"data_source,omitempty"`      //Optional. Allowed values: "users", "channels", "conversations", "external".
-	SelectedOptions string               `json:"selected_options,omitempty"` //Optional. Default value for "external" only
+	SelectedOptions []DialogSelectOption `json:"selected_options,omitempty"` //Optional. May hold at most one element, for use with "external" only.
 	Options         []DialogSelectOption `json:"options,omitempty"`          //One of options or option_groups is required.
 	OptionGroups    []DialogOptionGroup  `json:"option_groups,omitempty"`    //Provide up to 100 options.
 	MinQueryLength  int                  `json:"min_query_length,omitempty"` //Optional. minimum characters before query is sent.

--- a/dialog_test.go
+++ b/dialog_test.go
@@ -39,7 +39,7 @@ var simpleSelectElement = `{
 	"optional": true,
 	"value": "testing value",
 	"data_source": "users",
-	"selected_options": "",
+	"selected_options": [],
 	"options": [{"label": "option 1", "value": "1"}],
 	"option_groups": []
 }`
@@ -104,7 +104,7 @@ func TestCreateSimpleDialog(t *testing.T) {
 	selectElement.Optional = true
 	selectElement.Value = "testing value"
 	selectElement.DataSource = "users"
-	selectElement.SelectedOptions = ""
+	selectElement.SelectedOptions = []DialogSelectOption{}
 	selectElement.Options = []DialogSelectOption{
 		{Label: "option 1", Value: "1"},
 	}
@@ -149,7 +149,7 @@ func assertSimpleDialog(t *testing.T, dialog *Dialog) {
 	assert.Equal(t, true, selectElement.Optional)
 	assert.Equal(t, "testing value", selectElement.Value)
 	assert.Equal(t, DialogDataSourceUsers, selectElement.DataSource)
-	assert.Equal(t, "", selectElement.SelectedOptions)
+	assert.Equal(t, []DialogSelectOption{}, selectElement.SelectedOptions)
 	assert.Equal(t, "option 1", selectElement.Options[0].Label)
 	assert.Equal(t, "1", selectElement.Options[0].Value)
 	assert.Equal(t, 0, len(selectElement.OptionGroups))
@@ -159,26 +159,26 @@ func assertSimpleDialog(t *testing.T, dialog *Dialog) {
 var simpleCallback = `{
     "type": "dialog_submission",
     "submission": {
-        "name": "Sigourney Dreamweaver",
-        "email": "sigdre@example.com",
-        "phone": "+1 800-555-1212",
-        "meal": "burrito",
-        "comment": "No sour cream please",
-        "team_channel": "C0LFFBKPB",
-        "who_should_sing": "U0MJRG1AL"
+	"name": "Sigourney Dreamweaver",
+	"email": "sigdre@example.com",
+	"phone": "+1 800-555-1212",
+	"meal": "burrito",
+	"comment": "No sour cream please",
+	"team_channel": "C0LFFBKPB",
+	"who_should_sing": "U0MJRG1AL"
     },
     "callback_id": "employee_offsite_1138b",
     "team": {
-        "id": "T1ABCD2E12",
-        "domain": "coverbands"
+	"id": "T1ABCD2E12",
+	"domain": "coverbands"
     },
     "user": {
-        "id": "W12A3BCDEF",
-        "name": "dreamweaver"
+	"id": "W12A3BCDEF",
+	"name": "dreamweaver"
     },
     "channel": {
-        "id": "C1AB2C3DE",
-        "name": "coverthon-1999"
+	"id": "C1AB2C3DE",
+	"name": "coverthon-1999"
     },
     "action_ts": "936893340.702759",
     "token": "M1AqUUw3FqayAbqNtsGMch72",


### PR DESCRIPTION
According to https://api.slack.com/dialogs#select_default_values, this field can't be a string: it may hold an array with at most one value, giving an option that comes pre-selected on a select field with an "external" data source.

I tried sending just a value (as I would expect from the `string` type), but slack returns a validation error when you do that. Using this type (and a single element on it) does work.

This is an API change, but I don't expect that anyone using `SelectOptions` on that struct has seen it work. Insofar, it might be a "breaking" change in the sense of "fixing things incompatibly" (:

I didn't add a test, but can't quite tell if we test struct fields here. Let me know if you want one!