### PR TITLE
More complete example of modal interactions

### DIFF
--- a/examples/modal/modal.go
+++ b/examples/modal/modal.go
@@ -1,14 +1,27 @@
+// Modal example - How to respond to a slash command with an interactive modal and parse the response
+// The flow of this example:
+// 1. User trigers your app with a slash command (e.g. /modaltest) that will send a request to http://URL/slash and respond with a request to open a modal
+// 2. User fills out fields first and last name in modal and hits submit
+// 3. This will send a request to http://URL/modal and send a greeting message to the user
+
+// Note: Within your slack app you will need to enable and provide a URL for "Interactivity & Shortcuts" and "Slash Commands"
+// Note: Be sure to update YOUR_SIGNING_SECRET_HERE and YOUR_TOKEN_HERE
+// You can use ngrok to test this example: https://api.slack.com/tutorials/tunneling-with-ngrok
+// Helpful slack documentation to learn more: https://api.slack.com/interactivity/handling
+
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 
 	"github.com/slack-go/slack"
 )
 
-// A minimal example showing how to open a modal
-func main() {
-
+func generateModalRequest() slack.ModalViewRequest {
 	// Create a ModalViewRequest with a header and two inputs
 	titleText := slack.NewTextBlockObject("plain_text", "My App", false, false)
 	closeText := slack.NewTextBlockObject("plain_text", "Close", false, false)
@@ -25,7 +38,7 @@ func main() {
 
 	lastNameText := slack.NewTextBlockObject("plain_text", "Last Name", false, false)
 	lastNamePlaceholder := slack.NewTextBlockObject("plain_text", "Enter your first name", false, false)
-	lastNameElement := slack.NewPlainTextInputBlockElement(lastNamePlaceholder, "firstName")
+	lastNameElement := slack.NewPlainTextInputBlockElement(lastNamePlaceholder, "lastName")
 	lastName := slack.NewInputBlock("Last Name", lastNameText, lastNameElement)
 
 	blocks := slack.Blocks{
@@ -42,14 +55,102 @@ func main() {
 	modalRequest.Close = closeText
 	modalRequest.Submit = submitText
 	modalRequest.Blocks = blocks
+	return modalRequest
+}
 
-	api := slack.New("YOUR_BOT_TOKEN_HERE")
-
-	// Using a trigger ID you can open a modal
-	// The trigger ID is provided through certain events and interactions
-	// More information can be found here: https://api.slack.com/interactivity/handling#modal_responses
-	_, err := api.OpenView("YOUR_TRIGGERID_HERE", modalRequest)
+// This was taken from the slash example
+// https://github.com/slack-go/slack/blob/master/examples/slash/slash.go
+func verifySigningSecret(r *http.Request) error {
+	signingSecret := "YOUR_SIGNING_SECRET_HERE"
+	verifier, err := slack.NewSecretsVerifier(r.Header, signingSecret)
 	if err != nil {
-		fmt.Printf("Error opening view: %s", err)
+		fmt.Println(err.Error())
+		return err
 	}
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		fmt.Println(err.Error())
+		return err
+	}
+	// Need to use r.Body again when unmarshalling SlashCommand and InteractionCallback
+	r.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+
+	verifier.Write(body)
+	if err = verifier.Ensure(); err != nil {
+		fmt.Println(err.Error())
+		return err
+	}
+
+	return nil
+}
+
+func handleSlash(w http.ResponseWriter, r *http.Request) {
+
+	err := verifySigningSecret(r)
+	if err != nil {
+		fmt.Printf(err.Error())
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	s, err := slack.SlashCommandParse(r)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Println(err.Error())
+		return
+	}
+
+	switch s.Command {
+	case "/humboldttest":
+		api := slack.New("YOUR_TOKEN_HERE")
+		modalRequest := generateModalRequest()
+		_, err = api.OpenView(s.TriggerID, modalRequest)
+		if err != nil {
+			fmt.Printf("Error opening view: %s", err)
+		}
+	default:
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+}
+
+func handleModal(w http.ResponseWriter, r *http.Request) {
+
+	err := verifySigningSecret(r)
+	if err != nil {
+		fmt.Printf(err.Error())
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	var i slack.InteractionCallback
+	err = json.Unmarshal([]byte(r.FormValue("payload")), &i)
+	if err != nil {
+		fmt.Printf(err.Error())
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	// Note there might be a better way to get this info, but I figured this structure out from looking at the json response
+	firstName := i.View.State.Values["First Name"]["firstName"].Value
+	lastName := i.View.State.Values["Last Name"]["lastName"].Value
+
+	msg := fmt.Sprintf("Hello %s %s, nice to meet you!", firstName, lastName)
+
+	api := slack.New("YOUR_TOKEN_HERE")
+	_, _, err = api.PostMessage(i.User.ID,
+		slack.MsgOptionText(msg, false),
+		slack.MsgOptionAttachments())
+	if err != nil {
+		fmt.Printf(err.Error())
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+}
+
+func main() {
+	http.HandleFunc("/slash", handleSlash)
+	http.HandleFunc("/modal", handleModal)
+	http.ListenAndServe(":4390", nil)
 }


### PR DESCRIPTION
In response to issue #751, I expanded on the original example to show a more complete modal interaction flow.

I used [ngrok ](https://api.slack.com/tutorials/tunneling-with-ngrok) to test this locally and was able to trigger a slash command, receive a modal and then submit my response and receive a nice greeting in private message (had to have im:write and chat:write permissions for my slack app).
