### PR TITLE
handle unexpected integer ip from team.accessLogs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/slack-go/slack
 
 require (
+	github.com/evrenios/slack v0.6.7 // indirect
 	github.com/go-test/deep v1.0.4
 	github.com/gorilla/websocket v1.2.0
-	github.com/nlopes/slack v0.6.0
 	github.com/pkg/errors v0.8.0
 	github.com/stretchr/testify v1.2.2
 )

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
 module github.com/slack-go/slack
 
 require (
-	github.com/evrenios/slack v0.6.7 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-test/deep v1.0.4
 	github.com/gorilla/websocket v1.2.0
 	github.com/pkg/errors v0.8.0
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/evrenios/slack v0.6.7 h1:Owaw4BdxojykM9pdyLHPo6MChqJq06yFon/28nRrcao=
+github.com/evrenios/slack v0.6.7/go.mod h1:QSRiBHK5IQLOF9dRDDbj+yLriccGPKa/Y6KqTS9OFAs=
 github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
 github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gorilla/websocket v1.2.0 h1:VJtLvh6VQym50czpZzx07z/kw9EgAxI3x1ZB8taTMQQ=
@@ -10,5 +12,6 @@ github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/slack-go/slack v0.6.3/go.mod h1:HE4RwNe7YpOg/F0vqo5PwXH3Hki31TplTvKRW9dGGaw=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/go.sum
+++ b/go.sum
@@ -1,17 +1,12 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/evrenios/slack v0.6.7 h1:Owaw4BdxojykM9pdyLHPo6MChqJq06yFon/28nRrcao=
-github.com/evrenios/slack v0.6.7/go.mod h1:QSRiBHK5IQLOF9dRDDbj+yLriccGPKa/Y6KqTS9OFAs=
 github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
 github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gorilla/websocket v1.2.0 h1:VJtLvh6VQym50czpZzx07z/kw9EgAxI3x1ZB8taTMQQ=
 github.com/gorilla/websocket v1.2.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/nlopes/slack v0.6.0 h1:jt0jxVQGhssx1Ib7naAOZEZcGdtIhTzkP0nopK0AsRA=
-github.com/nlopes/slack v0.6.0/go.mod h1:JzQ9m3PMAqcpeCam7UaHSuBuupz7CmpjehYMayT6YOk=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/slack-go/slack v0.6.3/go.mod h1:HE4RwNe7YpOg/F0vqo5PwXH3Hki31TplTvKRW9dGGaw=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/team.go
+++ b/team.go
@@ -31,16 +31,17 @@ type LoginResponse struct {
 }
 
 type Login struct {
-	UserID    string `json:"user_id"`
-	Username  string `json:"username"`
-	DateFirst int    `json:"date_first"`
-	DateLast  int    `json:"date_last"`
-	Count     int    `json:"count"`
-	IP        string `json:"ip"`
-	UserAgent string `json:"user_agent"`
-	ISP       string `json:"isp"`
-	Country   string `json:"country"`
-	Region    string `json:"region"`
+	UserID    string      `json:"user_id"`
+	Username  string      `json:"username"`
+	DateFirst int         `json:"date_first"`
+	DateLast  int         `json:"date_last"`
+	Count     int         `json:"count"`
+	IP        interface{} `json:"ip"`
+	UserAgent string      `json:"user_agent"`
+	ISP       string      `json:"isp"`
+	Country   string      `json:"country"`
+	Region    string      `json:"region"`
+	RealIP    string
 }
 
 type BillableInfoResponse struct {
@@ -133,6 +134,15 @@ func (api *Client) GetAccessLogsContext(ctx context.Context, params AccessLogPar
 	response, err := api.accessLogsRequest(ctx, "team.accessLogs", values)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	for _, login := range response.Logins {
+		switch vv := login.IP.(type) {
+		case string:
+			login.RealIP = vv
+		default:
+			login.RealIP = "0.0.0.0"
+		}
 	}
 	return response.Logins, &response.Paging, nil
 }

--- a/team.go
+++ b/team.go
@@ -2,7 +2,6 @@ package slack
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 	"strconv"
 )
@@ -144,10 +143,6 @@ func (api *Client) GetAccessLogsContext(ctx context.Context, params AccessLogPar
 		default:
 			response.Logins[i].RealIP = "0.0.0.0"
 		}
-	}
-
-	for _, login := range response.Logins {
-		fmt.Println("real ip is:", login.RealIP)
 	}
 
 	return response.Logins, &response.Paging, nil

