### PR TITLE
Add omitempty to OptionBlockObject.URL, fixes invalid_blocks for select menus

### DIFF
--- a/block_object.go
+++ b/block_object.go
@@ -178,7 +178,7 @@ func NewConfirmationBlockObject(title, text, confirm, deny *TextBlockObject) *Co
 type OptionBlockObject struct {
 	Text  *TextBlockObject `json:"text"`
 	Value string           `json:"value"`
-	URL   string           `json:"url"`
+	URL   string           `json:"url,omitempty"`
 }
 
 // NewOptionBlockObject returns an instance of a new Option Block Element


### PR DESCRIPTION
The URL field is only valid for overflow menus: https://api.slack.com/reference/messaging/composition-objects#option