### PR TITLE
Fix bug that drops additional BlockActions

### DIFF
--- a/interactions.go
+++ b/interactions.go
@@ -135,7 +135,7 @@ func (a *ActionCallbacks) UnmarshalJSON(data []byte) error {
 			}
 
 			a.BlockActions = append(a.BlockActions, action.(*BlockAction))
-			return nil
+			continue
 		}
 
 		action, err := unmarshalAction(r, &AttachmentAction{})

--- a/interactions_test.go
+++ b/interactions_test.go
@@ -288,8 +288,14 @@ func TestInteractionCallbackJSONMarshalAndUnmarshal(t *testing.T) {
 		MessageTs:    "messageTs",
 		AttachmentID: "attachmentID",
 		ActionCallback: ActionCallbacks{
-			AttachmentActions: []*AttachmentAction{{Value: "value"}},
-			BlockActions:      []*BlockAction{{ActionID: "id123"}},
+			AttachmentActions: []*AttachmentAction{
+				{Value: "value"},
+				{Value: "value2"},
+			},
+			BlockActions: []*BlockAction{
+				{ActionID: "id123"},
+				{ActionID: "id456"},
+			},
 		},
 		View: View{
 			Type:  VTModal,


### PR DESCRIPTION
I discovered that `*ActionCallbacks` weren't being unmarshaled correctly, and there's a `return` where a `continue` is probably more correct.

I've adjusted the unit test to test the case where there are multiple `BlockActions`s

Signed-off-by: Dave Henderson <dhenderson@gmail.com>