### PR TITLE
Add member_left_channel event to slackevents

### DIFF
--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -111,7 +111,7 @@ type MessageEvent struct {
 	Files  []File `json:"files"`
 }
 
-// MemberJoinedChannelEvent A member join a channel
+// MemberJoinedChannelEvent A member joined a public or private channel
 type MemberJoinedChannelEvent struct {
 	Type        string `json:"type"`
 	User        string `json:"user"`
@@ -119,6 +119,15 @@ type MemberJoinedChannelEvent struct {
 	ChannelType string `json:"channel_type"`
 	Team        string `json:"team"`
 	Inviter     string `json:"inviter"`
+}
+
+// MemberLeftChannelEvent A member left a public or private channel
+type MemberLeftChannelEvent struct {
+	Type        string `json:"type"`
+	User        string `json:"user"`
+	Channel     string `json:"channel"`
+	ChannelType string `json:"channel_type"`
+	Team        string `json:"team"`
 }
 
 type pinEvent struct {
@@ -280,6 +289,8 @@ const (
 	Message = "message"
 	// Member Joined Channel
 	MemberJoinedChannel = "member_joined_channel"
+	// Member Left Channel
+	MemberLeftChannel = "member_left_channel"
 	// PinAdded An item was pinned to a channel
 	PinAdded = "pin_added"
 	// PinRemoved An item was unpinned from a channel
@@ -304,6 +315,7 @@ var EventsAPIInnerEventMapping = map[string]interface{}{
 	LinkShared:            LinkSharedEvent{},
 	Message:               MessageEvent{},
 	MemberJoinedChannel:   MemberJoinedChannelEvent{},
+	MemberLeftChannel:     MemberLeftChannelEvent{},
 	PinAdded:              PinAddedEvent{},
 	PinRemoved:            PinRemovedEvent{},
 	ReactionAdded:         ReactionAddedEvent{},

--- a/slackevents/inner_events_test.go
+++ b/slackevents/inner_events_test.go
@@ -151,6 +151,39 @@ func TestBotMessageEvent(t *testing.T) {
 	}
 }
 
+func TestMemberJoinedChannelEvent(t *testing.T) {
+	rawE := []byte(`
+			{
+				"type": "member_joined_channel",
+				"user": "W06GH7XHN",
+				"channel": "C0698JE0H",
+				"channel_type": "C",
+				"team": "T024BE7LD",
+				"inviter": "U123456789"
+		}
+	`)
+	err := json.Unmarshal(rawE, &MemberJoinedChannelEvent{})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestMemberLeftChannelEvent(t *testing.T) {
+	rawE := []byte(`
+			{
+				"type": "member_left_channel",
+				"user": "W06GH7XHN",
+				"channel": "C0698JE0H",
+				"channel_type": "C",
+				"team": "T024BE7LD"
+		}
+	`)
+	err := json.Unmarshal(rawE, &MemberLeftChannelEvent{})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func TestPinAdded(t *testing.T) {
 	rawE := []byte(`
 			{


### PR DESCRIPTION
Hey, this adds the [`member_left_channel`](https://api.slack.com/events/member_left_channel) event to slackevents (same as #286 but for the events API)

- [x] Run `make pr-prep`

e/ the one test failure seems unrelated to this PR