### PR TITLE
Removed separate TeamID field from OAuth2 response.

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -38,7 +38,6 @@ type OAuthV2Response struct {
 	Scope       string                    `json:"scope"`
 	BotUserID   string                    `json:"bot_user_id"`
 	AppID       string                    `json:"app_id"`
-	TeamID      string                    `json:"team_id"`
 	Team        OAuthV2ResponseTeam       `json:"team"`
 	Enterprise  OAuthV2ResponseEnterprise `json:"enterprise"`
 	AuthedUser  OAuthV2ResponseAuthedUser `json:"authed_user"`


### PR DESCRIPTION
Based on [official documentation](https://api.slack.com/methods/oauth.v2.access#response) and actual behavior OAuth2 response object has no TeamID field (only Team field with nested ID field).

It does not break something explicitly but disguiding during development.