### PR TITLE
Add support for unmarshalling of input blocks containing checkbox blo…

### DIFF
--- a/block_conv.go
+++ b/block_conv.go
@@ -111,6 +111,8 @@ func (b *InputBlock) UnmarshalJSON(data []byte) error {
 		e = &SelectBlockElement{}
 	case "multi_static_select", "multi_external_select", "multi_users_select", "multi_conversations_select", "multi_channels_select":
 		e = &MultiSelectBlockElement{}
+	case "checkboxes":
+		e = &CheckboxGroupsBlockElement{}
 	default:
 		return errors.New("unsupported block element type")
 	}


### PR DESCRIPTION
Unmarshalling an input block containing a checkbox block element currently returns this error `unsupported block element type`. 

I have added the checkboxes case to the custom unmarshaller for input blocks so this should no longer happen. 