### PR TITLE
users: fix rate limit handling when encountered on the first invocati…

### DIFF
--- a/users.go
+++ b/users.go
@@ -329,20 +329,23 @@ func (t UserPagination) Failure(err error) error {
 
 func (t UserPagination) Next(ctx context.Context) (_ UserPagination, err error) {
 	var (
-		resp *userResponseFull
+		resp   *userResponseFull
+		cursor string
 	)
 
 	if t.c == nil || (t.previousResp != nil && t.previousResp.Cursor == "") {
 		return t, errPaginationComplete
 	}
 
-	t.previousResp = t.previousResp.initialize()
+	if t.previousResp != nil {
+		cursor = t.previousResp.Cursor
+	}
 
 	values := url.Values{
 		"limit":          {strconv.Itoa(t.limit)},
 		"presence":       {strconv.FormatBool(t.presence)},
 		"token":          {t.c.token},
-		"cursor":         {t.previousResp.Cursor},
+		"cursor":         {cursor},
 		"include_locale": {strconv.FormatBool(true)},
 	}
 

--- a/users_test.go
+++ b/users_test.go
@@ -432,7 +432,7 @@ func getUserPage(max int64) func(rw http.ResponseWriter, r *http.Request) {
 // returns n pages of users and sends rate limited errors in between successful pages.
 func getUserPagesWithRateLimitErrors(max int64) func(rw http.ResponseWriter, r *http.Request) {
 	var n int64
-	doRateLimit := false
+	doRateLimit := true
 	return func(rw http.ResponseWriter, r *http.Request) {
 		defer func() {
 			doRateLimit = !doRateLimit


### PR DESCRIPTION
…on of UserPagination.Next()

The test harness was previously set up to respond successfully to the first user page request, then toggle back and forth between rate limiting and not.  This inverts that, returning a rate limit error on the first request which exposes the underlying bug.
