### PR TITLE
Add Unread property to History

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -578,7 +578,7 @@ type GetConversationHistoryResponse struct {
 	HasMore            bool   `json:"has_more"`
 	PinCount           int    `json:"pin_count"`
 	Latest             string `json:"latest"`
-	UnreadCountDisplay int    `json:"unread_count_display"`
+	Unread int    `json:"unread_count_display"`
 	ResponseMetaData   struct {
 		NextCursor string `json:"next_cursor"`
 	} `json:"response_metadata"`

--- a/conversation.go
+++ b/conversation.go
@@ -570,16 +570,14 @@ type GetConversationHistoryParameters struct {
 	Latest    string
 	Limit     int
 	Oldest    string
-	Unreads   bool
 }
 
 type GetConversationHistoryResponse struct {
 	SlackResponse
-	HasMore            bool   `json:"has_more"`
-	PinCount           int    `json:"pin_count"`
-	Latest             string `json:"latest"`
-	Unread int    `json:"unread_count_display"`
-	ResponseMetaData   struct {
+	HasMore          bool   `json:"has_more"`
+	PinCount         int    `json:"pin_count"`
+	Latest           string `json:"latest"`
+	ResponseMetaData struct {
 		NextCursor string `json:"next_cursor"`
 	} `json:"response_metadata"`
 	Messages []Message `json:"messages"`
@@ -609,9 +607,6 @@ func (api *Client) GetConversationHistoryContext(ctx context.Context, params *Ge
 	}
 	if params.Oldest != "" {
 		values.Add("oldest", params.Oldest)
-	}
-	if params.Unreads {
-		values.Add("unreads", "1")
 	}
 
 	response := GetConversationHistoryResponse{}

--- a/conversation.go
+++ b/conversation.go
@@ -570,14 +570,16 @@ type GetConversationHistoryParameters struct {
 	Latest    string
 	Limit     int
 	Oldest    string
+	Unreads   bool
 }
 
 type GetConversationHistoryResponse struct {
 	SlackResponse
-	HasMore          bool   `json:"has_more"`
-	PinCount         int    `json:"pin_count"`
-	Latest           string `json:"latest"`
-	ResponseMetaData struct {
+	HasMore            bool   `json:"has_more"`
+	PinCount           int    `json:"pin_count"`
+	Latest             string `json:"latest"`
+	UnreadCountDisplay int    `json:"unread_count_display"`
+	ResponseMetaData   struct {
 		NextCursor string `json:"next_cursor"`
 	} `json:"response_metadata"`
 	Messages []Message `json:"messages"`
@@ -607,6 +609,9 @@ func (api *Client) GetConversationHistoryContext(ctx context.Context, params *Ge
 	}
 	if params.Oldest != "" {
 		values.Add("oldest", params.Oldest)
+	}
+	if params.Unreads {
+		values.Add("unreads", "1")
 	}
 
 	response := GetConversationHistoryResponse{}

--- a/history.go
+++ b/history.go
@@ -19,9 +19,10 @@ type HistoryParameters struct {
 
 // History contains message history information needed to navigate a Channel / Group / DM history
 type History struct {
-	Latest   string    `json:"latest"`
-	Messages []Message `json:"messages"`
-	HasMore  bool      `json:"has_more"`
+	Latest             string    `json:"latest"`
+	Messages           []Message `json:"messages"`
+	HasMore            bool      `json:"has_more"`
+	UnreadCountDisplay int       `json:"unread_count_display"`
 }
 
 // NewHistoryParameters provides an instance of HistoryParameters with all the sane default values set

--- a/history.go
+++ b/history.go
@@ -19,10 +19,10 @@ type HistoryParameters struct {
 
 // History contains message history information needed to navigate a Channel / Group / DM history
 type History struct {
-	Latest             string    `json:"latest"`
-	Messages           []Message `json:"messages"`
-	HasMore            bool      `json:"has_more"`
-	Unread int       `json:"unread_count_display"`
+	Latest   string    `json:"latest"`
+	Messages []Message `json:"messages"`
+	HasMore  bool      `json:"has_more"`
+	Unread   int       `json:"unread_count_display"`
 }
 
 // NewHistoryParameters provides an instance of HistoryParameters with all the sane default values set

--- a/history.go
+++ b/history.go
@@ -22,7 +22,7 @@ type History struct {
 	Latest             string    `json:"latest"`
 	Messages           []Message `json:"messages"`
 	HasMore            bool      `json:"has_more"`
-	UnreadCountDisplay int       `json:"unread_count_display"`
+	Unread int       `json:"unread_count_display"`
 }
 
 // NewHistoryParameters provides an instance of HistoryParameters with all the sane default values set


### PR DESCRIPTION
This adds support for retrieving unread message counts with `conversations.history` and `channels.history`. 

I've contacted Slack support about the missing `Unreads` parameter in their [conversations.history documentation](https://api.slack.com/methods/conversations.history), but if you go to [their tester](https://api.slack.com/methods/conversations.history/test) and add `unreads=1` in the "extra args" field, you can see that it successfully returns message counts just like [conversations.history](https://api.slack.com/methods/channels.history/test). 


##### Pull Request Guidelines

These are recommendations for pull requests.  
They are strictly guidelines to help manage expectations.

##### should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.
