### PR TITLE
[Workaround] Skip rich_text blocks

### DIFF
--- a/block_conv.go
+++ b/block_conv.go
@@ -60,6 +60,8 @@ func (b *Blocks) UnmarshalJSON(data []byte) error {
 			block = &ImageBlock{}
 		case "section":
 			block = &SectionBlock{}
+		case "rich_text":
+			continue
 		default:
 			return errors.New("unsupported block type")
 		}


### PR DESCRIPTION
If we don't skip it, we will get `unmarshalling_error` when
unmarshaling RTM event data which contains rich text blocks.

See https://github.com/nlopes/slack/pull/618