### PR TITLE
Addition of BotID to AppMentionEvent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,11 @@
 module github.com/slack-go/slack
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-test/deep v1.0.4
 	github.com/gorilla/websocket v1.2.0
 	github.com/pkg/errors v0.8.0
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
 )
 

--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -27,6 +27,9 @@ type AppMentionEvent struct {
 	// When Message comes from a channel that is shared between workspaces
 	UserTeam   string `json:"user_team,omitempty"`
 	SourceTeam string `json:"source_team,omitempty"`
+
+	// BotID is filled out when a bot triggers the app_mention event
+	BotID    string `json:"bot_id,omitempty"`
 }
 
 // AppHomeOpenedEvent Your Slack app home was opened.


### PR DESCRIPTION
If a bot triggers the `app_mention` event, a `bot_id` attribute is provided as part of the event.  This allows consumers of the event to distinguish between a user and a bot.

_Note: This seems to be undocumented in the Slack Events API; however, it is still present._