### PR TITLE
Add missing omitempty to actionID of some elements. Add multi select components property to the BlockAction.

### DIFF
--- a/block.go
+++ b/block.go
@@ -49,11 +49,8 @@ type BlockAction struct {
 	SelectedDate          string              `json:"selected_date"`
 	InitialOption         OptionBlockObject   `json:"initial_option"`
 	InitialUser           string              `json:"initial_user"`
-	InitialUsers          []string            `json:"initial_users"`
 	InitialChannel        string              `json:"initial_channel"`
-	InitialChannels       []string            `json:"initial_channels"`
 	InitialConversation   string              `json:"initial_conversation"`
-	InitialConversations  []string            `json:"initial_conversations"`
 	InitialDate           string              `json:"initial_date"`
 }
 

--- a/block.go
+++ b/block.go
@@ -32,23 +32,29 @@ type Blocks struct {
 
 // BlockAction is the action callback sent when a block is interacted with
 type BlockAction struct {
-	ActionID             string              `json:"action_id"`
-	BlockID              string              `json:"block_id"`
-	Type                 actionType          `json:"type"`
-	Text                 TextBlockObject     `json:"text"`
-	Value                string              `json:"value"`
-	ActionTs             string              `json:"action_ts"`
-	SelectedOption       OptionBlockObject   `json:"selected_option"`
-	SelectedOptions      []OptionBlockObject `json:"selected_options"`
-	SelectedUser         string              `json:"selected_user"`
-	SelectedChannel      string              `json:"selected_channel"`
-	SelectedConversation string              `json:"selected_conversation"`
-	SelectedDate         string              `json:"selected_date"`
-	InitialOption        OptionBlockObject   `json:"initial_option"`
-	InitialUser          string              `json:"initial_user"`
-	InitialChannel       string              `json:"initial_channel"`
-	InitialConversation  string              `json:"initial_conversation"`
-	InitialDate          string              `json:"initial_date"`
+	ActionID              string              `json:"action_id"`
+	BlockID               string              `json:"block_id"`
+	Type                  actionType          `json:"type"`
+	Text                  TextBlockObject     `json:"text"`
+	Value                 string              `json:"value"`
+	ActionTs              string              `json:"action_ts"`
+	SelectedOption        OptionBlockObject   `json:"selected_option"`
+	SelectedOptions       []OptionBlockObject `json:"selected_options"`
+	SelectedUser          string              `json:"selected_user"`
+	SelectedUsers         []string            `json:"selected_users"`
+	SelectedChannel       string              `json:"selected_channel"`
+	SelectedChannels      []string            `json:"selected_channels"`
+	SelectedConversation  string              `json:"selected_conversation"`
+	SelectedConversations []string            `json:"selected_conversations"`
+	SelectedDate          string              `json:"selected_date"`
+	InitialOption         OptionBlockObject   `json:"initial_option"`
+	InitialUser           string              `json:"initial_user"`
+	InitialUsers          []string            `json:"initial_users"`
+	InitialChannel        string              `json:"initial_channel"`
+	InitialChannels       []string            `json:"initial_channels"`
+	InitialConversation   string              `json:"initial_conversation"`
+	InitialConversations  []string            `json:"initial_conversations"`
+	InitialDate           string              `json:"initial_date"`
 }
 
 // actionType returns the type of the action

--- a/block_element.go
+++ b/block_element.go
@@ -315,7 +315,7 @@ func NewOverflowBlockElement(actionID string, options ...*OptionBlockObject) *Ov
 // More Information: https://api.slack.com/reference/messaging/block-elements#datepicker
 type DatePickerBlockElement struct {
 	Type        MessageElementType       `json:"type"`
-	ActionID    string                   `json:"action_id"`
+	ActionID    string                   `json:"action_id,omitempty"`
 	Placeholder *TextBlockObject         `json:"placeholder,omitempty"`
 	InitialDate string                   `json:"initial_date,omitempty"`
 	Confirm     *ConfirmationBlockObject `json:"confirm,omitempty"`
@@ -341,7 +341,7 @@ func NewDatePickerBlockElement(actionID string) *DatePickerBlockElement {
 // More Information: https://api.slack.com/reference/block-kit/block-elements#input
 type PlainTextInputBlockElement struct {
 	Type         MessageElementType `json:"type"`
-	ActionID     string             `json:"action_id"`
+	ActionID     string             `json:"action_id,omitempty"`
 	Placeholder  *TextBlockObject   `json:"placeholder,omitempty"`
 	InitialValue string             `json:"initial_value,omitempty"`
 	Multiline    bool               `json:"multiline,omitempty"`
@@ -370,7 +370,7 @@ func NewPlainTextInputBlockElement(placeholder *TextBlockObject, actionID string
 // More Information: https://api.slack.com/reference/block-kit/block-elements#checkboxes
 type CheckboxGroupsBlockElement struct {
 	Type           MessageElementType       `json:"type"`
-	ActionID       string                   `json:"action_id"`
+	ActionID       string                   `json:"action_id,omitempty"`
 	Options        []*OptionBlockObject     `json:"options"`
 	InitialOptions []*OptionBlockObject     `json:"initial_options,omitempty"`
 	Confirm        *ConfirmationBlockObject `json:"confirm,omitempty"`
@@ -396,7 +396,7 @@ func NewCheckboxGroupsBlockElement(actionID string, options ...*OptionBlockObjec
 // More Information: https://api.slack.com/reference/block-kit/block-elements#radio
 type RadioButtonsBlockElement struct {
 	Type          MessageElementType       `json:"type"`
-	ActionID      string                   `json:"action_id"`
+	ActionID      string                   `json:"action_id,omitempty"`
 	Options       []*OptionBlockObject     `json:"options"`
 	InitialOption *OptionBlockObject       `json:"initial_option,omitempty"`
 	Confirm       *ConfirmationBlockObject `json:"confirm,omitempty"`

--- a/block_element.go
+++ b/block_element.go
@@ -381,7 +381,7 @@ func (c CheckboxGroupsBlockElement) ElementType() MessageElementType {
 	return c.Type
 }
 
-// NewRadioButtonsBlockElement returns an instance of a radio block element
+// NewCheckboxGroupsBlockElement returns an instance of a radio block element
 func NewCheckboxGroupsBlockElement(actionID string, options ...*OptionBlockObject) *CheckboxGroupsBlockElement {
 	return &CheckboxGroupsBlockElement{
 		Type:     METCheckboxGroups,


### PR DESCRIPTION
I fixed two parts.

## 1. Add missing omitempty to actionID of some elements
I noticed that there are some Block Elements whose actionID doesn't have omitempty property.

- DatePickerBlockElement
- DatePickerBlockElement
- CheckboxGroupsBlockElement
- RadioButtonsBlockElement

Like any other Block Elements, "actionID" is not required. (When we create modal's json by [BlockKit Builder](https://api.slack.com/tools/block-kit-builder?mode=modal), actionID is not attached initially.)

## 2.Add  selected_xxxxxs params to the BlockAction struct
I noticed that there aren't some Multi-Select components properties.
I added the params below to the struct `BlockAction`.

- SelectedUsers 
- SelectedChannels
- SelectedConversations

This change will resolve https://github.com/slack-go/slack/issues/713 :+1:

===

In addition, as boyscout, I fix a mistake of a comment of "NewCheckboxGroupsBlockElement".