### PR TITLE
Add support for blocks to slacktest package

### DIFF
--- a/slacktest/handlers.go
+++ b/slacktest/handlers.go
@@ -100,6 +100,25 @@ func (sts *Server) postMessageHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		m.Attachments = attaches
 	}
+	blocks := values.Get("blocks")
+	if blocks != "" {
+		decoded, err := url.QueryUnescape(blocks)
+		if err != nil {
+			msg := fmt.Sprintf("Unable to decode blocks: %s", err.Error())
+			log.Printf(msg)
+			http.Error(w, msg, http.StatusInternalServerError)
+			return
+		}
+		var decodedBlocks slack.Blocks
+		dbJErr := json.Unmarshal([]byte(decoded), &decodedBlocks)
+		if dbJErr != nil {
+			msg := fmt.Sprintf("Unable to decode blocks string to json: %s", dbJErr.Error())
+			log.Printf(msg)
+			http.Error(w, msg, http.StatusInternalServerError)
+			return
+		}
+		m.Blocks = decodedBlocks
+	}
 	jsonMessage, jsonErr := json.Marshal(m)
 	if jsonErr != nil {
 		msg := fmt.Sprintf("Unable to marshal message: %s", jsonErr.Error())


### PR DESCRIPTION
This PR adds support for blocks when using the `slacktest` package. We're currently using it to run integration tests for our Slackbot, but the tests fail because the mock server does not support deserializing blocks. This PR adds support for that, in the same way it does for attachments.