### PR TITLE
Add support for V2 OAuth for granular permissions

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -31,6 +31,40 @@ type OAuthResponse struct {
 	SlackResponse
 }
 
+// OAuthV2Response ...
+type OAuthV2Response struct {
+	AccessToken string                    `json:"access_token"`
+	TokenType   string                    `json:"token_type"`
+	Scope       string                    `json:"scope"`
+	BotUserID   string                    `json:"bot_user_id"`
+	AppID       string                    `json:"app_id"`
+	TeamID      string                    `json:"team_id"`
+	Team        OAuthV2ResponseTeam       `json:"team"`
+	Enterprise  OAuthV2ResponseEnterprise `json:"enterprise"`
+	AuthedUser  OAuthV2ResponseAuthedUser `json:"authed_user"`
+	SlackResponse
+}
+
+// OAuthV2ResponseTeam ...
+type OAuthV2ResponseTeam struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// OAuthV2ResponseEnterprise ...
+type OAuthV2ResponseEnterprise struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// OAuthV2ResponseAuthedUser ...
+type OAuthV2ResponseAuthedUser struct {
+	ID          string `json:"id"`
+	Scope       string `json:"scope"`
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+}
+
 // GetOAuthToken retrieves an AccessToken
 func GetOAuthToken(client httpClient, clientID, clientSecret, code, redirectURI string) (accessToken string, scope string, err error) {
 	return GetOAuthTokenContext(context.Background(), client, clientID, clientSecret, code, redirectURI)
@@ -58,6 +92,26 @@ func GetOAuthResponseContext(ctx context.Context, client httpClient, clientID, c
 	}
 	response := &OAuthResponse{}
 	if err = postForm(ctx, client, APIURL+"oauth.access", values, response, discard{}); err != nil {
+		return nil, err
+	}
+	return response, response.Err()
+}
+
+// GetOAuthV2Response gets a V2 OAuth access token response - https://api.slack.com/methods/oauth.v2.access
+func GetOAuthV2Response(client httpClient, clientID, clientSecret, code, redirectURI string) (resp *OAuthV2Response, err error) {
+	return GetOAuthV2ResponseContext(context.Background(), client, clientID, clientSecret, code, redirectURI)
+}
+
+// GetOAuthV2ResponseContext with a context, gets a V2 OAuth access token response
+func GetOAuthV2ResponseContext(ctx context.Context, client httpClient, clientID, clientSecret, code, redirectURI string) (resp *OAuthV2Response, err error) {
+	values := url.Values{
+		"client_id":     {clientID},
+		"client_secret": {clientSecret},
+		"code":          {code},
+		"redirect_uri":  {redirectURI},
+	}
+	response := &OAuthV2Response{}
+	if err = postForm(ctx, client, APIURL+"oauth.v2.access", values, response, discard{}); err != nil {
 		return nil, err
 	}
 	return response, response.Err()


### PR DESCRIPTION
* Support the V2 OAuth flow used with granular permissions: https://api.slack.com/authentication/oauth-v2
* The new structs andle te new JSON response from the `oauth.v2.access` endpoint on the Slack API
* `make pr-prep` is shows no test failures, linting for formatting issues
