### PR TITLE
Message Struct Lacking ClientMsgID

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -22,6 +22,7 @@ type Message struct {
 // Msg contains information about a slack message
 type Msg struct {
 	// Basic Message
+	ClientMsgID     string       `json:"client_msg_id"`
 	Type            string       `json:"type,omitempty"`
 	Channel         string       `json:"channel,omitempty"`
 	User            string       `json:"user,omitempty"`


### PR DESCRIPTION
Added an ID field (string - no omitempty) to distinguish between different messages coming from the server.