### PR TITLE
Add plural fields in BlockAction struct for user, channel and conversation selection

### DIFF
--- a/block.go
+++ b/block.go
@@ -32,23 +32,26 @@ type Blocks struct {
 
 // BlockAction is the action callback sent when a block is interacted with
 type BlockAction struct {
-	ActionID             string              `json:"action_id"`
-	BlockID              string              `json:"block_id"`
-	Type                 actionType          `json:"type"`
-	Text                 TextBlockObject     `json:"text"`
-	Value                string              `json:"value"`
-	ActionTs             string              `json:"action_ts"`
-	SelectedOption       OptionBlockObject   `json:"selected_option"`
-	SelectedOptions      []OptionBlockObject `json:"selected_options"`
-	SelectedUser         string              `json:"selected_user"`
-	SelectedChannel      string              `json:"selected_channel"`
-	SelectedConversation string              `json:"selected_conversation"`
-	SelectedDate         string              `json:"selected_date"`
-	InitialOption        OptionBlockObject   `json:"initial_option"`
-	InitialUser          string              `json:"initial_user"`
-	InitialChannel       string              `json:"initial_channel"`
-	InitialConversation  string              `json:"initial_conversation"`
-	InitialDate          string              `json:"initial_date"`
+	ActionID              string              `json:"action_id"`
+	BlockID               string              `json:"block_id"`
+	Type                  actionType          `json:"type"`
+	Text                  TextBlockObject     `json:"text"`
+	Value                 string              `json:"value"`
+	ActionTs              string              `json:"action_ts"`
+	SelectedOption        OptionBlockObject   `json:"selected_option"`
+	SelectedOptions       []OptionBlockObject `json:"selected_options"`
+	SelectedUser          string              `json:"selected_user"`
+	SelectedUsers         []string            `json:"selected_users"`
+	SelectedChannel       string              `json:"selected_channel"`
+	SelectedChannels      []string            `json:"selected_channels"`
+	SelectedConversation  string              `json:"selected_conversation"`
+	SelectedConversations []string            `json:"selected_conversation"`
+	SelectedDate          string              `json:"selected_date"`
+	InitialOption         OptionBlockObject   `json:"initial_option"`
+	InitialUser           string              `json:"initial_user"`
+	InitialChannel        string              `json:"initial_channel"`
+	InitialConversation   string              `json:"initial_conversation"`
+	InitialDate           string              `json:"initial_date"`
 }
 
 // actionType returns the type of the action

--- a/block.go
+++ b/block.go
@@ -45,7 +45,7 @@ type BlockAction struct {
 	SelectedChannel       string              `json:"selected_channel"`
 	SelectedChannels      []string            `json:"selected_channels"`
 	SelectedConversation  string              `json:"selected_conversation"`
-	SelectedConversations []string            `json:"selected_conversation"`
+	SelectedConversations []string            `json:"selected_conversations"`
 	SelectedDate          string              `json:"selected_date"`
 	InitialOption         OptionBlockObject   `json:"initial_option"`
 	InitialUser           string              `json:"initial_user"`


### PR DESCRIPTION
At the moment `BlockActions` doesn't support event with `selected_channels`, `selected_users` and `selected_conversations`. They are used to represent multi selection blocks and this PR implements them.

Implements #733 