### PR TITLE
Add check in OpenView to verify that BlockID is unique for InputBlock's

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -9,6 +9,7 @@ const (
 	ErrRTMGoodbye           = errorsx.String("goodbye detected")
 	ErrRTMDeadman           = errorsx.String("deadman switch triggered")
 	ErrParametersMissing    = errorsx.String("received empty parameters")
+	ErrBlockIDNotUnique     = errorsx.String("Block ID needs to be unique")
 	ErrInvalidConfiguration = errorsx.String("invalid configuration")
 	ErrMissingHeaders       = errorsx.String("missing headers")
 	ErrExpiredTimestamp     = errorsx.String("timestamp is too old")

--- a/views.go
+++ b/views.go
@@ -150,6 +150,23 @@ func (api *Client) OpenView(triggerID string, view ModalViewRequest) (*ViewRespo
 	return api.OpenViewContext(context.Background(), triggerID, view)
 }
 
+// ValidateUniqueBlockID will verify if each input block has a unique block ID if set
+func ValidateUniqueBlockID(view ModalViewRequest) bool {
+
+	uniqueBlockID := map[string]bool{}
+
+	for _, b := range view.Blocks.BlockSet {
+		if inputBlock, ok := b.(*InputBlock); ok {
+			if _, ok := uniqueBlockID[inputBlock.BlockID]; ok {
+				return false
+			}
+			uniqueBlockID[inputBlock.BlockID] = true
+		}
+	}
+
+	return true
+}
+
 // OpenViewContext opens a view for a user with a custom context.
 func (api *Client) OpenViewContext(
 	ctx context.Context,
@@ -159,6 +176,11 @@ func (api *Client) OpenViewContext(
 	if triggerID == "" {
 		return nil, ErrParametersMissing
 	}
+
+	if !ValidateUniqueBlockID(view) {
+		return nil, ErrBlockIDNotUnique
+	}
+
 	req := openViewRequest{
 		TriggerID: triggerID,
 		View:      view,

--- a/views_test.go
+++ b/views_test.go
@@ -60,8 +60,9 @@ func TestSlack_OpenView(t *testing.T) {
 			expectedErr:  ErrBlockIDNotUnique,
 		},
 		{
-			caseName:  "raise an error from Slack API",
-			triggerID: "dummy_trigger_id",
+			caseName:         "raise an error from Slack API",
+			triggerID:        "dummy_trigger_id",
+			modalViewRequest: ModalViewRequest{},
 			rawResp: `{
 				"ok": false,
 				"error": "dummy_error_from_slack",


### PR DESCRIPTION
The goal of this pull request is to validate input blocks before sending a request to be able to return a useful error message. 

I ran into this issue were I had duplicate block id's but the only error message I got back from Slack API was "invalid_arguments". The requirement that these block id's need to be unique is described in the slack documentation with the description ["unique identifier for a block"](https://api.slack.com/reference/block-kit/blocks) but I overlooked it. I thought maybe other people could run into this same issue because while block ID is optional in the slack API it is required when you use `slack.NewInputBlock("BlockID", label, element)`.

Hopefully this is an appropriate change, could it be considered a convenience method?
I made a unit test case for OpenView and ran `make pr-prep`

Thanks.