### PR TITLE
Resolve: Revert changes to json tags in Attachment's Text field

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -75,7 +75,8 @@ type Attachment struct {
 	Title     string `json:"title,omitempty"`
 	TitleLink string `json:"title_link,omitempty"`
 	Pretext   string `json:"pretext,omitempty"`
-	Text      string `json:"text"` // Required
+	Text      string `json:"text,omitempty"` // Required
+
 
 	ImageURL string `json:"image_url,omitempty"`
 	ThumbURL string `json:"thumb_url,omitempty"`

--- a/attachments.go
+++ b/attachments.go
@@ -75,8 +75,7 @@ type Attachment struct {
 	Title     string `json:"title,omitempty"`
 	TitleLink string `json:"title_link,omitempty"`
 	Pretext   string `json:"pretext,omitempty"`
-	Text      string `json:"text,omitempty"` // Required
-
+	Text      string `json:"text,omitempty"`
 
 	ImageURL string `json:"image_url,omitempty"`
 	ThumbURL string `json:"thumb_url,omitempty"`

--- a/attachments_test.go
+++ b/attachments_test.go
@@ -12,7 +12,6 @@ func TestAttachment_UnmarshalMarshalJSON_WithBlocks(t *testing.T) {
 
 	originalAttachmentJson := `{
     "id": 1,
-    "text":"",
     "blocks": [
       {
         "type": "section",

--- a/chat_test.go
+++ b/chat_test.go
@@ -101,7 +101,7 @@ func TestPostMessage(t *testing.T) {
 					}),
 			},
 			expected: url.Values{
-				"attachments": []string{`[{"text":"","blocks":` + blockStr + `}]`},
+				"attachments": []string{`[{"blocks":` + blockStr + `}]`},
 				"channel":     []string{"CXXX"},
 				"token":       []string{"testing-token"},
 			},


### PR DESCRIPTION
Resolve: Revert changes to json tags in Attachment's Text field. #784 

Documentation of API says that `text` field is required in `Attachment`, but when you want to send it with `blocks` field as well, it returns `invalid_attachment` error. This is because `blocks` cannot be sent along with `text` (even with empty `"text":""`)