### PR TITLE
Support for decoding "checkboxes" block element

### DIFF
--- a/block_conv.go
+++ b/block_conv.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/pkg/errors"
 )
@@ -172,10 +173,12 @@ func (b *BlockElements) UnmarshalJSON(data []byte) error {
 			blockElement = &DatePickerBlockElement{}
 		case "plain_text_input":
 			blockElement = &PlainTextInputBlockElement{}
+		case "checkboxes":
+			blockElement = &CheckboxGroupsBlockElement{}
 		case "static_select", "external_select", "users_select", "conversations_select", "channels_select":
 			blockElement = &SelectBlockElement{}
 		default:
-			return errors.New("unsupported block element type")
+			return fmt.Errorf("unsupported block element type %v", blockElementType)
 		}
 
 		err = json.Unmarshal(r, blockElement)


### PR DESCRIPTION
See the "todo app" template example in the block kit builder https://api.slack.com/tools/block-kit-builder for an example of an action block that contains a checkbox group block element.

The library allows constructing an `ActionBlock` that contains a `CheckBoxGroupBlockElement`, but didn't handle decoding when Slack responds.

Updated error if the type is unsupported to include the name of the unsupported type to make it easier to track down similar errors in the future.