### PR TITLE
Add client_msg_id to MessageEvent

### DIFF
--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -84,6 +84,7 @@ type sharedLinks struct {
 // TODO: Improve this so that it is not required to manually parse ChannelType
 type MessageEvent struct {
 	// Basic Message Event - https://api.slack.com/events/message
+	ClientMsgID     string      `json:"client_msg_id"`
 	Type            string      `json:"type"`
 	User            string      `json:"user"`
 	Text            string      `json:"text"`

--- a/slackevents/inner_events_test.go
+++ b/slackevents/inner_events_test.go
@@ -106,6 +106,7 @@ func TestLinkSharedEvent(t *testing.T) {
 func TestMessageEvent(t *testing.T) {
 	rawE := []byte(`
 			{
+				"client_msg_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
 				"type": "message",
 				"channel": "G024BE91L",
 				"user": "U2147483697",


### PR DESCRIPTION
A message event has a `client_msg_id` attribute to identify the message. The RTM `Msg` already contains it. I've added it to the EventsAPI `MessageEvent`. 