### PR TITLE
 fix unsupported block type Error by 'file' type block

### DIFF
--- a/block_conv.go
+++ b/block_conv.go
@@ -65,6 +65,9 @@ func (b *Blocks) UnmarshalJSON(data []byte) error {
 		case "rich_text":
 			// for now ignore the (complex) content of rich_text blocks until we can fully support it
 			continue
+		case "file":
+			// for now ignore the file blocks until we can fully support it
+			continue
 		default:
 			return errors.New("unsupported block type")
 		}


### PR DESCRIPTION
These changes fix the unsupported block type error when we receive a file block in histories.

Note: This is [same PRs](https://github.com/nlopes/slack/pull/653) in awesome pioneer `nlopes/slack`.
This is the first step of handling `blockType:file` (as mentioned [here](https://github.com/nlopes/slack/pull/653#issuecomment-587280164)) and ~probably~ related in https://github.com/nlopes/slack/issues/656.
