### PR TITLE
improve disconnect and retry interactions.

### DIFF
--- a/websocket_internals.go
+++ b/websocket_internals.go
@@ -35,6 +35,7 @@ type ConnectingEvent struct {
 // DisconnectedEvent contains information about how we disconnected
 type DisconnectedEvent struct {
 	Intentional bool
+	Cause       error
 }
 
 // LatencyReport contains information about connection latency


### PR DESCRIPTION
RTM unconditionally slept for the entire duration
of the backoff, ignoring any disconnect signals
sent by the library or calling applications.

this leads to unnecessary and excessive delays when
invoking Disconnect().

- adds error details to the disconnect events for visibility.
