### PR TITLE
Add SelectedUsers field to BlockAction

### DIFF
--- a/block.go
+++ b/block.go
@@ -41,6 +41,7 @@ type BlockAction struct {
 	SelectedOption       OptionBlockObject   `json:"selected_option"`
 	SelectedOptions      []OptionBlockObject `json:"selected_options"`
 	SelectedUser         string              `json:"selected_user"`
+	SelectedUsers        []string            `json:"selected_users"`
 	SelectedChannel      string              `json:"selected_channel"`
 	SelectedConversation string              `json:"selected_conversation"`
 	SelectedDate         string              `json:"selected_date"`


### PR DESCRIPTION
The `users_multi_select` block element (https://api.slack.com/reference/block-kit/block-elements#users_multi_select) returns its results in the JSON key `selected_users` as an array of strings. This PR adds that key to the `BlockAction` struct so that we can use it to receive data from that input element.