### PR TITLE
Add api_app_id to interactions and events

### DIFF
--- a/interactions.go
+++ b/interactions.go
@@ -44,6 +44,7 @@ type InteractionCallback struct {
 	MessageTs       string          `json:"message_ts"`
 	AttachmentID    string          `json:"attachment_id"`
 	ActionCallback  ActionCallbacks `json:"actions"`
+	APIAppID        string          `json:"api_app_id"`
 	DialogSubmissionCallback
 }
 

--- a/slackevents/outer_events.go
+++ b/slackevents/outer_events.go
@@ -11,6 +11,7 @@ type EventsAPIEvent struct {
 	Token      string `json:"token"`
 	TeamID     string `json:"team_id"`
 	Type       string `json:"type"`
+	APIAppID   string `json:"api_app_id"`
 	Data       interface{}
 	InnerEvent EventsAPIInnerEvent
 }

--- a/slackevents/parsers.go
+++ b/slackevents/parsers.go
@@ -38,6 +38,7 @@ func parseOuterEvent(rawE json.RawMessage) (EventsAPIEvent, error) {
 			"",
 			"",
 			"unmarshalling_error",
+			"",
 			&slack.UnmarshallingErrorEvent{ErrorObj: err},
 			EventsAPIInnerEvent{},
 		}, err
@@ -50,6 +51,7 @@ func parseOuterEvent(rawE json.RawMessage) (EventsAPIEvent, error) {
 				"",
 				"",
 				"unmarshalling_error",
+				"",
 				&slack.UnmarshallingErrorEvent{ErrorObj: err},
 				EventsAPIInnerEvent{},
 			}, err
@@ -58,6 +60,7 @@ func parseOuterEvent(rawE json.RawMessage) (EventsAPIEvent, error) {
 			e.Token,
 			e.TeamID,
 			e.Type,
+			e.APIAppID,
 			cbEvent,
 			EventsAPIInnerEvent{},
 		}, nil
@@ -69,6 +72,7 @@ func parseOuterEvent(rawE json.RawMessage) (EventsAPIEvent, error) {
 			"",
 			"",
 			"unmarshalling_error",
+			"",
 			&slack.UnmarshallingErrorEvent{ErrorObj: err},
 			EventsAPIInnerEvent{},
 		}, err
@@ -77,6 +81,7 @@ func parseOuterEvent(rawE json.RawMessage) (EventsAPIEvent, error) {
 		e.Token,
 		e.TeamID,
 		e.Type,
+		e.APIAppID,
 		urlVE,
 		EventsAPIInnerEvent{},
 	}, nil
@@ -91,6 +96,7 @@ func parseInnerEvent(e *EventsAPICallbackEvent) (EventsAPIEvent, error) {
 			e.Token,
 			e.TeamID,
 			"unmarshalling_error",
+			e.APIAppID,
 			&slack.UnmarshallingErrorEvent{ErrorObj: err},
 			EventsAPIInnerEvent{},
 		}, err
@@ -101,6 +107,7 @@ func parseInnerEvent(e *EventsAPICallbackEvent) (EventsAPIEvent, error) {
 			e.Token,
 			e.TeamID,
 			iE.Type,
+			e.APIAppID,
 			nil,
 			EventsAPIInnerEvent{},
 		}, fmt.Errorf("Inner Event does not exist! %s", iE.Type)
@@ -113,6 +120,7 @@ func parseInnerEvent(e *EventsAPICallbackEvent) (EventsAPIEvent, error) {
 			e.Token,
 			e.TeamID,
 			"unmarshalling_error",
+			e.APIAppID,
 			&slack.UnmarshallingErrorEvent{ErrorObj: err},
 			EventsAPIInnerEvent{},
 		}, err
@@ -121,6 +129,7 @@ func parseInnerEvent(e *EventsAPICallbackEvent) (EventsAPIEvent, error) {
 		e.Token,
 		e.TeamID,
 		e.Type,
+		e.APIAppID,
 		e,
 		EventsAPIInnerEvent{iE.Type, recvEvent},
 	}, nil
@@ -186,6 +195,7 @@ func ParseEvent(rawEvent json.RawMessage, opts ...Option) (EventsAPIEvent, error
 				"",
 				"",
 				"unmarshalling_error",
+				"",
 				&slack.UnmarshallingErrorEvent{ErrorObj: err},
 				EventsAPIInnerEvent{},
 			}, err
@@ -199,6 +209,7 @@ func ParseEvent(rawEvent json.RawMessage, opts ...Option) (EventsAPIEvent, error
 			"",
 			"",
 			"unmarshalling_error",
+			"",
 			&slack.UnmarshallingErrorEvent{ErrorObj: err},
 			EventsAPIInnerEvent{},
 		}, err
@@ -207,6 +218,7 @@ func ParseEvent(rawEvent json.RawMessage, opts ...Option) (EventsAPIEvent, error
 		e.Token,
 		e.TeamID,
 		e.Type,
+		e.APIAppID,
 		urlVerificationEvent,
 		EventsAPIInnerEvent{},
 	}, nil


### PR DESCRIPTION
* Add `api_app_id` to event and interaction structs
* Very useful when different slack apps have events going to a single endpoint and you need to distinguish the apps from eachother
* `make pr-prep` was run and no issues with linting, formatting or tests

FYI The test failures seem to be intermittent and related to the websocket integration tests being non-deterministic in some way. That error is not caused by this PR.