### PR TITLE
Add missing fields from bots.info API call

### DIFF
--- a/bots.go
+++ b/bots.go
@@ -7,10 +7,13 @@ import (
 
 // Bot contains information about a bot
 type Bot struct {
-	ID      string `json:"id"`
-	Name    string `json:"name"`
-	Deleted bool   `json:"deleted"`
-	Icons   Icons  `json:"icons"`
+	ID      string   `json:"id"`
+	Name    string   `json:"name"`
+	Deleted bool     `json:"deleted"`
+	UserID  string   `json:"user_id"`
+	AppID   string   `json:"app_id"`
+	Updated JSONTime `json:"updated"`
+	Icons   Icons    `json:"icons"`
 }
 
 type botResponseFull struct {

--- a/bots_test.go
+++ b/bots_test.go
@@ -11,6 +11,9 @@ func getBotInfo(rw http.ResponseWriter, r *http.Request) {
 			"id":"B02875YLA",
 			"deleted":false,
 			"name":"github",
+			"updated": 1449272004,
+			"app_id":"A161CLERW",
+			"user_id": "U012ABCDEF",
 			"icons": {
               "image_36":"https:\/\/a.slack-edge.com\/2fac\/plugins\/github\/assets\/service_36.png",
               "image_48":"https:\/\/a.slack-edge.com\/2fac\/plugins\/github\/assets\/service_48.png",
@@ -37,6 +40,15 @@ func TestGetBotInfo(t *testing.T) {
 	}
 	if bot.Name != "github" {
 		t.Fatal("Incorrect Name")
+	}
+	if bot.AppID != "A161CLERW" {
+		t.Fatal("Incorrect App ID")
+	}
+	if bot.UserID != "U012ABCDEF" {
+		t.Fatal("Incorrect User ID")
+	}
+	if bot.Updated != 1449272004 {
+		t.Fatal("Incorrect Updated")
 	}
 	if len(bot.Icons.Image36) == 0 {
 		t.Fatal("Missing Image36")


### PR DESCRIPTION
Added the following missing fields:
  * UserID (`user_id`)
  * AppID (`app_id`)
  * Updated  (`updated`)

See [bot.info documentation](https://api.slack.com/methods/bots.info)