### PR TITLE
Include GetOAuth* methods in Client's method set

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -66,13 +66,13 @@ type OAuthV2ResponseAuthedUser struct {
 }
 
 // GetOAuthToken retrieves an AccessToken
-func GetOAuthToken(client httpClient, clientID, clientSecret, code, redirectURI string) (accessToken string, scope string, err error) {
-	return GetOAuthTokenContext(context.Background(), client, clientID, clientSecret, code, redirectURI)
+func (api *Client) GetOAuthToken(clientID, clientSecret, code, redirectURI string) (accessToken string, scope string, err error) {
+	return api.GetOAuthTokenContext(context.Background(), clientID, clientSecret, code, redirectURI)
 }
 
 // GetOAuthTokenContext retrieves an AccessToken with a custom context
-func GetOAuthTokenContext(ctx context.Context, client httpClient, clientID, clientSecret, code, redirectURI string) (accessToken string, scope string, err error) {
-	response, err := GetOAuthResponseContext(ctx, client, clientID, clientSecret, code, redirectURI)
+func (api *Client) GetOAuthTokenContext(ctx context.Context, clientID, clientSecret, code, redirectURI string) (accessToken string, scope string, err error) {
+	response, err := api.GetOAuthResponseContext(ctx, clientID, clientSecret, code, redirectURI)
 	if err != nil {
 		return "", "", err
 	}
@@ -80,13 +80,13 @@ func GetOAuthTokenContext(ctx context.Context, client httpClient, clientID, clie
 }
 
 // GetBotOAuthToken retrieves top-level and bot AccessToken - https://api.slack.com/legacy/oauth#bot_user_access_tokens
-func GetBotOAuthToken(client httpClient, clientID, clientSecret, code, redirectURI string) (accessToken string, scope string, bot OAuthResponseBot, err error) {
-	return GetBotOAuthTokenContext(context.Background(), client, clientID, clientSecret, code, redirectURI)
+func (api *Client) GetBotOAuthToken(clientID, clientSecret, code, redirectURI string) (accessToken string, scope string, bot OAuthResponseBot, err error) {
+	return api.GetBotOAuthTokenContext(context.Background(), clientID, clientSecret, code, redirectURI)
 }
 
 // GetBotOAuthTokenContext retrieves top-level and bot AccessToken with a custom context
-func GetBotOAuthTokenContext(ctx context.Context, client httpClient, clientID, clientSecret, code, redirectURI string) (accessToken string, scope string, bot OAuthResponseBot, err error) {
-	response, err := GetOAuthResponseContext(ctx, client, clientID, clientSecret, code, redirectURI)
+func (api *Client) GetBotOAuthTokenContext(ctx context.Context, clientID, clientSecret, code, redirectURI string) (accessToken string, scope string, bot OAuthResponseBot, err error) {
+	response, err := api.GetOAuthResponseContext(ctx, clientID, clientSecret, code, redirectURI)
 	if err != nil {
 		return "", "", OAuthResponseBot{}, err
 	}
@@ -94,12 +94,12 @@ func GetBotOAuthTokenContext(ctx context.Context, client httpClient, clientID, c
 }
 
 // GetOAuthResponse retrieves OAuth response
-func GetOAuthResponse(client httpClient, clientID, clientSecret, code, redirectURI string) (resp *OAuthResponse, err error) {
-	return GetOAuthResponseContext(context.Background(), client, clientID, clientSecret, code, redirectURI)
+func (api *Client) GetOAuthResponse(clientID, clientSecret, code, redirectURI string) (resp *OAuthResponse, err error) {
+	return api.GetOAuthResponseContext(context.Background(), clientID, clientSecret, code, redirectURI)
 }
 
 // GetOAuthResponseContext retrieves OAuth response with custom context
-func GetOAuthResponseContext(ctx context.Context, client httpClient, clientID, clientSecret, code, redirectURI string) (resp *OAuthResponse, err error) {
+func (api *Client) GetOAuthResponseContext(ctx context.Context, clientID, clientSecret, code, redirectURI string) (resp *OAuthResponse, err error) {
 	values := url.Values{
 		"client_id":     {clientID},
 		"client_secret": {clientSecret},
@@ -107,19 +107,19 @@ func GetOAuthResponseContext(ctx context.Context, client httpClient, clientID, c
 		"redirect_uri":  {redirectURI},
 	}
 	response := &OAuthResponse{}
-	if err = postForm(ctx, client, APIURL+"oauth.access", values, response, discard{}); err != nil {
+	if err = api.postMethod(ctx, "oauth.access", values, response); err != nil {
 		return nil, err
 	}
 	return response, response.Err()
 }
 
 // GetOAuthV2Response gets a V2 OAuth access token response - https://api.slack.com/methods/oauth.v2.access
-func GetOAuthV2Response(client httpClient, clientID, clientSecret, code, redirectURI string) (resp *OAuthV2Response, err error) {
-	return GetOAuthV2ResponseContext(context.Background(), client, clientID, clientSecret, code, redirectURI)
+func (api *Client) GetOAuthV2Response(clientID, clientSecret, code, redirectURI string) (resp *OAuthV2Response, err error) {
+	return api.GetOAuthV2ResponseContext(context.Background(), clientID, clientSecret, code, redirectURI)
 }
 
 // GetOAuthV2ResponseContext with a context, gets a V2 OAuth access token response
-func GetOAuthV2ResponseContext(ctx context.Context, client httpClient, clientID, clientSecret, code, redirectURI string) (resp *OAuthV2Response, err error) {
+func (api *Client) GetOAuthV2ResponseContext(ctx context.Context, clientID, clientSecret, code, redirectURI string) (resp *OAuthV2Response, err error) {
 	values := url.Values{
 		"client_id":     {clientID},
 		"client_secret": {clientSecret},
@@ -127,7 +127,7 @@ func GetOAuthV2ResponseContext(ctx context.Context, client httpClient, clientID,
 		"redirect_uri":  {redirectURI},
 	}
 	response := &OAuthV2Response{}
-	if err = postForm(ctx, client, APIURL+"oauth.v2.access", values, response, discard{}); err != nil {
+	if err = api.postMethod(ctx, "oauth.v2.access", values, response); err != nil {
 		return nil, err
 	}
 	return response, response.Err()

--- a/slack.go
+++ b/slack.go
@@ -43,7 +43,7 @@ type AuthTestResponse struct {
 	UserID string `json:"user_id"`
 	// EnterpriseID is only returned when an enterprise id present
 	EnterpriseID string `json:"enterprise_id,omitempty"`
-	BotID  string `json:"bot_id"`
+	BotID        string `json:"bot_id"`
 }
 
 type authTestResponseFull struct {


### PR DESCRIPTION
Fixes #744 .

This PR moves the previously static `GetOAuth*` methods into `Client`'s method set. This permits to use the configurable API endpoint instead of the global constant, and the existing HTTP client that is set on the `Client`.

This PR currently doesn't include unit tests, as no such tests existed before either. Please advise if you want me to add tests.

**Note:** this PR breaks backwards compatibility.

Verification please.