### PR TITLE
expose response metadata when present

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -22,8 +22,9 @@ import (
 
 // SlackResponse handles parsing out errors from the web api.
 type SlackResponse struct {
-	Ok    bool   `json:"ok"`
-	Error string `json:"error"`
+	Ok       bool             `json:"ok"`
+	Error    string           `json:"error"`
+	Metadata ResponseMetadata `json:"response_metadata,omitempty"`
 }
 
 func (t SlackResponse) Err() error {

--- a/slack.go
+++ b/slack.go
@@ -23,7 +23,8 @@ type httpClient interface {
 
 // ResponseMetadata holds pagination metadata
 type ResponseMetadata struct {
-	Cursor string `json:"next_cursor"`
+	Cursor   string   `json:"next_cursor"`
+	Messages []string `json:"messages"`
 }
 
 func (t *ResponseMetadata) initialize() *ResponseMetadata {
@@ -43,7 +44,7 @@ type AuthTestResponse struct {
 	UserID string `json:"user_id"`
 	// EnterpriseID is only returned when an enterprise id present
 	EnterpriseID string `json:"enterprise_id,omitempty"`
-	BotID  string `json:"bot_id"`
+	BotID        string `json:"bot_id"`
 }
 
 type authTestResponseFull struct {


### PR DESCRIPTION
Slack responses often contain a `"response_metadata"` field with
additional information for an error. This patch unmarshals those, when
present, so that they are shown to users of the library.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Fixes https://github.com/slack-go/slack/issues/805
