### PR TITLE
Remove omitempty on SelectBlockElement.MinQueryLength

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,87 +1,12 @@
-Slack API in Go [![GoDoc](https://godoc.org/github.com/nlopes/slack?status.svg)](https://godoc.org/github.com/nlopes/slack) [![Build Status](https://travis-ci.org/nlopes/slack.svg)](https://travis-ci.org/nlopes/slack)
-===============
+# `nlopes/slack` has moved!
 
-[![Join the chat at https://gitter.im/go-slack/Lobby](https://badges.gitter.im/go-slack/Lobby.svg)](https://gitter.im/go-slack/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+It is being actively maintained at [slack-go/slack](https://github.com/slack-go/slack).
 
-This library supports most if not all of the `api.slack.com` REST
-calls, as well as the Real-Time Messaging protocol over websocket, in
-a fully managed way.
+This fork was created when the project was moved, and is provided
+for backwards compatibility for old projects, but no guarantees are
+made on how up to date it will be.
 
+You're encouraged to update your import statements to use the official `slack-go/slack`
+version above.
 
-
-
-## Changelog
-
-[CHANGELOG.md](https://github.com/nlopes/slack/blob/master/CHANGELOG.md) is available. Please visit it for updates.
-
-## Installing
-
-### *go get*
-
-    $ go get -u github.com/nlopes/slack
-
-## Example
-
-### Getting all groups
-
-```golang
-import (
-	"fmt"
-
-	"github.com/nlopes/slack"
-)
-
-func main() {
-	api := slack.New("YOUR_TOKEN_HERE")
-	// If you set debugging, it will log all requests to the console
-	// Useful when encountering issues
-	// slack.New("YOUR_TOKEN_HERE", slack.OptionDebug(true))
-	groups, err := api.GetGroups(false)
-	if err != nil {
-		fmt.Printf("%s\n", err)
-		return
-	}
-	for _, group := range groups {
-		fmt.Printf("ID: %s, Name: %s\n", group.ID, group.Name)
-	}
-}
-```
-
-### Getting User Information
-
-```golang
-import (
-    "fmt"
-
-    "github.com/nlopes/slack"
-)
-
-func main() {
-    api := slack.New("YOUR_TOKEN_HERE")
-    user, err := api.GetUserInfo("U023BECGF")
-    if err != nil {
-	    fmt.Printf("%s\n", err)
-	    return
-    }
-    fmt.Printf("ID: %s, Fullname: %s, Email: %s\n", user.ID, user.Profile.RealName, user.Profile.Email)
-}
-```
-
-## Minimal RTM usage:
-
-See https://github.com/nlopes/slack/blob/master/examples/websocket/websocket.go
-
-
-## Minimal EventsAPI usage:
-
-See https://github.com/nlopes/slack/blob/master/examples/eventsapi/events.go
-
-
-## Contributing
-
-You are more than welcome to contribute to this project.  Fork and
-make a Pull Request, or create an Issue if you see any problem.
-
-## License
-
-BSD 2 Clause license
+Apologies for the fuss, the new place has amazing people maintaining the community alive.

--- a/block_element.go
+++ b/block_element.go
@@ -148,7 +148,7 @@ type SelectBlockElement struct {
 	InitialUser         string                    `json:"initial_user,omitempty"`
 	InitialConversation string                    `json:"initial_conversation,omitempty"`
 	InitialChannel      string                    `json:"initial_channel,omitempty"`
-	MinQueryLength      int                       `json:"min_query_length,omitempty"`
+	MinQueryLength      int                       `json:"min_query_length"` // Slack defaults to 3.
 	Confirm             *ConfirmationBlockObject  `json:"confirm,omitempty"`
 }
 
@@ -165,6 +165,8 @@ func NewOptionsSelectBlockElement(optType string, placeholder *TextBlockObject, 
 		Placeholder: placeholder,
 		ActionID:    actionID,
 		Options:     options,
+
+		MinQueryLength: 3, // Slack default value
 	}
 }
 
@@ -181,6 +183,8 @@ func NewOptionsGroupSelectBlockElement(
 		Placeholder:  placeholder,
 		ActionID:     actionID,
 		OptionGroups: optGroups,
+
+		MinQueryLength: 3, // Slack default value
 	}
 }
 

--- a/block_element_test.go
+++ b/block_element_test.go
@@ -36,6 +36,7 @@ func TestNewOptionsSelectBlockElement(t *testing.T) {
 	option := NewOptionsSelectBlockElement("static_select", nil, "test", testOption)
 	assert.Equal(t, option.Type, "static_select")
 	assert.Equal(t, len(option.Options), 1)
+	assert.Equal(t, option.MinQueryLength, 3)
 	assert.Nil(t, option.OptionGroups)
 
 }
@@ -52,6 +53,7 @@ func TestNewOptionsGroupSelectBlockElement(t *testing.T) {
 	assert.Equal(t, string(optGroup.Type), "static_select")
 	assert.Equal(t, optGroup.ActionID, "test")
 	assert.Equal(t, len(optGroup.OptionGroups), 1)
+	assert.Equal(t, optGroup.MinQueryLength, 3)
 
 }
 


### PR DESCRIPTION
In new Block API, default MinQueryLength is 3. It seems not to be documented; however, it was confirmed to me by Slack support. It means that by default, for an `external_select`, the query to populate the select menu will be sent by Slack only if the user has typed at least 3 characters.

To change this value to 0 (in order to populate the select menu even if no character is typed), setting MinQueryLength = 0 does not work currently because 0 is Go default value for int and is omitted from JSON.

This change removes "omitempty" which means that setting `MinQueryLength = 0` adds `"min_query_length": 0` in JSON serialization.
