### PR TITLE
enable setting status for other users than the authenticated one

### DIFF
--- a/users.go
+++ b/users.go
@@ -485,13 +485,27 @@ func (api *Client) DeleteUserPhotoContext(ctx context.Context) error {
 // the Slack API will unset the custom status/emoji. If statusExpiration is set to 0
 // the status will not expire.
 func (api *Client) SetUserCustomStatus(statusText, statusEmoji string, statusExpiration int64) error {
-	return api.SetUserCustomStatusContext(context.Background(), statusText, statusEmoji, statusExpiration)
+	return api.SetUserCustomStatusContextWithUser(context.Background(), "", statusText, statusEmoji, statusExpiration)
 }
 
 // SetUserCustomStatusContext will set a custom status and emoji for the currently authenticated user with a custom context
 //
 // For more information see SetUserCustomStatus
 func (api *Client) SetUserCustomStatusContext(ctx context.Context, statusText, statusEmoji string, statusExpiration int64) error {
+	return api.SetUserCustomStatusContextWithUser(context.Background(), "", statusText, statusEmoji, statusExpiration)
+}
+
+// SetUserCustomStatusWithUser will set a custom status and emoji for the provided user.
+//
+// For more information see SetUserCustomStatus
+func (api *Client) SetUserCustomStatusWithUser(user, statusText, statusEmoji string, statusExpiration int64) error {
+	return api.SetUserCustomStatusContextWithUser(context.Background(), user, statusText, statusEmoji, statusExpiration)
+}
+
+// SetUserCustomStatusContextWithUser will set a custom status and emoji for the provided user with a custom context
+//
+// For more information see SetUserCustomStatus
+func (api *Client) SetUserCustomStatusContextWithUser(ctx context.Context, user, statusText, statusEmoji string, statusExpiration int64) error {
 	// XXX(theckman): this anonymous struct is for making requests to the Slack
 	// API for setting and unsetting a User's Custom Status/Emoji. To change
 	// these values we must provide a JSON document as the profile POST field.
@@ -519,6 +533,7 @@ func (api *Client) SetUserCustomStatusContext(ctx context.Context, statusText, s
 	}
 
 	values := url.Values{
+		"user":    {user},
 		"token":   {api.token},
 		"profile": {string(profile)},
 	}


### PR DESCRIPTION
Adding a function to set the user status for a user other than the authenticated one.

See details in https://github.com/nlopes/slack/issues/562 as well.

In order to retain backwards compatibility, I added a new function instead of changing the interface of the existing ones.

Note: I had a look at the existing tests to see whether I can meaningfully test the user being set correctly but I don't think this can be done easily?