### PR TITLE
added is_invited_user flag in user struct

### DIFF
--- a/users.go
+++ b/users.go
@@ -117,6 +117,7 @@ type User struct {
 	IsUltraRestricted bool           `json:"is_ultra_restricted"`
 	IsStranger        bool           `json:"is_stranger"`
 	IsAppUser         bool           `json:"is_app_user"`
+	IsInvitedUser     bool           `json:"is_invited_user"`
 	Has2FA            bool           `json:"has_2fa"`
 	HasFiles          bool           `json:"has_files"`
 	Presence          string         `json:"presence"`


### PR DESCRIPTION
Fixes #552 
This is particularly helpful when getting users list for a team which has invited users but have not accepted the invite yet
