### PR TITLE
Fix potential security vuln in eventsapi example

### DIFF
--- a/examples/eventsapi/events.go
+++ b/examples/eventsapi/events.go
@@ -21,6 +21,7 @@ func main() {
 		eventsAPIEvent, e := slackevents.ParseEvent(json.RawMessage(body), slackevents.OptionVerifyToken(&slackevents.TokenComparator{VerificationToken: "TOKEN"}))
 		if e != nil {
 			w.WriteHeader(http.StatusInternalServerError)
+			return
 		}
 
 		if eventsAPIEvent.Type == slackevents.URLVerification {


### PR DESCRIPTION
Without `return` the handler will continue to process events even if `slackevents.ParseEvent` returns an error (such as an invalid verify token)
