### PR TITLE
Added missed fields for Select block element struct

### DIFF
--- a/block_element.go
+++ b/block_element.go
@@ -186,17 +186,19 @@ type OptionGroupsResponse struct {
 //
 // More Information: https://api.slack.com/reference/messaging/block-elements#select
 type SelectBlockElement struct {
-	Type                string                    `json:"type,omitempty"`
-	Placeholder         *TextBlockObject          `json:"placeholder,omitempty"`
-	ActionID            string                    `json:"action_id,omitempty"`
-	Options             []*OptionBlockObject      `json:"options,omitempty"`
-	OptionGroups        []*OptionGroupBlockObject `json:"option_groups,omitempty"`
-	InitialOption       *OptionBlockObject        `json:"initial_option,omitempty"`
-	InitialUser         string                    `json:"initial_user,omitempty"`
-	InitialConversation string                    `json:"initial_conversation,omitempty"`
-	InitialChannel      string                    `json:"initial_channel,omitempty"`
-	MinQueryLength      *int                      `json:"min_query_length,omitempty"`
-	Confirm             *ConfirmationBlockObject  `json:"confirm,omitempty"`
+	Type                         string                    `json:"type,omitempty"`
+	Placeholder                  *TextBlockObject          `json:"placeholder,omitempty"`
+	ActionID                     string                    `json:"action_id,omitempty"`
+	Options                      []*OptionBlockObject      `json:"options,omitempty"`
+	OptionGroups                 []*OptionGroupBlockObject `json:"option_groups,omitempty"`
+	InitialOption                *OptionBlockObject        `json:"initial_option,omitempty"`
+	InitialUser                  string                    `json:"initial_user,omitempty"`
+	InitialConversation          string                    `json:"initial_conversation,omitempty"`
+	InitialChannel               string                    `json:"initial_channel,omitempty"`
+	DefaultToCurrentConversation bool                      `json:"default_to_current_conversation,omitempty"`
+	ResponseURLEnabled           bool                      `json:"response_url_enabled,omitempty"`
+	MinQueryLength               *int                      `json:"min_query_length,omitempty"`
+	Confirm                      *ConfirmationBlockObject  `json:"confirm,omitempty"`
 }
 
 // ElementType returns the type of the Element


### PR DESCRIPTION
Based on official documentation SelectBlockElement struct has additional properties: `default_to_current_conversation` and `response_url_enabled` which is useful in conjunction with modals.

See for details: https://api.slack.com/reference/block-kit/block-elements#conversation_select