### PR TITLE
Update examples/eventsapi to avoid TOKEN confusion

### DIFF
--- a/examples/eventsapi/events.go
+++ b/examples/eventsapi/events.go
@@ -18,7 +18,7 @@ func main() {
 		buf := new(bytes.Buffer)
 		buf.ReadFrom(r.Body)
 		body := buf.String()
-		eventsAPIEvent, e := slackevents.ParseEvent(json.RawMessage(body), slackevents.OptionVerifyToken(&slackevents.TokenComparator{VerificationToken: "TOKEN"}))
+		eventsAPIEvent, e := slackevents.ParseEvent(json.RawMessage(body), slackevents.OptionVerifyToken(&slackevents.TokenComparator{VerificationToken: "VERIFICATION_TOKEN"}))
 		if e != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return


### PR DESCRIPTION
Related to #705 and https://github.com/go-joe/slack-adapter/issues/16