### PR TITLE
add blocks attribute to attachments, too

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -61,7 +61,7 @@ type ConfirmationField struct {
 // Attachment contains all the information for an attachment
 type Attachment struct {
 	Color    string `json:"color,omitempty"`
-	Fallback string `json:"fallback"`
+	Fallback string `json:"fallback,omitempty"`
 
 	CallbackID string `json:"callback_id,omitempty"`
 	ID         int    `json:"id,omitempty"`
@@ -75,7 +75,7 @@ type Attachment struct {
 	Title     string `json:"title,omitempty"`
 	TitleLink string `json:"title_link,omitempty"`
 	Pretext   string `json:"pretext,omitempty"`
-	Text      string `json:"text"`
+	Text      string `json:"text,omitempty"`
 
 	ImageURL string `json:"image_url,omitempty"`
 	ThumbURL string `json:"thumb_url,omitempty"`

--- a/attachments.go
+++ b/attachments.go
@@ -84,6 +84,8 @@ type Attachment struct {
 	Actions    []AttachmentAction `json:"actions,omitempty"`
 	MarkdownIn []string           `json:"mrkdwn_in,omitempty"`
 
+	Blocks []Block `json:"blocks,omitempty"`
+
 	Footer     string `json:"footer,omitempty"`
 	FooterIcon string `json:"footer_icon,omitempty"`
 

--- a/chat_test.go
+++ b/chat_test.go
@@ -97,12 +97,11 @@ func TestPostMessage(t *testing.T) {
 			opt: []MsgOption{
 				MsgOptionAttachments(
 					Attachment{
-						Text:   "text",
 						Blocks: blocks,
 					}),
 			},
 			expected: url.Values{
-				"attachments": []string{`[{"fallback":"","text":"text","blocks":` + blockStr + `}]`},
+				"attachments": []string{`[{"blocks":` + blockStr + `}]`},
 				"channel":     []string{"CXXX"},
 				"token":       []string{"testing-token"},
 			},

--- a/chat_test.go
+++ b/chat_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"reflect"
 	"testing"
 )
 
@@ -70,31 +71,68 @@ func TestGetPermalink(t *testing.T) {
 	}
 }
 
-func TestPostMessageWithBlocks(t *testing.T) {
-	http.DefaultServeMux = new(http.ServeMux)
-	http.HandleFunc("/chat.postMessage", func(rw http.ResponseWriter, r *http.Request) {
-		body, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-			return
-		}
-		form, err := url.ParseQuery(string(body))
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-			return
-		}
-		actualBlocks := form.Get("blocks")
-		expectedBlocks := `[{"type":"context","block_id":"context","elements":[{"type":"plain_text","text":"hello"}]}]`
-		if expectedBlocks != actualBlocks {
-			t.Errorf("expected: %s, got: %s", expectedBlocks, actualBlocks)
-			return
-		}
-	})
+func TestPostMessage(t *testing.T) {
+	type messageTest struct {
+		opt      []MsgOption
+		expected url.Values
+	}
+
+	blocks := []Block{NewContextBlock("context", NewTextBlockObject(PlainTextType, "hello", false, false))}
+	blockStr := `[{"type":"context","block_id":"context","elements":[{"type":"plain_text","text":"hello"}]}]`
+
+	tests := map[string]messageTest{
+		"Blocks": {
+			opt: []MsgOption{
+				MsgOptionBlocks(blocks...),
+				MsgOptionText("text", false),
+			},
+			expected: url.Values{
+				"blocks":  []string{blockStr},
+				"channel": []string{"CXXX"},
+				"text":    []string{"text"},
+				"token":   []string{"testing-token"},
+			},
+		},
+		"Attachment": {
+			opt: []MsgOption{
+				MsgOptionAttachments(
+					Attachment{
+						Text:   "text",
+						Blocks: blocks,
+					}),
+			},
+			expected: url.Values{
+				"attachments": []string{`[{"fallback":"","text":"text","blocks":` + blockStr + `}]`},
+				"channel":     []string{"CXXX"},
+				"token":       []string{"testing-token"},
+			},
+		},
+	}
 
 	once.Do(startServer)
 	api := New(validToken, OptionAPIURL("http://"+serverAddr+"/"))
 
-	blocks := []Block{NewContextBlock("context", NewTextBlockObject(PlainTextType, "hello", false, false))}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			http.DefaultServeMux = new(http.ServeMux)
+			http.HandleFunc("/chat.postMessage", func(rw http.ResponseWriter, r *http.Request) {
+				body, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+					return
+				}
+				actual, err := url.ParseQuery(string(body))
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+					return
+				}
+				if !reflect.DeepEqual(actual, test.expected) {
+					t.Errorf("\nexpected: %s\n  actual: %s", test.expected, actual)
+					return
+				}
+			})
 
-	_, _, _ = api.PostMessage("CXXX", MsgOptionBlocks(blocks...), MsgOptionText("text", false))
+			_, _, _ = api.PostMessage("CXXX", test.opt...)
+		})
+	}
 }


### PR DESCRIPTION
blocks can be embedded within attachments, to work around the lack of
colorbar support in blocks, or as a migration path to blocks

- https://api.slack.com/messaging/attachments-to-blocks#finding_equivalents_for_older_visual_elements
- https://api.slack.com/reference/messaging/attachments#fields

This also extends the existing postMessage test to include an attachment
with a block