### PR TITLE
Added omitempty tag for attachment text field

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -75,7 +75,7 @@ type Attachment struct {
 	Title     string `json:"title,omitempty"`
 	TitleLink string `json:"title_link,omitempty"`
 	Pretext   string `json:"pretext,omitempty"`
-	Text      string `json:"text"` // Required
+	Text      string `json:"text,omitempty"`
 
 	ImageURL string `json:"image_url,omitempty"`
 	ThumbURL string `json:"thumb_url,omitempty"`


### PR DESCRIPTION
Based on official documentation (https://api.slack.com/reference/messaging/attachments#legacy_fields):

> All of these fields are optional if you're including blocks as above. If you aren't, one of either fallback or text are required

It means the Text field of Attachment struct cannot be required. The current implementation leads to 500 responses from Slack API when you are sending Attachment without Text but with Blocks field.

