### PR TITLE
Add `omitempty struct tag for Title field of ImageBlock

### DIFF
--- a/block_image.go
+++ b/block_image.go
@@ -8,7 +8,7 @@ type ImageBlock struct {
 	ImageURL string           `json:"image_url"`
 	AltText  string           `json:"alt_text"`
 	BlockID  string           `json:"block_id,omitempty"`
-	Title    *TextBlockObject `json:"title"`
+	Title    *TextBlockObject `json:"title,omitempty"`
 }
 
 // BlockType returns the type of the block


### PR DESCRIPTION
As per [API documentation](https://api.slack.com/reference/block-kit/blocks#image), the `title` of ImageBlock is not required.

In the current library implementation, an empty field of `*TextBlockObject` type leads to `null` in the encoded JSON representation. Slack API rejects such payload with an error. The proper behavior: do not send the `title` field if it's empty. where `omitempty`  struct tag helps.