### PR TITLE
Add input block and plain-text input element

### DIFF
--- a/block.go
+++ b/block.go
@@ -14,6 +14,7 @@ const (
 	MBTImage   MessageBlockType = "image"
 	MBTAction  MessageBlockType = "actions"
 	MBTContext MessageBlockType = "context"
+	MBTInput   MessageBlockType = "input"
 )
 
 // Block defines an interface all block types should implement

--- a/block_conv.go
+++ b/block_conv.go
@@ -58,6 +58,8 @@ func (b *Blocks) UnmarshalJSON(data []byte) error {
 			block = &DividerBlock{}
 		case "image":
 			block = &ImageBlock{}
+		case "input":
+			block = &InputBlock{}
 		case "section":
 			block = &SectionBlock{}
 		case "rich_text":

--- a/block_conv.go
+++ b/block_conv.go
@@ -127,6 +127,8 @@ func (b *BlockElements) UnmarshalJSON(data []byte) error {
 			blockElement = &OverflowBlockElement{}
 		case "datepicker":
 			blockElement = &DatePickerBlockElement{}
+		case "plain_text_input":
+			blockElement = &PlainTextInputBlockElement{}
 		case "static_select", "external_select", "users_select", "conversations_select", "channels_select":
 			blockElement = &SelectBlockElement{}
 		default:

--- a/block_element.go
+++ b/block_element.go
@@ -3,10 +3,11 @@ package slack
 // https://api.slack.com/reference/messaging/block-elements
 
 const (
-	METImage      MessageElementType = "image"
-	METButton     MessageElementType = "button"
-	METOverflow   MessageElementType = "overflow"
-	METDatepicker MessageElementType = "datepicker"
+	METImage          MessageElementType = "image"
+	METButton         MessageElementType = "button"
+	METOverflow       MessageElementType = "overflow"
+	METDatepicker     MessageElementType = "datepicker"
+	METPlainTextInput MessageElementType = "plain_text_input"
 
 	MixedElementImage MixedElementType = "mixed_image"
 	MixedElementText  MixedElementType = "mixed_text"
@@ -234,5 +235,33 @@ func NewDatePickerBlockElement(actionID string) *DatePickerBlockElement {
 	return &DatePickerBlockElement{
 		Type:     METDatepicker,
 		ActionID: actionID,
+	}
+}
+
+// PlainTextInputBlockElement creates a field where a user can enter freeform data.
+// Plain-text input elements are currently only available in modals.
+//
+// More Information: https://api.slack.com/reference/messaging/block-elements#input
+type PlainTextInputBlockElement struct {
+	Type         MessageElementType `json:"type"`
+	ActionID     string             `json:"action_id"`
+	Placeholder  *TextBlockObject   `json:"placeholder,omitempty"`
+	InitialValue string             `json:"initial_value,omitempty"`
+	Multiline    bool               `json:"multiline,omitempty"`
+	MinLength    int                `json:"min_length,omitempty"`
+	MaxLength    int                `json:"max_length,omitempty"`
+}
+
+// ElementType returns the type of the Element
+func (s PlainTextInputBlockElement) ElementType() MessageElementType {
+	return s.Type
+}
+
+// NewPlainTextInputBlockElement returns an instance of a plain-text input element
+func NewPlainTextInputBlockElement(placeholder *TextBlockObject, actionID string) *PlainTextInputBlockElement {
+	return &PlainTextInputBlockElement{
+		Type:        METPlainTextInput,
+		ActionID:    actionID,
+		Placeholder: placeholder,
 	}
 }

--- a/block_element_test.go
+++ b/block_element_test.go
@@ -84,3 +84,10 @@ func TestNewDatePickerBlockElement(t *testing.T) {
 	assert.Equal(t, datepickerElement.ActionID, "test")
 
 }
+
+func TestNewPlainTextInputBlockElement(t *testing.T) {
+	inputElement := NewPlainTextInputBlockElement(nil, "test")
+
+	assert.Equal(t, string(inputElement.Type), "plain_text_input")
+	assert.Equal(t, inputElement.ActionID, "test")
+}

--- a/block_input.go
+++ b/block_input.go
@@ -1,0 +1,30 @@
+package slack
+
+// InputBlock defines data that is used to collect information from users -
+// it can hold a plain-text input element, a select menu element,
+// a multi-select menu element, or a datepicker.
+//
+// More Information: https://api.slack.com/reference/messaging/blocks#input
+type InputBlock struct {
+	Type     MessageBlockType `json:"type"`
+	BlockID  string           `json:"block_id,omitempty"`
+	Label    *TextBlockObject `json:"label"`
+	Element  BlockElement     `json:"element"`
+	Hint     *TextBlockObject `json:"hint,omitempty"`
+	Optional bool             `json:"optional,omitempty"`
+}
+
+// BlockType returns the type of the block
+func (s InputBlock) BlockType() MessageBlockType {
+	return s.Type
+}
+
+// NewInputBlock returns a new instance of an Input Block
+func NewInputBlock(blockID string, label *TextBlockObject, element BlockElement) *InputBlock {
+	return &InputBlock{
+		Type:    MBTInput,
+		BlockID: blockID,
+		Label:   label,
+		Element: element,
+	}
+}

--- a/block_input_test.go
+++ b/block_input_test.go
@@ -1,0 +1,17 @@
+package slack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewInputBlock(t *testing.T) {
+	label := NewTextBlockObject("plain_text", "Input", false, false)
+	inputElement := NewPlainTextInputBlockElement(nil, "input_123")
+
+	inputBlock := NewInputBlock("test", label, inputElement)
+	assert.Equal(t, string(inputBlock.Type), "input")
+	assert.Equal(t, inputBlock.BlockID, "test")
+	assert.Equal(t, string(inputBlock.Element.ElementType()), "plain_text_input")
+}

--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
 )
+
+go 1.13


### PR DESCRIPTION
### What this PR does

- Add [input block](https://api.slack.com/reference/block-kit/blocks#input)
- Add [plain-text input element](https://api.slack.com/reference/block-kit/block-elements#input)

### Note

Currently, the modal is not supported in master branch.
It will be available after #632 is merged.