### PR TITLE
Add explanation how the message could be sent in a proper way

### DIFF
--- a/examples/messages/messages.go
+++ b/examples/messages/messages.go
@@ -22,7 +22,12 @@ func main() {
 		*/
 	}
 
-	channelID, timestamp, err := api.PostMessage("CHANNEL_ID", slack.MsgOptionText("Some text", false), slack.MsgOptionAttachments(attachment))
+	channelID, timestamp, err := api.PostMessage(
+		"CHANNEL_ID",
+		slack.MsgOptionText("Some text", false),
+		slack.MsgOptionAttachments(attachment),
+		slack.MsgOptionAsUser(true), // Add this if you want that the bot would post message as a user, otherwise it will send response using the default slackbot
+	)
 	if err != nil {
 		fmt.Printf("%s\n", err)
 		return


### PR DESCRIPTION
### What does this PR do?
- [x] It adds a concise way of how a bot would post a message to the user as a user, not as a default slackbot `(examples/messages/messages.go)`

- [x] It fixes [#785 ](https://github.com/slack-go/slack/issues/785)