### PR TITLE
Send blocks on SendMessage when MsgOptionResponseURL applied

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -228,6 +228,7 @@ type sendConfig struct {
 	endpoint     string
 	values       url.Values
 	attachments  []Attachment
+	blocks       Blocks
 	responseType string
 }
 
@@ -242,6 +243,7 @@ func (t sendConfig) BuildRequest(token, channelID string) (req *http.Request, _ 
 			endpoint:     t.endpoint,
 			values:       t.values,
 			attachments:  t.attachments,
+			blocks:       t.blocks,
 			responseType: t.responseType,
 		}.BuildRequest()
 	default:
@@ -265,6 +267,7 @@ type responseURLSender struct {
 	endpoint     string
 	values       url.Values
 	attachments  []Attachment
+	blocks       Blocks
 	responseType string
 }
 
@@ -273,6 +276,7 @@ func (t responseURLSender) BuildRequest() (*http.Request, func(*chatResponseFull
 		Text:         t.values.Get("text"),
 		Timestamp:    t.values.Get("ts"),
 		Attachments:  t.attachments,
+		Blocks:       t.blocks,
 		ResponseType: t.responseType,
 	})
 	return req, func(resp *chatResponseFull) responseParser {
@@ -419,6 +423,8 @@ func MsgOptionBlocks(blocks ...Block) MsgOption {
 		if blocks == nil {
 			return nil
 		}
+
+		config.blocks.BlockSet = append(config.blocks.BlockSet, blocks...)
 
 		blocks, err := json.Marshal(blocks)
 		if err == nil {


### PR DESCRIPTION
Found that blocks do not passed to responseURLSender through
sendConfig. Fixed implementation by adding separate field
for blocks to responseURLSender and sendConfig.