### PR TITLE
Allow EMPTY Text fields on attachments (required field)

### DIFF
--- a/attachements_test.go
+++ b/attachements_test.go
@@ -12,6 +12,7 @@ func TestAttachment_UnmarshalMarshalJSON_WithBlocks(t *testing.T) {
 
 	originalAttachmentJson := `{
     "id": 1,
+    "text":"",
     "blocks": [
       {
         "type": "section",

--- a/attachments.go
+++ b/attachments.go
@@ -75,7 +75,7 @@ type Attachment struct {
 	Title     string `json:"title,omitempty"`
 	TitleLink string `json:"title_link,omitempty"`
 	Pretext   string `json:"pretext,omitempty"`
-	Text      string `json:"text,omitempty"`
+	Text      string `json:"text"` // Required
 
 	ImageURL string `json:"image_url,omitempty"`
 	ThumbURL string `json:"thumb_url,omitempty"`

--- a/chat_test.go
+++ b/chat_test.go
@@ -101,7 +101,7 @@ func TestPostMessage(t *testing.T) {
 					}),
 			},
 			expected: url.Values{
-				"attachments": []string{`[{"blocks":` + blockStr + `}]`},
+				"attachments": []string{`[{"text":"","blocks":` + blockStr + `}]`},
 				"channel":     []string{"CXXX"},
 				"token":       []string{"testing-token"},
 			},


### PR DESCRIPTION
This patch makes `text` a required field on attachments. We have code that creates a button as an attachment with empty text field. The regression caused the `text` json attribute to be removed when empty, which breaks the slack API.

This change moves it back to required, so even if empty, a field is still sent: `"text":""`


##### Pull Request Guidelines

These are recommendations for pull requests.
They are strictly guidelines to help manage expectations.

##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead
Maybe? It was definitely a regression from 0.6.0. Without this change, you cannot post a button attachment w/o having some text included.

##### API changes

- fixed existing tests