--- a/team.go
+++ b/team.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strconv"
 )
@@ -136,14 +137,19 @@ func (api *Client) GetAccessLogsContext(ctx context.Context, params AccessLogPar
 		return nil, nil, err
 	}
 
-	for _, login := range response.Logins {
+	for i, login := range response.Logins {
 		switch vv := login.IP.(type) {
 		case string:
-			login.RealIP = vv
+			response.Logins[i].RealIP = vv
 		default:
-			login.RealIP = "0.0.0.0"
+			response.Logins[i].RealIP = "0.0.0.0"
 		}
 	}
+
+	for _, login := range response.Logins {
+		fmt.Println("real ip is:", login.RealIP)
+	}
+
 	return response.Logins, &response.Paging, nil
 }
 

--- a/team_test.go
+++ b/team_test.go
@@ -79,14 +79,26 @@ func getTeamAccessLogs(rw http.ResponseWriter, r *http.Request) {
 			"isp": null,
                         "country": null,
                         "region": null
-                        }],
+												},
+                        {
+                        "user_id": "BUMEV0F",
+			"username": "judge",
+			"date_first": 1447495893,
+			"date_last": 1447495965,
+			"count": 9,
+			"ip": 0,
+			"user_agent": "com.tinyspeck.chatlyio/2.60 (iPhone; iOS 9.1; Scale/3.00)",
+			"isp": null,
+                        "country": null,
+                        "region": null
+												}],
                         "paging": {
-    			"count": 2,
-    			"total": 2,
+    			"count": 3,
+    			"total": 3,
     			"page": 1,
     			"pages": 1
     			}
-  }`)
+	}`)
 	rw.Write(response)
 }
 
@@ -102,13 +114,14 @@ func TestGetAccessLogs(t *testing.T) {
 		return
 	}
 
-	if len(logins) != 2 {
-		t.Fatal("Should have been 2 logins")
+	if len(logins) != 3 {
+		t.Fatal("Should have been 3 logins")
 	}
 
 	// test the first login
 	login1 := logins[0]
 	login2 := logins[1]
+	login3 := logins[2]
 
 	if login1.UserID != "F0UWHUX" {
 		t.Fatal(ErrIncorrectResponse)
@@ -126,6 +139,12 @@ func TestGetAccessLogs(t *testing.T) {
 		t.Fatal(ErrIncorrectResponse)
 	}
 	if login1.IP != "127.0.0.1" {
+		t.Fatal(ErrIncorrectResponse)
+	}
+	if login1.RealIP != "127.0.0.1" {
+		t.Fatal(ErrIncorrectResponse)
+	}
+	if login1.IP != login1.RealIP {
 		t.Fatal(ErrIncorrectResponse)
 	}
 	if !strings.HasPrefix(login1.UserAgent, "SlackWeb") {
@@ -152,11 +171,22 @@ func TestGetAccessLogs(t *testing.T) {
 		t.Fatal(ErrIncorrectResponse)
 	}
 
-	// test the paging
-	if paging.Count != 2 {
+	// test that sometimes sdk can handle 0 ip from login3 without any panic
+	if login3.IP == 0 {
 		t.Fatal(ErrIncorrectResponse)
 	}
-	if paging.Total != 2 {
+	if login3.RealIP != "0.0.0.0" {
+		t.Fatal(ErrIncorrectResponse)
+	}
+	if login3.IP == login3.RealIP {
+		t.Fatal(ErrIncorrectResponse)
+	}
+
+	// test the paging
+	if paging.Count != 3 {
+		t.Fatal(ErrIncorrectResponse)
+	}
+	if paging.Total != 3 {
 		t.Fatal(ErrIncorrectResponse)
 	}
 	if paging.Page != 1 {


### PR DESCRIPTION
when i tried to use `GetAccessLogs` we've seen a panic 

`panic: json: cannot unmarshal number into Go struct field Login.logins.ip of type string`

when i tried to see the response i've seen that the API returns 0 for some cases and when tried to bind to a string field, it fails. 

Example response from slack api shown from REST API 

![image](https://user-images.githubusercontent.com/8480356/79486509-798f5700-801f-11ea-9ada-a7ea00c94b3d.png)


here is a link that mocks the situation; https://play.golang.org/p/KWf363iOnNx