### PR TITLE
fix unmarshallable `Message` from new WYSIWYG Slack feature

### DIFF
--- a/block_conv.go
+++ b/block_conv.go
@@ -60,6 +60,9 @@ func (b *Blocks) UnmarshalJSON(data []byte) error {
 			block = &ImageBlock{}
 		case "section":
 			block = &SectionBlock{}
+		case "rich_text":
+			// for now ignore the (complex) content of rich_text blocks until we can fully support it
+			continue
 		default:
 			return errors.New("unsupported block type")
 		}


### PR DESCRIPTION
Slack is rolling out their WYSIWYG chat messages on web and desktop, the result is that the RTM `Message`s we receive now contain a `rich_text` block which has significant list of new blocks that it be be composed of as you can see here; https://api.slack.com/changelog/2019-09-what-they-see-is-what-you-get-and-more-and-less

I suggest (and this PR implements just that), that we for now ignore the content of rich_text blocks until we can fully support it because atm we're unable to parse messages at all...  

Slack wrote in their blog;
> Once we release WYSIWYG editing, the text field found in message objects your app encounters will become an approximation of a user's more richly formatted message.

So we can continue using the `text` property just fine...

fixes https://github.com/nlopes/slack/issues/616



