### PR TITLE
Add Header block

### DIFF
--- a/block.go
+++ b/block.go
@@ -16,6 +16,7 @@ const (
 	MBTContext MessageBlockType = "context"
 	MBTFile    MessageBlockType = "file"
 	MBTInput   MessageBlockType = "input"
+	MBTHeader  MessageBlockType = "header"
 )
 
 // Block defines an interface all block types should implement

--- a/block_header.go
+++ b/block_header.go
@@ -1,0 +1,38 @@
+package slack
+
+// HeaderBlock defines a new block of type header
+//
+// More Information: https://api.slack.com/reference/messaging/blocks#header
+type HeaderBlock struct {
+	Type    MessageBlockType `json:"type"`
+	Text    *TextBlockObject `json:"text,omitempty"`
+	BlockID string           `json:"block_id,omitempty"`
+}
+
+// BlockType returns the type of the block
+func (s HeaderBlock) BlockType() MessageBlockType {
+	return s.Type
+}
+
+// HeaderBlockOption allows configuration of options for a new header block
+type HeaderBlockOption func(*HeaderBlock)
+
+func HeaderBlockOptionBlockID(blockID string) HeaderBlockOption {
+	return func(block *HeaderBlock) {
+		block.BlockID = blockID
+	}
+}
+
+// NewHeaderBlock returns a new instance of a header block to be rendered
+func NewHeaderBlock(textObj *TextBlockObject, options ...HeaderBlockOption) *HeaderBlock {
+	block := HeaderBlock{
+		Type: MBTHeader,
+		Text: textObj,
+	}
+
+	for _, option := range options {
+		option(&block)
+	}
+
+	return &block
+}

--- a/block_header_test.go
+++ b/block_header_test.go
@@ -1,0 +1,18 @@
+package slack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewHeaderBlock(t *testing.T) {
+
+	textInfo := NewTextBlockObject("plain_text", "This is quite the header", false, false)
+
+	headerBlock := NewHeaderBlock(textInfo, HeaderBlockOptionBlockID("test_block"))
+	assert.Equal(t, string(headerBlock.Type), "header")
+	assert.Equal(t, string(headerBlock.BlockID), "test_block")
+	assert.Equal(t, headerBlock.Text.Type, "plain_text")
+	assert.Contains(t, headerBlock.Text.Text, "quite the header")
+}


### PR DESCRIPTION
This PR adds Slack's shiny new Header block! (https://api.slack.com/reference/messaging/blocks#header)