### PR TITLE
Unmarshal multi select input block

### DIFF
--- a/block_conv.go
+++ b/block_conv.go
@@ -108,6 +108,8 @@ func (b *InputBlock) UnmarshalJSON(data []byte) error {
 		e = &PlainTextInputBlockElement{}
 	case "static_select", "external_select", "users_select", "conversations_select", "channels_select":
 		e = &SelectBlockElement{}
+	case "multi_static_select", "multi_external_select", "multi_users_select", "multi_conversations_select", "multi_channels_select":
+		e = &MultiSelectBlockElement{}
 	default:
 		return errors.New("unsupported block element type")
 	}


### PR DESCRIPTION
Multi-select menus are also available in input blocks.
https://api.slack.com/reference/block-kit/block-elements#multi_select