### PR TITLE
Add ID to Msg

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -22,6 +22,7 @@ type Message struct {
 // Msg contains information about a slack message
 type Msg struct {
 	// Basic Message
+	ID              int          `json:"id,omitempty"`
 	ClientMsgID     string       `json:"client_msg_id,omitempty"`
 	Type            string       `json:"type,omitempty"`
 	Channel         string       `json:"channel,omitempty"`


### PR DESCRIPTION
On documentation method [chat.scheduledMessages.list](https://api.slack.com/methods/chat.scheduledMessages.list) return messages with ID.
ID is needed for delete scheduled message.