### PR TITLE
Add function to use context in webhook posts

### DIFF
--- a/webhooks.go
+++ b/webhooks.go
@@ -1,11 +1,8 @@
 package slack
 
 import (
-	"bytes"
-	"encoding/json"
+	"context"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 type WebhookMessage struct {
@@ -20,21 +17,13 @@ type WebhookMessage struct {
 }
 
 func PostWebhook(url string, msg *WebhookMessage) error {
-	return PostWebhookCustomHTTP(url, http.DefaultClient, msg)
+	return PostWebhookCustomHTTPContext(context.Background(), url, http.DefaultClient, msg)
+}
+
+func PostWebhookContext(ctx context.Context, url string, msg *WebhookMessage) error {
+	return PostWebhookCustomHTTPContext(ctx, url, http.DefaultClient, msg)
 }
 
 func PostWebhookCustomHTTP(url string, httpClient *http.Client, msg *WebhookMessage) error {
-	raw, err := json.Marshal(msg)
-
-	if err != nil {
-		return errors.Wrap(err, "marshal failed")
-	}
-
-	response, err := httpClient.Post(url, "application/json", bytes.NewReader(raw))
-
-	if err != nil {
-		return errors.Wrap(err, "failed to post webhook")
-	}
-
-	return checkStatusCode(response, discard{})
+	return PostWebhookCustomHTTPContext(context.Background(), url, httpClient, msg)
 }

--- a/webhooks_go112.go
+++ b/webhooks_go112.go
@@ -1,0 +1,34 @@
+// +build !go1.13
+
+package slack
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+func PostWebhookCustomHTTPContext(ctx context.Context, url string, httpClient *http.Client, msg *WebhookMessage) error {
+	raw, err := json.Marshal(msg)
+	if err != nil {
+		return errors.Wrap(err, "marshal failed")
+	}
+
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(raw))
+	if err != nil {
+		return errors.Wrap(err, "failed new request")
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "failed to post webhook")
+	}
+	defer resp.Body.Close()
+
+	return checkStatusCode(resp, discard{})
+}

--- a/webhooks_go113.go
+++ b/webhooks_go113.go
@@ -1,0 +1,33 @@
+// +build go1.13
+
+package slack
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+func PostWebhookCustomHTTPContext(ctx context.Context, url string, httpClient *http.Client, msg *WebhookMessage) error {
+	raw, err := json.Marshal(msg)
+	if err != nil {
+		return errors.Wrap(err, "marshal failed")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(raw))
+	if err != nil {
+		return errors.Wrap(err, "failed new request")
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "failed to post webhook")
+	}
+	defer resp.Body.Close()
+
+	return checkStatusCode(resp, discard{})
+}


### PR DESCRIPTION
The added function is as follows.
- PostWebhookContext
- PostWebhookCustomHTTPContext

Go 1.13 uses `NewRequestWithContext`.
Added `webhooks_go112.go` and` webhooks_go113.go` to use build tags.

This is the same change as https://github.com/nlopes/slack/pull/658.