### PR TITLE
Add support for `user_team` and `source_team` in `app_mention` and `message` events

### DIFF
--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -23,6 +23,10 @@ type AppMentionEvent struct {
 	ThreadTimeStamp string      `json:"thread_ts"`
 	Channel         string      `json:"channel"`
 	EventTimeStamp  json.Number `json:"event_ts"`
+
+	// When Message comes from a channel that is shared between workspaces
+	UserTeam   string `json:"user_team,omitempty"`
+	SourceTeam string `json:"source_team,omitempty"`
 }
 
 // AppHomeOpenedEvent Your Slack app home was opened.
@@ -84,6 +88,10 @@ type MessageEvent struct {
 	Channel         string      `json:"channel"`
 	ChannelType     string      `json:"channel_type"`
 	EventTimeStamp  json.Number `json:"event_ts"`
+
+	// When Message comes from a channel that is shared between workspaces
+	UserTeam   string `json:"user_team,omitempty"`
+	SourceTeam string `json:"source_team,omitempty"`
 
 	// Edited Message
 	Message         *MessageEvent `json:"message,omitempty"`

--- a/slackevents/inner_events_test.go
+++ b/slackevents/inner_events_test.go
@@ -14,7 +14,10 @@ func TestAppMention(t *testing.T) {
 				"ts": "1515449522.000016",
 				"thread_ts": "1515449522.000016",
 				"channel": "C0LAN2Q65",
-				"event_ts": "1515449522000016"
+				"event_ts": "1515449522000016",
+				"source_team": "T3MQV36V7",
+				"user_team": "T3MQV36V7",
+				"blah": "test"
 		}
 	`)
 	err := json.Unmarshal(rawE, &AppMentionEvent{})
@@ -109,6 +112,8 @@ func TestMessageEvent(t *testing.T) {
 				"ts": "1355517523.000005",
 				"event_ts": "1355517523.000005",
 				"channel_type": "channel",
+				"source_team": "T3MQV36V7",
+				"user_team": "T3MQV36V7",
 				"message": {
 					"text": "To infinity and beyond.",
 					"edited": {


### PR DESCRIPTION
#### Summary

* Isse #695 
* Adds support for `user_team` and `source_team` in `app_mention` and `message` events.