### PR TITLE
Add Root field to MessageEvent to support thread_broadcast subtype

### DIFF
--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -115,6 +115,11 @@ type MessageEvent struct {
 	Files  []File `json:"files"`
 
 	Attachments []slack.Attachment `json:"attachments,omitempty"`
+
+	// Root is the message that was broadcast to the channel when the SubType is
+	// thread_broadcast. If this is not a thread_broadcast message event, this
+	// value is nil.
+	Root *MessageEvent `json:"root"`
 }
 
 // MemberJoinedChannelEvent A member joined a public or private channel

--- a/slackevents/inner_events_test.go
+++ b/slackevents/inner_events_test.go
@@ -152,6 +152,54 @@ func TestBotMessageEvent(t *testing.T) {
 	}
 }
 
+func TestThreadBroadcastEvent(t *testing.T) {
+	rawE := []byte(`
+			{
+				"type": "message",
+				"subtype": "thread_broadcast",
+				"channel": "G024BE91L",
+				"user": "U2147483697",
+				"text": "Live long and prospect.",
+				"ts": "1355517523.000005",
+				"event_ts": "1355517523.000005",
+				"channel_type": "channel",
+				"source_team": "T3MQV36V7",
+				"user_team": "T3MQV36V7",
+				"message": {
+					"text": "To infinity and beyond.",
+					"root": {
+						"text": "To infinity and beyond.",
+						"ts": "1355517523.000005"
+					},
+					"edited": {
+						"user": "U2147483697",
+						"ts": "1355517524.000000"
+					}
+				},
+				"previous_message": {
+					"text": "Live long and prospect."
+				}
+		}
+	`)
+
+	var me MessageEvent
+	if err := json.Unmarshal(rawE, &me); err != nil {
+		t.Error(err)
+	}
+
+	if me.Root != nil {
+		t.Error("me.Root should be nil")
+	}
+
+	if me.Message.Root == nil {
+		t.Fatal("me.Message.Root is nil")
+	}
+
+	if me.Message.Root.TimeStamp != "1355517523.000005" {
+		t.Errorf("me.Message.Root.TimeStamp = %q, want %q", me.Root.TimeStamp, "1355517523.000005")
+	}
+}
+
 func TestMemberJoinedChannelEvent(t *testing.T) {
 	rawE := []byte(`
 			{


### PR DESCRIPTION
The `thread_broadcast` subtype includes extra data in the MessageEvent that
we're currently losing, the `root` field. This is where it puts the message that
is being shared to a channel as a reply to a thread.

Fixes #792

