### PR TITLE
Support views API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
 )
+
+go 1.13

--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -2,7 +2,11 @@
 
 package slackevents
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/nlopes/slack"
+)
 
 // EventsAPIInnerEvent the inner event of a EventsAPI event_callback Event.
 type EventsAPIInnerEvent struct {
@@ -27,6 +31,8 @@ type AppHomeOpenedEvent struct {
 	User           string      `json:"user"`
 	Channel        string      `json:"channel"`
 	EventTimeStamp json.Number `json:"event_ts"`
+	Tab            string      `json:"tab"`
+	View           slack.View  `json:"view"`
 }
 
 // AppUninstalledEvent Your Slack app was uninstalled.

--- a/views.go
+++ b/views.go
@@ -1,0 +1,221 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+)
+
+const (
+	VTModal   ViewType = "modal"
+	VTHomeTab ViewType = "home"
+)
+
+type ViewType string
+
+type View struct {
+	SlackResponse
+	ID              string           `json:"id"`
+	TeamID          string           `json:"team_id"`
+	Type            ViewType         `json:"type"`
+	Title           *TextBlockObject `json:"title"`
+	Close           *TextBlockObject `json:"close"`
+	Submit          *TextBlockObject `json:"submit"`
+	Blocks          Blocks           `json:"blocks"`
+	PrivateMetadata string           `json:"private_metadata"`
+	CallbackID      string           `json:"callback_id"`
+	State           interface{}      `json:"state"`
+	Hash            string           `json:"hash"`
+	ClearOnClose    bool             `json:"clear_on_close"`
+	NotifyOnClose   bool             `json:"notify_on_close"`
+	RootViewID      string           `json:"root_view_id"`
+	PreviousViewID  string           `json:"previous_view_id"`
+	AppID           string           `json:"app_id"`
+	ExternalID      string           `json:"external_id"`
+	BotID           string           `json:"bot_id"`
+}
+
+type ModalViewRequest struct {
+	Type            ViewType         `json:"type"`
+	Title           *TextBlockObject `json:"title"`
+	Blocks          Blocks           `json:"blocks"`
+	Close           *TextBlockObject `json:"close,omitempty"`
+	Submit          *TextBlockObject `json:"submit,omitempty"`
+	PrivateMetadata string           `json:"private_metadata,omitempty"`
+	CallbackID      string           `json:"callback_id,omitempty"`
+	ClearOnClose    bool             `json:"clear_on_close,omitempty"`
+	NotifyOnClose   bool             `json:"notify_on_close,omitempty"`
+	ExternalID      string           `json:"external_id,omitempty"`
+}
+
+func (v *ModalViewRequest) ViewType() ViewType {
+	return v.Type
+}
+
+type HomeTabViewRequest struct {
+	Type            ViewType `json:"type"`
+	Blocks          Blocks   `json:"blocks"`
+	PrivateMetadata string   `json:"private_metadata,omitempty"`
+	CallbackID      string   `json:"callback_id,omitempty"`
+	ExternalID      string   `json:"external_id,omitempty"`
+}
+
+func (v *HomeTabViewRequest) ViewType() ViewType {
+	return v.Type
+}
+
+type openViewRequest struct {
+	TriggerID string           `json:"trigger_id"`
+	View      ModalViewRequest `json:"view"`
+}
+
+type publishViewRequest struct {
+	UserID string             `json:"user_id"`
+	View   HomeTabViewRequest `json:"view"`
+	Hash   string             `json:"hash,omitempty"`
+}
+
+type pushViewRequest struct {
+	TriggerID string           `json:"trigger_id"`
+	View      ModalViewRequest `json:"view"`
+}
+
+type updateViewRequest struct {
+	View       ModalViewRequest `json:"view"`
+	ExternalID string           `json:"external_id,omitempty"`
+	Hash       string           `json:"hash,omitempty"`
+	ViewID     string           `json:"view_id,omitempty"`
+}
+
+type ViewResponse struct {
+	SlackResponse
+	View `json:"view"`
+}
+
+// OpenView opens a view for a user.
+func (api *Client) OpenView(triggerID string, view ModalViewRequest) (*ViewResponse, error) {
+	return api.OpenViewContext(context.Background(), triggerID, view)
+}
+
+// OpenViewContext opens a view for a user with a custom context.
+func (api *Client) OpenViewContext(
+	ctx context.Context,
+	triggerID string,
+	view ModalViewRequest,
+) (*ViewResponse, error) {
+	if triggerID == "" {
+		return nil, ErrParametersMissing
+	}
+	req := openViewRequest{
+		TriggerID: triggerID,
+		View:      view,
+	}
+	encoded, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	endpoint := api.endpoint + "views.open"
+	resp := &ViewResponse{}
+	err = postJSON(ctx, api.httpclient, endpoint, api.token, encoded, resp, api)
+	if err != nil {
+		return nil, err
+	}
+	return resp, resp.Err()
+}
+
+// PublishView publishes a static view for a user.
+func (api *Client) PublishView(userID string, view HomeTabViewRequest, hash string) (*ViewResponse, error) {
+	return api.PublishViewContext(context.Background(), userID, view, hash)
+}
+
+// PublishViewContext publishes a static view for a user with a custom context.
+func (api *Client) PublishViewContext(
+	ctx context.Context,
+	userID string,
+	view HomeTabViewRequest,
+	hash string,
+) (*ViewResponse, error) {
+	if userID == "" {
+		return nil, ErrParametersMissing
+	}
+	req := publishViewRequest{
+		UserID: userID,
+		View:   view,
+		Hash:   hash,
+	}
+	encoded, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	endpoint := api.endpoint + "views.publish"
+	resp := &ViewResponse{}
+	err = postJSON(ctx, api.httpclient, endpoint, api.token, encoded, resp, api)
+	if err != nil {
+		return nil, err
+	}
+	return resp, resp.Err()
+}
+
+// PushView pushes a view onto the stack of a root view.
+func (api *Client) PushView(triggerID string, view ModalViewRequest) (*ViewResponse, error) {
+	return api.PushViewContext(context.Background(), triggerID, view)
+}
+
+// PublishViewContext pushes a view onto the stack of a root view with a custom context.
+func (api *Client) PushViewContext(
+	ctx context.Context,
+	triggerID string,
+	view ModalViewRequest,
+) (*ViewResponse, error) {
+	if triggerID == "" {
+		return nil, ErrParametersMissing
+	}
+	req := pushViewRequest{
+		TriggerID: triggerID,
+		View:      view,
+	}
+	encoded, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	endpoint := api.endpoint + "views.push"
+	resp := &ViewResponse{}
+	err = postJSON(ctx, api.httpclient, endpoint, api.token, encoded, resp, api)
+	if err != nil {
+		return nil, err
+	}
+	return resp, resp.Err()
+}
+
+// UpdateView updates an existing view.
+func (api *Client) UpdateView(view ModalViewRequest, externalID, hash, viewID string) (*ViewResponse, error) {
+	return api.UpdateViewContext(context.Background(), view, externalID, hash, viewID)
+}
+
+// UpdateViewContext updates an existing view with a custom context.
+func (api *Client) UpdateViewContext(
+	ctx context.Context,
+	view ModalViewRequest,
+	externalID, hash,
+	viewID string,
+) (*ViewResponse, error) {
+	if externalID == "" && viewID == "" {
+		return nil, ErrParametersMissing
+	}
+	req := updateViewRequest{
+		View:       view,
+		ExternalID: externalID,
+		Hash:       hash,
+		ViewID:     viewID,
+	}
+	encoded, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	endpoint := api.endpoint + "views.update"
+	resp := &ViewResponse{}
+	err = postJSON(ctx, api.httpclient, endpoint, api.token, encoded, resp, api)
+	if err != nil {
+		return nil, err
+	}
+	return resp, resp.Err()
+}

