### PR TITLE
Allow Fields and Accessory to be optional

### DIFF
--- a/block_section.go
+++ b/block_section.go
@@ -25,7 +25,7 @@ func SectionBlockOptionBlockID(blockID string) SectionBlockOption {
 	}
 }
 
-func SectionBlockOptionAccesory(accessory *Accessory) SectionBlockOption {
+func SectionBlockOptionAccessory(accessory *Accessory) SectionBlockOption {
 	return func(block *SectionBlock) {
 		block.Accessory = accessory
 	}
@@ -40,8 +40,8 @@ func SectionBlockOptionFields(fields []*TextBlockObject) SectionBlockOption {
 // NewSectionBlock returns a new instance of a section block to be rendered
 func NewSectionBlock(textObj *TextBlockObject, options ...SectionBlockOption) *SectionBlock {
 	block := SectionBlock{
-		Type:      MBTSection,
-		Text:      textObj,
+		Type: MBTSection,
+		Text: textObj,
 	}
 
 	for _, option := range options {

--- a/block_section.go
+++ b/block_section.go
@@ -27,7 +27,7 @@ func SectionBlockOptionBlockID(blockID string) SectionBlockOption {
 
 func SectionBlockOptionAccesory(accessory *Accessory) SectionBlockOption {
 	return func(block *SectionBlock) {
-		block.Accessory = aceessory
+		block.Accessory = accessory
 	}
 }
 

--- a/block_section.go
+++ b/block_section.go
@@ -25,13 +25,23 @@ func SectionBlockOptionBlockID(blockID string) SectionBlockOption {
 	}
 }
 
+func SectionBlockOptionAccesory(accessory *Accessory) SectionBlockOption {
+	return func(block *SectionBlock) {
+		block.Accessory = aceessory
+	}
+}
+
+func SectionBlockOptionFields(fields []*TextBlockObject) SectionBlockOption {
+	return func(block *SectionBlock) {
+		block.Fields = fields
+	}
+}
+
 // NewSectionBlock returns a new instance of a section block to be rendered
-func NewSectionBlock(textObj *TextBlockObject, fields []*TextBlockObject, accessory *Accessory, options ...SectionBlockOption) *SectionBlock {
+func NewSectionBlock(textObj *TextBlockObject, options ...SectionBlockOption) *SectionBlock {
 	block := SectionBlock{
 		Type:      MBTSection,
 		Text:      textObj,
-		Fields:    fields,
-		Accessory: accessory,
 	}
 
 	for _, option := range options {

--- a/block_section_test.go
+++ b/block_section_test.go
@@ -10,7 +10,7 @@ func TestNewSectionBlock(t *testing.T) {
 
 	textInfo := NewTextBlockObject("mrkdwn", "*<fakeLink.toHotelPage.com|The Ritz-Carlton New Orleans>*\n★★★★★\n$340 per night\nRated: 9.1 - Excellent", false, false)
 
-	sectionBlock := NewSectionBlock(textInfo, nil, nil, SectionBlockOptionBlockID("test_block"))
+	sectionBlock := NewSectionBlock(textInfo, SectionBlockOptionBlockID("test_block"))
 	assert.Equal(t, string(sectionBlock.Type), "section")
 	assert.Equal(t, string(sectionBlock.BlockID), "test_block")
 	assert.Equal(t, len(sectionBlock.Fields), 0)
@@ -23,7 +23,7 @@ func TestNewSectionBlock(t *testing.T) {
 func TestNewBlockSectionContainsAddedTextBlockAndAccessory(t *testing.T) {
 	textBlockObject := NewTextBlockObject("mrkdwn", "You have a new test: *Hi there* :wave:", true, false)
 	conflictImage := NewImageBlockElement("https://api.slack.com/img/blocks/bkb_template_images/notificationsWarningIcon.png", "notifications warning icon")
-	sectionBlock := NewSectionBlock(textBlockObject, nil, NewAccessory(conflictImage))
+	sectionBlock := NewSectionBlock(textBlockObject, SectionBlockOptionAccessory(NewAccessory(conflictImage)))
 
 	assert.Equal(t, sectionBlock.BlockType(), MBTSection)
 	assert.Equal(t, len(sectionBlock.BlockID), 0)

--- a/interactions_test.go
+++ b/interactions_test.go
@@ -180,13 +180,12 @@ func TestViewClosedck(t *testing.T) {
 				BlockSet: []Block{
 					NewSectionBlock(
 						NewTextBlockObject("mrkdwn", "*Sally* has requested you set the deadline for the Nano launch project", false, false),
-						nil,
-						NewAccessory(&DatePickerBlockElement{
+						SectionBlockOptionAccessory(NewAccessory(&DatePickerBlockElement{
 							Type:        METDatepicker,
 							ActionID:    "datepicker123",
 							InitialDate: "1990-04-28",
 							Placeholder: NewTextBlockObject("plain_text", "Select a date", false, false),
-						}),
+						})),
 					),
 				},
 			},


### PR DESCRIPTION
According to the official Slack API documentation, Section blocks do not require fields and accessory argument to be required. 

The current implementation requires the user to specify both these fields if he/she wants to use the NewSectionBlock method.

In keeping with the spirit of the official implementation, I have made it such that these 2 arguments are now optional.

##### Pull Request Guidelines

These are recommendations for pull requests.
They are strictly guidelines to help manage expectations.

##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead
- [X] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### Examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.
