### PR TITLE
Message Struct lacking ID

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -15,13 +15,14 @@ type OutgoingMessage struct {
 // Message is an auxiliary type to allow us to have a message containing sub messages
 type Message struct {
 	Msg
-	SubMessage *Msg `json:"message,omitempty"`
+	SubMessage      *Msg `json:"message,omitempty"`
 	PreviousMessage *Msg `json:"previous_message,omitempty"`
 }
 
 // Msg contains information about a slack message
 type Msg struct {
 	// Basic Message
+	ID              string       `json:"client_msg_id"`
 	Type            string       `json:"type,omitempty"`
 	Channel         string       `json:"channel,omitempty"`
 	User            string       `json:"user,omitempty"`


### PR DESCRIPTION
Added an ID field (string - no omitempty) to distinguish between different messages coming from the server. 
