### PR TITLE
Add fields to CtxChannel to get search API's response

### DIFF
--- a/search.go
+++ b/search.go
@@ -23,8 +23,14 @@ type SearchParameters struct {
 }
 
 type CtxChannel struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	ID                 string `json:"id"`
+	Name               string `json:"name"`
+	IsExtShared        bool   `json:"is_ext_shared"`
+	IsMPIM             bool   `json:"is_mpim"`
+	ISOrgShared        bool   `json:"is_org_shared"`
+	IsPendingExtShared bool   `json:"is_pending_ext_shared"`
+	IsPrivate          bool   `json:"is_private"`
+	IsShared           bool   `json:"is_shared"`
 }
 
 type CtxMessage struct {


### PR DESCRIPTION
See the official reference's Response section.

* https://api.slack.com/methods/search.all
* https://api.slack.com/methods/search.messages

```json
"channel": {
  "id": "C12345678",
  "is_ext_shared": false,
  "is_mpim": false,
  "is_org_shared": false,
  "is_pending_ext_shared": false,
  "is_private": false,
  "is_shared": false,
  "name": "general",
  "pending_shared": []
}
```

In this commit `"pending_shared"` is ignored because I don't know the data structure.

##### Pull Request Guidelines

These are recommendations for pull requests.  
They are strictly guidelines to help manage expectations.

##### should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.
