### PR TITLE
MsgOptionResponseURL: make argument name easy

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -347,11 +347,11 @@ func MsgOptionUnfurl(timestamp string, unfurls map[string]Attachment) MsgOption 
 }
 
 // MsgOptionResponseURL supplies a url to use as the endpoint.
-func MsgOptionResponseURL(url string, rt string) MsgOption {
+func MsgOptionResponseURL(url string, responseType string) MsgOption {
 	return func(config *sendConfig) error {
 		config.mode = chatResponse
 		config.endpoint = url
-		config.responseType = rt
+		config.responseType = responseType
 		config.values.Del("ts")
 		return nil
 	}


### PR DESCRIPTION
The argument name `rt` is not easy to understand as `responseType` (at least for me).

could you update it to `responseType` or add comment?