--- a/views_test.go
+++ b/views_test.go
@@ -1,0 +1,529 @@
+package slack
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/nlopes/slack/internal/errorsx"
+)
+
+var dummySlackErr = errorsx.String("dummy_error_from_slack")
+
+type viewsHandler struct {
+	rawResponse string
+}
+
+func (h *viewsHandler) handler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte(h.rawResponse))
+}
+
+func TestSlack_OpenView(t *testing.T) {
+	once.Do(startServer)
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
+
+	cases := []struct {
+		caseName     string
+		triggerID    string
+		rawResp      string
+		expectedResp *ViewResponse
+		expectedErr  error
+	}{
+		{
+			caseName:     "pass empty trigger_id",
+			triggerID:    "",
+			rawResp:      "",
+			expectedResp: nil,
+			expectedErr:  ErrParametersMissing,
+		},
+		{
+			caseName:  "raise an error from Slack API",
+			triggerID: "dummy_trigger_id",
+			rawResp: `{
+				"ok": false,
+				"error": "dummy_error_from_slack",
+				"response_metadata": {
+					"messages": [
+						"dummy error response"
+					]
+				}
+			}`,
+			expectedResp: &ViewResponse{
+				SlackResponse{
+					Ok:    false,
+					Error: dummySlackErr.Error(),
+				},
+				View{},
+			},
+			expectedErr: dummySlackErr,
+		},
+		{
+			caseName:  "success",
+			triggerID: "dummy_trigger_id",
+			rawResp: `{
+				"ok": true,
+				"view": {
+					"id": "VMHU10V25",
+					"team_id": "T8N4K1JN",
+					"type": "modal",
+					"title": {
+						"type": "plain_text",
+						"text": "Quite a plain modal"
+					},
+					"submit": {
+						"type": "plain_text",
+						"text": "Create"
+					},
+					"blocks": [
+						{
+							"type": "rich_text",
+							"block_id": "a_block_id",
+							"label": {
+								"type": "plain_text",
+								"text": "A simple label",
+								"emoji": true
+							},
+							"optional": false,
+							"element": {
+								"type": "plain_text_input",
+								"action_id": "an_action_id"
+							}
+						}
+					],
+					"private_metadata": "Shh it is a secret",
+					"callback_id": "identify_your_modals",
+					"external_id": "",
+					"state": {
+						"values": []
+					},
+					"hash": "156772938.1827394",
+					"clear_on_close": false,
+					"notify_on_close": false,
+					"root_view_id": "VMHU10V25",
+					"app_id": "AA4928AQ",
+					"bot_id": "BA13894H"
+				}
+			}`,
+			expectedResp: &ViewResponse{
+				SlackResponse{
+					Ok:    true,
+					Error: "",
+				},
+				View{
+					ID:   "VMHU10V25",
+					Type: VTModal,
+				},
+			},
+			expectedErr: nil,
+		},
+	}
+
+	h := &viewsHandler{}
+	http.HandleFunc("/views.open", h.handler)
+	for _, c := range cases {
+		t.Run(c.caseName, func(t *testing.T) {
+			h.rawResponse = c.rawResp
+
+			resp, err := api.OpenView(c.triggerID, ModalViewRequest{})
+			if c.expectedErr == nil && err != nil {
+				t.Errorf("unexpected error: %s\n", err)
+				return
+			}
+			if c.expectedErr != nil && err == nil {
+				t.Errorf("expected %s, but did not raise an error", c.expectedErr)
+				return
+			}
+			if c.expectedErr != nil && err != nil && c.expectedErr.Error() != err.Error() {
+				t.Errorf("expected %s as error but got %s\n", c.expectedErr, err)
+				return
+			}
+			if resp == nil || c.expectedResp == nil {
+				return
+			}
+			if c.expectedResp.ID != resp.ID || c.expectedResp.Type != resp.Type {
+				t.Errorf("expected:\n\t%v\nas response but got:\n\t%v\n", c.expectedResp, resp)
+			}
+		})
+	}
+}
+
+func TestSlack_View_PublishView(t *testing.T) {
+	once.Do(startServer)
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
+
+	cases := []struct {
+		caseName     string
+		userID       string
+		rawResp      string
+		expectedResp *ViewResponse
+		expectedErr  error
+	}{
+		{
+			caseName:     "pass empty user_id",
+			userID:       "",
+			rawResp:      "",
+			expectedResp: nil,
+			expectedErr:  ErrParametersMissing,
+		},
+		{
+			caseName: "raise an error from Slack API",
+			userID:   "dummy_user_id",
+			rawResp: `{
+				"ok": false,
+				"error": "dummy_error_from_slack",
+				"response_metadata": {
+					"messages": [
+						"dummy error response"
+					]
+				}
+			}`,
+			expectedResp: &ViewResponse{
+				SlackResponse{
+					Ok:    false,
+					Error: dummySlackErr.Error(),
+				},
+				View{},
+			},
+			expectedErr: dummySlackErr,
+		},
+		{
+			caseName: "success",
+			userID:   "dummy_user_id",
+			rawResp: `{
+				"ok": true,
+				"view": {
+					"id": "VMHU10V25",
+					"team_id": "T8N4K1JN",
+					"type": "home",
+					"close": null,
+					"submit": null,
+					"blocks": [
+						{
+							"type": "section",
+							"block_id": "2WGp9",
+							"text": {
+								"type": "mrkdwn",
+								"text": "A simple section with some sample sentence.",
+								"verbatim": false
+							}
+						}
+					],
+					"private_metadata": "Shh it is a secret",
+					"callback_id": "identify_your_home_tab",
+					"state": {
+						"values": []
+					},
+					"hash": "156772938.1827394",
+					"clear_on_close": false,
+					"notify_on_close": false,
+					"root_view_id": "VMHU10V25",
+					"previous_view_id": null,
+					"app_id": "AA4928AQ",
+					"external_id": "",
+					"bot_id": "BA13894H"
+				}
+			}`,
+			expectedResp: &ViewResponse{
+				SlackResponse{
+					Ok:    true,
+					Error: "",
+				},
+				View{
+					ID:   "VMHU10V25",
+					Type: VTHomeTab,
+				},
+			},
+			expectedErr: nil,
+		},
+	}
+
+	h := &viewsHandler{}
+	http.HandleFunc("/views.publish", h.handler)
+	for _, c := range cases {
+		t.Run(c.caseName, func(t *testing.T) {
+			h.rawResponse = c.rawResp
+
+			resp, err := api.PublishView(c.userID, HomeTabViewRequest{}, "dummy_hash")
+			if c.expectedErr == nil && err != nil {
+				t.Errorf("unexpected error: %s\n", err)
+				return
+			}
+			if c.expectedErr != nil && err == nil {
+				t.Errorf("expected %s, but did not raise an error", c.expectedErr)
+				return
+			}
+			if c.expectedErr != nil && err != nil && c.expectedErr.Error() != err.Error() {
+				t.Errorf("expected %s as error but got %s\n", c.expectedErr, err)
+				return
+			}
+			if resp == nil || c.expectedResp == nil {
+				return
+			}
+			if c.expectedResp.ID != resp.ID || c.expectedResp.Type != resp.Type {
+				t.Errorf("expected:\n\t%v\nas response but got:\n\t%v\n", c.expectedResp, resp)
+			}
+		})
+	}
+}
+
+func TestSlack_PushView(t *testing.T) {
+	once.Do(startServer)
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
+
+	cases := []struct {
+		caseName     string
+		triggerID    string
+		rawResp      string
+		expectedResp *ViewResponse
+		expectedErr  error
+	}{
+		{
+			caseName:     "pass empty trigger_id",
+			triggerID:    "",
+			rawResp:      "",
+			expectedResp: nil,
+			expectedErr:  ErrParametersMissing,
+		},
+		{
+			caseName:  "raise an error from Slack API",
+			triggerID: "dummy_trigger_id",
+			rawResp: `{
+				"ok": false,
+				"error": "dummy_error_from_slack",
+				"response_metadata": {
+					"messages": [
+						"dummy error response"
+					]
+				}
+			}`,
+			expectedResp: &ViewResponse{
+				SlackResponse{
+					Ok:    false,
+					Error: dummySlackErr.Error(),
+				},
+				View{},
+			},
+			expectedErr: dummySlackErr,
+		},
+		{
+			caseName:  "success",
+			triggerID: "dummy_trigger_id",
+			rawResp: `{
+				"ok": true,
+				"view": {
+					"id": "VMHU10V25",
+					"team_id": "T8N4K1JN",
+					"type": "modal",
+					"title": {
+						"type": "plain_text",
+						"text": "Quite a plain modal"
+					},
+					"submit": {
+						"type": "plain_text",
+						"text": "Create"
+					},
+					"blocks": [
+						{
+							"type": "rich_text",
+							"block_id": "a_block_id",
+							"label": {
+								"type": "plain_text",
+								"text": "A simple label",
+								"emoji": true
+							},
+							"optional": false,
+							"element": {
+								"type": "plain_text_input",
+								"action_id": "an_action_id"
+							}
+						}
+					],
+					"private_metadata": "Shh it is a secret",
+					"callback_id": "identify_your_modals",
+					"external_id": "",
+					"state": {
+						"values": []
+					},
+					"hash": "156772938.1827394",
+					"clear_on_close": false,
+					"notify_on_close": false,
+					"root_view_id": "VMHU10V25",
+					"app_id": "AA4928AQ",
+					"bot_id": "BA13894H"
+				}
+			}`,
+			expectedResp: &ViewResponse{
+				SlackResponse{
+					Ok:    true,
+					Error: "",
+				},
+				View{
+					ID:   "VMHU10V25",
+					Type: VTModal,
+				},
+			},
+			expectedErr: nil,
+		},
+	}
+
+	h := &viewsHandler{}
+	http.HandleFunc("/views.push", h.handler)
+	for _, c := range cases {
+		t.Run(c.caseName, func(t *testing.T) {
+			h.rawResponse = c.rawResp
+
+			resp, err := api.PushView(c.triggerID, ModalViewRequest{})
+			if c.expectedErr == nil && err != nil {
+				t.Errorf("unexpected error: %s\n", err)
+				return
+			}
+			if c.expectedErr != nil && err == nil {
+				t.Errorf("expected %s, but did not raise an error", c.expectedErr)
+				return
+			}
+			if c.expectedErr != nil && err != nil && c.expectedErr.Error() != err.Error() {
+				t.Errorf("expected %s as error but got %s\n", c.expectedErr, err)
+				return
+			}
+			if resp == nil || c.expectedResp == nil {
+				return
+			}
+			if c.expectedResp.ID != resp.ID || c.expectedResp.Type != resp.Type {
+				t.Errorf("expected:\n\t%v\nas response but got:\n\t%v\n", c.expectedResp, resp)
+			}
+		})
+	}
+}
+
+func TestSlack_UpdateView(t *testing.T) {
+	once.Do(startServer)
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
+
+	cases := []struct {
+		caseName     string
+		externalID   string
+		viewID       string
+		rawResp      string
+		expectedResp *ViewResponse
+		expectedErr  error
+	}{
+		{
+			caseName:     "pass empty external_id and empty view_id",
+			externalID:   "",
+			viewID:       "",
+			rawResp:      "",
+			expectedResp: nil,
+			expectedErr:  ErrParametersMissing,
+		},
+		{
+			caseName:   "raise an error from Slack API",
+			externalID: "dummy_external_id",
+			viewID:     "",
+			rawResp: `{
+				"ok": false,
+				"error": "dummy_error_from_slack",
+				"response_metadata": {
+					"messages": [
+						"dummy error response"
+					]
+				}
+			}`,
+			expectedResp: &ViewResponse{
+				SlackResponse{
+					Ok:    false,
+					Error: dummySlackErr.Error(),
+				},
+				View{},
+			},
+			expectedErr: dummySlackErr,
+		},
+		{
+			caseName:   "success",
+			externalID: "",
+			viewID:     "dummy_view_id",
+			rawResp: `{
+				"ok": true,
+				"view": {
+					"id": "VMHU10V25",
+					"team_id": "T8N4K1JN",
+					"type": "modal",
+					"title": {
+						"type": "plain_text",
+						"text": "Quite a plain modal"
+					},
+					"submit": {
+						"type": "plain_text",
+						"text": "Create"
+					},
+					"blocks": [
+						{
+							"type": "rich_text",
+							"block_id": "a_block_id",
+							"label": {
+								"type": "plain_text",
+								"text": "A simple label",
+								"emoji": true
+							},
+							"optional": false,
+							"element": {
+								"type": "plain_text_input",
+								"action_id": "an_action_id"
+							}
+						}
+					],
+					"private_metadata": "Shh it is a secret",
+					"callback_id": "identify_your_modals",
+					"external_id": "",
+					"state": {
+						"values": []
+					},
+					"hash": "156772938.1827394",
+					"clear_on_close": false,
+					"notify_on_close": false,
+					"root_view_id": "VMHU10V25",
+					"app_id": "AA4928AQ",
+					"bot_id": "BA13894H"
+				}
+			}`,
+			expectedResp: &ViewResponse{
+				SlackResponse{
+					Ok:    true,
+					Error: "",
+				},
+				View{
+					ID:   "VMHU10V25",
+					Type: VTModal,
+				},
+			},
+			expectedErr: nil,
+		},
+	}
+
+	h := &viewsHandler{}
+	http.HandleFunc("/views.update", h.handler)
+	for _, c := range cases {
+		t.Run(c.caseName, func(t *testing.T) {
+			h.rawResponse = c.rawResp
+
+			resp, err := api.UpdateView(ModalViewRequest{}, c.externalID, "dummy_hash", c.viewID)
+			if c.expectedErr == nil && err != nil {
+				t.Errorf("unexpected error: %s\n", err)
+				return
+			}
+			if c.expectedErr != nil && err == nil {
+				t.Errorf("expected %s, but did not raise an error", c.expectedErr)
+				return
+			}
+			if c.expectedErr != nil && err != nil && c.expectedErr.Error() != err.Error() {
+				t.Errorf("expected %s as error but got %s\n", c.expectedErr, err)
+				return
+			}
+			if resp == nil || c.expectedResp == nil {
+				return
+			}
+			if c.expectedResp.ID != resp.ID || c.expectedResp.Type != resp.Type {
+				t.Errorf("expected:\n\t%v\nas response but got:\n\t%v\n", c.expectedResp, resp)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Overview
This PR supports views API. This is useful for Modal, Home Tab.

ref: https://api.slack.com/reference/surfaces/views

---

##### Pull Request Guidelines

These are recommendations for pull requests.  
They are strictly guidelines to help manage expectations.

##### should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.
