### PR TITLE
Adding const for Interaction Type Shortcut

### DIFF
--- a/interactions.go
+++ b/interactions.go
@@ -27,6 +27,7 @@ const (
 	InteractionTypeBlockSuggestion    = InteractionType("block_suggestion")
 	InteractionTypeViewSubmission     = InteractionType("view_submission")
 	InteractionTypeViewClosed         = InteractionType("view_closed")
+	InteractionTypeShortcut           = InteractionType("shortcut")
 )
 
 // InteractionCallback is sent from slack when a user interactions with a button or dialog.


### PR DESCRIPTION
With the latest release, we're now able to make use of [Shortcuts](https://api.slack.com/interactivity/shortcuts/using), adding the const def for new Type. 