### PR TITLE
Ommitted the "URL" attribute when returning a json of Select Options,…

### DIFF
--- a/block_object.go
+++ b/block_object.go
@@ -178,7 +178,7 @@ func NewConfirmationBlockObject(title, text, confirm, deny *TextBlockObject) *Co
 type OptionBlockObject struct {
 	Text  *TextBlockObject `json:"text"`
 	Value string           `json:"value"`
-	URL   string           `json:"url"`
+	URL   string           `json:"url,omitempty"`
 }
 
 // NewOptionBlockObject returns an instance of a new Option Block Element


### PR DESCRIPTION
… since this attribute is only used in one situation on slack and when used in any other way return "invalid_blocks" errors

##### Pull Request Guidelines

These are recommendations for pull requests.  
They are strictly guidelines to help manage expectations.

##### should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.
