### PR TITLE
charset_missing

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -238,7 +238,7 @@ func postJSON(ctx context.Context, client httpClient, endpoint, token string, js
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 
 	return doPost(ctx, client, req, newJSONParser(intf), d)


### PR DESCRIPTION
Create a checkbox as input element as follows:
```
envTxt := slack.NewTextBlockObject("plain_text", "Environment", false, false)
allProdText := slack.NewTextBlockObject("plain_text", "All", false, false)
prodText := slack.NewTextBlockObject("plain_text", "Prod", false, false)
stageText := slack.NewTextBlockObject("plain_text", "Stage", false, false)
allProdOpt := slack.NewOptionBlockObject("All", allProdText)
prodOpt := slack.NewOptionBlockObject("Prod", prodText)
stageOpt := slack.NewOptionBlockObject("Stage", stageText)
envOption := slack.NewCheckboxGroupsBlockElement("", allProdOpt, prodOpt, stageOpt)
envBlock := slack.NewInputBlock("env_affected", envTxt, envOption)
```

Using this to construct a modal and opening the modal view request with OpenViewContext results in an error `unsupported block element type`. The view displays for the user however. On closer inspection, the response contains a warning `missing_charset`.

Closes https://github.com/slack-go/slack/issues/743

Tested locally, no error or response warning after change.