### PR TITLE
Added Blocks struct to WebhookMessage

### DIFF
--- a/webhooks.go
+++ b/webhooks.go
@@ -14,6 +14,7 @@ type WebhookMessage struct {
 	Text            string       `json:"text,omitempty"`
 	Attachments     []Attachment `json:"attachments,omitempty"`
 	Parse           string       `json:"parse,omitempty"`
+	Blocks          Blocks       `json:"blocks,omitempty"`
 }
 
 func PostWebhook(url string, msg *WebhookMessage) error {

--- a/webhooks.go
+++ b/webhooks.go
@@ -14,7 +14,7 @@ type WebhookMessage struct {
 	Text            string       `json:"text,omitempty"`
 	Attachments     []Attachment `json:"attachments,omitempty"`
 	Parse           string       `json:"parse,omitempty"`
-	Blocks          Blocks       `json:"blocks,omitempty"`
+	Blocks          *Blocks      `json:"blocks,omitempty"`
 }
 
 func PostWebhook(url string, msg *WebhookMessage) error {

--- a/webhooks_test.go
+++ b/webhooks_test.go
@@ -70,8 +70,8 @@ func TestWebhookMessage_WithBlocks(t *testing.T) {
 	textBlockObject := NewTextBlockObject("plain_text", "text", false, false)
 	sectionBlock := NewSectionBlock(textBlockObject, nil, nil)
 
-	singleBlock := Blocks{BlockSet: []Block{sectionBlock}}
-	twoBlocks := Blocks{BlockSet: []Block{sectionBlock, sectionBlock}}
+	singleBlock := &Blocks{BlockSet: []Block{sectionBlock}}
+	twoBlocks := &Blocks{BlockSet: []Block{sectionBlock, sectionBlock}}
 
 	msgSingleBlock := WebhookMessage{Blocks: singleBlock}
 	assert.Equal(t, 1, len(msgSingleBlock.Blocks.BlockSet))
@@ -87,5 +87,5 @@ func TestWebhookMessage_WithBlocks(t *testing.T) {
 
 	msgNoBlocks := WebhookMessage{Text: "foo"}
 	msgJsonNoBlocks, _ := json.Marshal(msgNoBlocks)
-	assert.Equal(t, `{"text":"foo","blocks":null}`, string(msgJsonNoBlocks))
+	assert.Equal(t, `{"text":"foo"}`, string(msgJsonNoBlocks))
 }

--- a/webhooks_test.go
+++ b/webhooks_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPostWebhook_OK(t *testing.T) {
@@ -62,4 +64,28 @@ func TestPostWebhook_NotOK(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected to receive error")
 	}
+}
+
+func TestWebhookMessage_WithBlocks(t *testing.T) {
+	textBlockObject := NewTextBlockObject("plain_text", "text", false, false)
+	sectionBlock := NewSectionBlock(textBlockObject, nil, nil)
+
+	singleBlock := Blocks{BlockSet: []Block{sectionBlock}}
+	twoBlocks := Blocks{BlockSet: []Block{sectionBlock, sectionBlock}}
+
+	msgSingleBlock := WebhookMessage{Blocks: singleBlock}
+	assert.Equal(t, 1, len(msgSingleBlock.Blocks.BlockSet))
+
+	msgJsonSingleBlock, _ := json.Marshal(msgSingleBlock)
+	assert.Equal(t, `{"blocks":[{"type":"section","text":{"type":"plain_text","text":"text"}}]}`, string(msgJsonSingleBlock))
+
+	msgTwoBlocks := WebhookMessage{Blocks: twoBlocks}
+	assert.Equal(t, 2, len(msgTwoBlocks.Blocks.BlockSet))
+
+	msgJsonTwoBlocks, _ := json.Marshal(msgTwoBlocks)
+	assert.Equal(t, `{"blocks":[{"type":"section","text":{"type":"plain_text","text":"text"}},{"type":"section","text":{"type":"plain_text","text":"text"}}]}`, string(msgJsonTwoBlocks))
+
+	msgNoBlocks := WebhookMessage{Text: "foo"}
+	msgJsonNoBlocks, _ := json.Marshal(msgNoBlocks)
+	assert.Equal(t, `{"text":"foo","blocks":null}`, string(msgJsonNoBlocks))
 }


### PR DESCRIPTION
Replaces [PR-595](https://github.com/slack-go/slack/pull/595) and adds the missing tests.
Closes [Issue-594](https://github.com/slack-go/slack/issues/594)

##### Pull Request Guidelines

These are recommendations for pull requests.
They are strictly guidelines to help manage expectations.

##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### Examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.
