### PR TITLE
Make filename optional for uploading files

### DIFF
--- a/files.go
+++ b/files.go
@@ -288,9 +288,6 @@ func (api *Client) UploadFileContext(ctx context.Context, params FileUploadParam
 	if err != nil {
 		return nil, err
 	}
-	if params.Filename == "" {
-		return nil, fmt.Errorf("files.upload: FileUploadParameters.Filename is mandatory")
-	}
 	response := &fileResponseFull{}
 	values := url.Values{
 		"token": {api.token},
@@ -319,6 +316,9 @@ func (api *Client) UploadFileContext(ctx context.Context, params FileUploadParam
 	} else if params.File != "" {
 		err = postLocalWithMultipartResponse(ctx, api.httpclient, api.endpoint+"files.upload", params.File, "file", values, response, api)
 	} else if params.Reader != nil {
+		if params.Filename == "" {
+			return nil, fmt.Errorf("files.upload: FileUploadParameters.Filename is mandatory when using FileUploadParameters.Reader")
+		}
 		err = postWithMultipartResponse(ctx, api.httpclient, api.endpoint+"files.upload", params.Filename, "file", values, params.Reader, response, api)
 	}
 	if err != nil {


### PR DESCRIPTION
To make the library mirror the API more closely, this removes the filename being a mandatory parameter, _unless_ the primary method of uploading the file uses the Reader field, in which case we throw an error.

This was mentioned in https://github.com/nlopes/slack/issues/568

Filename tests pass without changing them and this also makes the example code in `examples/files.go` consistent with the library, since the example code doesn't specify a Filename (and so running the example file results in an error).