### PR TITLE
Add missing omitempty for `client_msg_id`

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -22,7 +22,7 @@ type Message struct {
 // Msg contains information about a slack message
 type Msg struct {
 	// Basic Message
-	ClientMsgID     string       `json:"client_msg_id"`
+	ClientMsgID     string       `json:"client_msg_id,omitempty"`
 	Type            string       `json:"type,omitempty"`
 	Channel         string       `json:"channel,omitempty"`
 	User            string       `json:"user,omitempty"`


### PR DESCRIPTION
Unlike all the other fields in the `Msg` struct, the `ClientMsgID` field does not have `omitempty` set in its json tag. This PR adds it back so that the JSON generation is consistent.