### PR TITLE
Add thread_ts to to LinkSharedEvent

### DIFF
--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -63,6 +63,7 @@ type LinkSharedEvent struct {
 	TimeStamp        string        `json:"ts"`
 	Channel          string        `json:"channel"`
 	MessageTimeStamp json.Number   `json:"message_ts"`
+	ThreadTimeStamp  json.Number   `json:"thread_ts"`
 	Links            []sharedLinks `json:"links"`
 }
 

--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -63,7 +63,7 @@ type LinkSharedEvent struct {
 	TimeStamp        string        `json:"ts"`
 	Channel          string        `json:"channel"`
 	MessageTimeStamp json.Number   `json:"message_ts"`
-	ThreadTimeStamp  json.Number   `json:"thread_ts"`
+	ThreadTimeStamp  string        `json:"thread_ts"`
 	Links            []sharedLinks `json:"links"`
 }
 

--- a/slackevents/inner_events_test.go
+++ b/slackevents/inner_events_test.go
@@ -79,6 +79,7 @@ func TestLinkSharedEvent(t *testing.T) {
 				"channel": "Cxxxxxx",
 				"user": "Uxxxxxxx",
 				"message_ts": "123456789.9875",
+				"thread_ts": "123456789.9876",
 				"links":
 						[
 								{


### PR DESCRIPTION
I was doing some unfurling and noticed that `thread_ts` was missing in the `LinkSharedEvent` struct. This is a little cumbersome if my bot wants to respond in the thread where the URL was mentioned.

https://api.slack.com/events/link_shared