### PR TITLE
Allow multi_static_select input block unmarshalling

### DIFF
--- a/block_conv.go
+++ b/block_conv.go
@@ -106,7 +106,7 @@ func (b *InputBlock) UnmarshalJSON(data []byte) error {
 		e = &DatePickerBlockElement{}
 	case "plain_text_input":
 		e = &PlainTextInputBlockElement{}
-	case "static_select", "external_select", "users_select", "conversations_select", "channels_select":
+	case "static_select", "external_select", "users_select", "conversations_select", "channels_select", "multi_static_select":
 		e = &SelectBlockElement{}
 	default:
 		return errors.New("unsupported block element type")

--- a/block_conv_test.go
+++ b/block_conv_test.go
@@ -1,0 +1,18 @@
+package slack
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestInputBlock_UnmarshalJSON_MultiStaticSelect(t *testing.T) {
+	block := NewInputBlock("", nil, NewOptionsMultiSelectBlockElement(MultiOptTypeStatic, nil, ""))
+
+	data, _ := json.Marshal(block)
+
+	var newBlock = InputBlock{}
+	err := json.Unmarshal(data, &newBlock)
+
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
We can open [a modal with a multi_static_select input](https://api.slack.com/tools/block-kit-builder?mode=modal&view=%7B%22type%22%3A%22modal%22%2C%22title%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22My%20App%22%2C%22emoji%22%3Atrue%7D%2C%22submit%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Submit%22%2C%22emoji%22%3Atrue%7D%2C%22close%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Cancel%22%2C%22emoji%22%3Atrue%7D%2C%22blocks%22%3A%5B%7B%22type%22%3A%22input%22%2C%22element%22%3A%7B%22type%22%3A%22multi_static_select%22%2C%22placeholder%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Select%20options%22%2C%22emoji%22%3Atrue%7D%2C%22options%22%3A%5B%7B%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22*this%20is%20plain_text%20text*%22%2C%22emoji%22%3Atrue%7D%2C%22value%22%3A%22value-0%22%7D%2C%7B%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22*this%20is%20plain_text%20text*%22%2C%22emoji%22%3Atrue%7D%2C%22value%22%3A%22value-1%22%7D%2C%7B%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22*this%20is%20plain_text%20text*%22%2C%22emoji%22%3Atrue%7D%2C%22value%22%3A%22value-2%22%7D%5D%7D%2C%22label%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Label%22%2C%22emoji%22%3Atrue%7D%7D%5D%7D) but the SDK fails to unmarshal the API reponse (error: unsupported block element type)