### PR TITLE
Added missed fields for Container struct

### DIFF
--- a/interactions.go
+++ b/interactions.go
@@ -59,8 +59,11 @@ type InteractionCallback struct {
 }
 
 type Container struct {
-	Type   string `json:"type"`
-	ViewID string `json:"view_id"`
+	Type         string      `json:"type"`
+	ViewID       string      `json:"view_id"`
+	MessageTs    string      `json:"message_ts"`
+	AttachmentID json.Number `json:"attachment_id"`
+	ChannelID    string      `json:"channel_id"`
 }
 
 // ActionCallback is a convenience struct defined to allow dynamic unmarshalling of

--- a/interactions.go
+++ b/interactions.go
@@ -64,6 +64,8 @@ type Container struct {
 	MessageTs    string      `json:"message_ts"`
 	AttachmentID json.Number `json:"attachment_id"`
 	ChannelID    string      `json:"channel_id"`
+	IsEphemeral  bool        `json:"is_ephemeral"`
+	IsAppUnfurl  bool        `json:"is_app_unfurl"`
 }
 
 // ActionCallback is a convenience struct defined to allow dynamic unmarshalling of


### PR DESCRIPTION
As per [API documentation](https://api.slack.com/reference/interaction-payloads/block-actions#examples), `container` subtype of interaction callback can contain additional fields like:

- message_ts
- attachment_id
- channel_id
- is_ephemeral
- is_app_unfurl

They are missed in the current version of the library.