### PR TITLE
[Feat] conversations.mark

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -635,9 +635,7 @@ func (api *Client) MarkConversationContext(ctx context.Context, channel, ts stri
 		"ts":      {ts},
 	}
 
-	response := struct {
-		SlackResponse
-	}{}
+	response := &SlackResponse{}
 
 	err := api.postMethod(ctx, "conversations.mark", values, response)
 	if err != nil {

--- a/conversation.go
+++ b/conversation.go
@@ -621,3 +621,27 @@ func (api *Client) GetConversationHistoryContext(ctx context.Context, params *Ge
 
 	return &response, response.Err()
 }
+
+// MarkConversation sets the read mark of a conversation to a specific point
+func (api *Client) MarkConversation(channel, ts string) (err error) {
+	return api.MarkConversationContext(context.Background(), channel, ts)
+}
+
+// MarkConversationContext sets the read mark of a conversation to a specific point with a custom context
+func (api *Client) MarkConversationContext(ctx context.Context, channel, ts string) error {
+	values := url.Values{
+		"token":   {api.token},
+		"channel": {channel},
+		"ts":      {ts},
+	}
+
+	response := struct {
+		SlackResponse
+	}{}
+
+	err := api.postMethod(ctx, "conversations.mark", values, response)
+	if err != nil {
+		return err
+	}
+	return response.Err()
+}

--- a/conversation_test.go
+++ b/conversation_test.go
@@ -555,3 +555,13 @@ func TestGetConversationHistory(t *testing.T) {
 		return
 	}
 }
+
+func TestMarkConversation(t *testing.T) {
+	once.Do(startServer)
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
+	err := api.MarkConversation("CXXXXXXXX", "1401383885.000061")
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/QuanteriumTech/slack
+module github.com/slack-go/slack
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/slack-go/slack
+module github.com/QuanteriumTech/slack
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect


### PR DESCRIPTION
Slack has added a conversations.mark endpoint which will replace the existing im, mpim, channel and group mark endpoints.

This PR implements the new endpoint.