### PR TITLE
Add ScheduledMessage type

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -722,12 +722,12 @@ type GetScheduledMessagesParameters struct {
 }
 
 // GetScheduledMessages returns the list of scheduled messages based on params
-func (api *Client) GetScheduledMessages(params *GetScheduledMessagesParameters) (channels []Message, nextCursor string, err error) {
+func (api *Client) GetScheduledMessages(params *GetScheduledMessagesParameters) (channels []ScheduledMessage, nextCursor string, err error) {
 	return api.GetScheduledMessagesContext(context.Background(), params)
 }
 
 // GetScheduledMessagesContext returns the list of scheduled messages in a Slack team with a custom context
-func (api *Client) GetScheduledMessagesContext(ctx context.Context, params *GetScheduledMessagesParameters) (channels []Message, nextCursor string, err error) {
+func (api *Client) GetScheduledMessagesContext(ctx context.Context, params *GetScheduledMessagesParameters) (channels []ScheduledMessage, nextCursor string, err error) {
 	values := url.Values{
 		"token": {api.token},
 	}
@@ -747,8 +747,8 @@ func (api *Client) GetScheduledMessagesContext(ctx context.Context, params *GetS
 		values.Add("oldest", params.Oldest)
 	}
 	response := struct {
-		Messages         []Message        `json:"scheduled_messages"`
-		ResponseMetaData responseMetaData `json:"response_metadata"`
+		Messages         []ScheduledMessage `json:"scheduled_messages"`
+		ResponseMetaData responseMetaData   `json:"response_metadata"`
 		SlackResponse
 	}{}
 

--- a/messages.go
+++ b/messages.go
@@ -106,6 +106,15 @@ const (
 	ResponseTypeEphemeral = "ephemeral"
 )
 
+// ScheduledMessage contains information about a slack scheduled message
+type ScheduledMessage struct {
+	ID          string `json:"id"`
+	Channel     string `json:"channel_id"`
+	PostAt      int    `json:"post_at"`
+	DateCreated int    `json:"date_created"`
+	Text        string `json:"text"`
+}
+
 // Icon is used for bot messages
 type Icon struct {
 	IconURL   string `json:"icon_url,omitempty"`


### PR DESCRIPTION
Added ScheduledMessage to make fully compatible with slack `scheduledMessages.list` including `date_created`

The pull request also include updates for `GetScheduledMessages` and `GetScheduledMessagesContext` in order to use this ScheduledMessage type.
