### PR TITLE
bugfix: fix json unmarshal error and fix unsupported block type 'file' error

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -84,7 +84,7 @@ type Attachment struct {
 	Actions    []AttachmentAction `json:"actions,omitempty"`
 	MarkdownIn []string           `json:"mrkdwn_in,omitempty"`
 
-	Blocks []Block `json:"blocks,omitempty"`
+	Blocks Blocks `json:"blocks,omitempty"`
 
 	Footer     string `json:"footer,omitempty"`
 	FooterIcon string `json:"footer_icon,omitempty"`

--- a/block_conv.go
+++ b/block_conv.go
@@ -63,6 +63,8 @@ func (b *Blocks) UnmarshalJSON(data []byte) error {
 		case "rich_text":
 			// for now ignore the (complex) content of rich_text blocks until we can fully support it
 			continue
+		case "file":
+			continue
 		default:
 			return errors.New("unsupported block type")
 		}

--- a/chat_test.go
+++ b/chat_test.go
@@ -97,7 +97,7 @@ func TestPostMessage(t *testing.T) {
 			opt: []MsgOption{
 				MsgOptionAttachments(
 					Attachment{
-						Blocks: blocks,
+						Blocks: Blocks{BlockSet: blocks},
 					}),
 			},
 			expected: url.Values{

--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
 )
+
+go 1.13


### PR DESCRIPTION
These changes fix the `unsupported block type` error when we receive a `file` block in histories.
But, unfortunately, these changes assuming fixed a json unmarshal from `InteractionCallback`, so I fixed it too (note: this is the same approach as #638 and #638 is more precise than my solution).
