### PR TITLE
basic conversations.info endpoint for slacktest

### DIFF
--- a/slacktest/server.go
+++ b/slacktest/server.go
@@ -45,6 +45,7 @@ func NewTestServer(custom ...binder) *Server {
 		c(s)
 	}
 
+	s.Handle("/conversations.info", s.conversationsInfoHandler)
 	s.Handle("/ws", s.wsHandler)
 	s.Handle("/rtm.start", rtmStartHandler)
 	s.Handle("/rtm.connect", RTMConnectHandler)


### PR DESCRIPTION
Added a basic endpoint to slacktest for `conversations.info`.

It only returns an ID and Name. Name is a cropped version of the channel ID, removing the `C` prefix.