### PR TITLE
Allowing OptionBlockObject.URL to be stripped when empty

### DIFF
--- a/block_object.go
+++ b/block_object.go
@@ -178,7 +178,7 @@ func NewConfirmationBlockObject(title, text, confirm, deny *TextBlockObject) *Co
 type OptionBlockObject struct {
 	Text  *TextBlockObject `json:"text"`
 	Value string           `json:"value"`
-	URL   string           `json:"url"`
+	URL   string           `json:"url,omitempty"`
 }
 
 // NewOptionBlockObject returns an instance of a new Option Block Element


### PR DESCRIPTION
I faced the same problem with issue #603 . The detail solution had already proposed by detailed issue.