### PR TITLE
Add missing subteam_members_changed event mapping

### DIFF
--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -572,10 +572,11 @@ var EventMapping = map[string]interface{}{
 	"member_joined_channel": MemberJoinedChannelEvent{},
 	"member_left_channel":   MemberLeftChannelEvent{},
 
-	"subteam_created":      SubteamCreatedEvent{},
-	"subteam_self_added":   SubteamSelfAddedEvent{},
-	"subteam_self_removed": SubteamSelfRemovedEvent{},
-	"subteam_updated":      SubteamUpdatedEvent{},
+	"subteam_created":         SubteamCreatedEvent{},
+	"subteam_members_changed": SubteamMembersChangedEvent{},
+	"subteam_self_added":      SubteamSelfAddedEvent{},
+	"subteam_self_removed":    SubteamSelfRemovedEvent{},
+	"subteam_updated":         SubteamUpdatedEvent{},
 
 	"desktop_notification":       DesktopNotificationEvent{},
 	"mobile_in_app_notification": MobileInAppNotificationEvent{},


### PR DESCRIPTION
The `subteam_members_changed` event mapping was missed in #390, even though the `SubteamMembersChangedEvent` struct was created.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>
