### PR TITLE
GetUsersContext Bug Fixes

### DIFF
--- a/users.go
+++ b/users.go
@@ -355,7 +355,7 @@ func (api *Client) GetUsersContext(ctx context.Context) (results []User, err err
 		} else if rateLimitedError, ok := err.(*RateLimitedError); ok {
 			select {
 			case <-ctx.Done():
-				return nil, ctx.Err()
+				err = ctx.Err()
 			case <-time.After(rateLimitedError.RetryAfter):
 				err = nil
 			}


### PR DESCRIPTION
Fix #563 (Auto-Paginated API Methods Can Include Duplicates If Errors Occur)
Fix #557 (GetUsersContext() doesn't return error)

Implements the changes discussed in #563 to fix the GetUsersContext bugs above.

The two new tests captured the defective behavior described in the issues. They pass after the change to the GetUsersContext function.