### PR TITLE
Implement app-level tokens + event authorizations

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -19,7 +19,7 @@ type EventAuthorization struct {
 }
 
 // ListEventAuthorizations lists authed users and teams for the given event_context. You must provide an app-level token to the client using OptionAppLevelToken. More info: https://api.slack.com/methods/apps.event.authorizations.list
-func (api *Client) ListEventAuthorizations(event_context string) ([]EventAuthorization, error) {
+func (api *Client) ListEventAuthorizations(eventContext string) ([]EventAuthorization, error) {
 	resp := &listEventAuthorizationsResponse{}
 
 	err := api.postMethodWithBearerToken(context.Background(), "apps.event.authorizations.list", url.Values{

--- a/apps.go
+++ b/apps.go
@@ -1,0 +1,37 @@
+package slack
+
+import (
+	"context"
+	"net/url"
+)
+
+type listEventAuthorizationsResponse struct {
+	SlackResponse
+	Authorizations []EventAuthorization `json:"authorizations"`
+}
+
+type EventAuthorization struct {
+	EnterpriseID        string `json:"enterprise_id"`
+	TeamID              string `json:"team_id"`
+	UserID              string `json:"user_id"`
+	IsBot               bool   `json:"is_bot"`
+	IsEnterpriseInstall bool   `json:"is_enterprise_install"`
+}
+
+// ListEventAuthorizations lists authed users and teams for the given event_context. You must provide an app-level token to the client using OptionAppLevelToken. More info: https://api.slack.com/methods/apps.event.authorizations.list
+func (api *Client) ListEventAuthorizations(event_context string) ([]EventAuthorization, error) {
+	resp := &listEventAuthorizationsResponse{}
+
+	err := api.postMethodWithBearerToken(context.Background(), "apps.event.authorizations.list", url.Values{
+		"event_context": {event_context},
+	}, &resp, api.appLevelToken)
+
+	if err != nil {
+		return nil, err
+	}
+	if !resp.Ok {
+		return nil, resp.Err()
+	}
+
+	return resp.Authorizations, nil
+}

--- a/apps.go
+++ b/apps.go
@@ -2,7 +2,7 @@ package slack
 
 import (
 	"context"
-	"net/url"
+	"encoding/json"
 )
 
 type listEventAuthorizationsResponse struct {
@@ -18,13 +18,19 @@ type EventAuthorization struct {
 	IsEnterpriseInstall bool   `json:"is_enterprise_install"`
 }
 
-// ListEventAuthorizations lists authed users and teams for the given event_context. You must provide an app-level token to the client using OptionAppLevelToken. More info: https://api.slack.com/methods/apps.event.authorizations.list
 func (api *Client) ListEventAuthorizations(eventContext string) ([]EventAuthorization, error) {
+	return api.ListEventAuthorizationsContext(context.Background(), eventContext)
+}
+
+// ListEventAuthorizationsContext lists authed users and teams for the given event_context. You must provide an app-level token to the client using OptionAppLevelToken. More info: https://api.slack.com/methods/apps.event.authorizations.list
+func (api *Client) ListEventAuthorizationsContext(ctx context.Context, eventContext string) ([]EventAuthorization, error) {
 	resp := &listEventAuthorizationsResponse{}
 
-	err := api.postMethodWithBearerToken(context.Background(), "apps.event.authorizations.list", url.Values{
-		"event_context": {eventContext},
-	}, &resp, api.appLevelToken)
+	request, _ := json.Marshal(map[string]string{
+		"event_context": eventContext,
+	})
+
+	err := postJSON(ctx, api.httpclient, api.endpoint+"apps.event.authorizations.list", api.appLevelToken, request, &resp, api)
 
 	if err != nil {
 		return nil, err

--- a/apps.go
+++ b/apps.go
@@ -23,7 +23,7 @@ func (api *Client) ListEventAuthorizations(eventContext string) ([]EventAuthoriz
 	resp := &listEventAuthorizationsResponse{}
 
 	err := api.postMethodWithBearerToken(context.Background(), "apps.event.authorizations.list", url.Values{
-		"event_context": {event_context},
+		"event_context": {eventContext},
 	}, &resp, api.appLevelToken)
 
 	if err != nil {

--- a/apps_test.go
+++ b/apps_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestListEventAuthorizations(t *testing.T) {
-	http.DefaultServeMux = new(http.ServeMux)
 	http.HandleFunc("/apps.event.authorizations.list", testListEventAuthorizationsHandler)
 	once.Do(startServer)
 

--- a/apps_test.go
+++ b/apps_test.go
@@ -1,0 +1,39 @@
+package slack
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestListEventAuthorizations(t *testing.T) {
+	http.DefaultServeMux = new(http.ServeMux)
+	http.HandleFunc("/apps.event.authorizations.list", testListEventAuthorizationsHandler)
+	once.Do(startServer)
+
+	api := New("", OptionAppLevelToken("test-token"), OptionAPIURL("http://"+serverAddr+"/"))
+
+	authorizations, err := api.ListEventAuthorizations("1-message-T012345678-DR12345678")
+
+	if err != nil {
+		t.Errorf("Failed, but should have succeeded")
+	} else if len(authorizations) != 1 {
+		t.Errorf("Didn't get 1 authorization")
+	} else if authorizations[0].UserID != "U123456789" {
+		t.Errorf("User ID is wrong")
+	}
+}
+
+func testListEventAuthorizationsHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	response, _ := json.Marshal(listEventAuthorizationsResponse{
+		SlackResponse: SlackResponse{Ok: true},
+		Authorizations: []EventAuthorization{
+			{
+				UserID: "U123456789",
+				TeamID: "T012345678",
+			},
+		},
+	})
+	w.Write(response)
+}

--- a/misc.go
+++ b/misc.go
@@ -246,13 +246,16 @@ func postJSON(ctx context.Context, client httpClient, endpoint, token string, js
 }
 
 // post a url encoded form.
-func postForm(ctx context.Context, client httpClient, endpoint string, values url.Values, intf interface{}, d debug) error {
+func postForm(ctx context.Context, client httpClient, endpoint string, values url.Values, intf interface{}, d debug, token ...string) error {
 	reqBody := strings.NewReader(values.Encode())
 	req, err := http.NewRequest("POST", endpoint, reqBody)
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if len(token) > 0 {
+		req.Header.Set("Authorization", "Bearer "+token[0])
+	}
 	return doPost(ctx, client, req, newJSONParser(intf), d)
 }
 

--- a/misc.go
+++ b/misc.go
@@ -246,16 +246,13 @@ func postJSON(ctx context.Context, client httpClient, endpoint, token string, js
 }
 
 // post a url encoded form.
-func postForm(ctx context.Context, client httpClient, endpoint string, values url.Values, intf interface{}, d debug, token ...string) error {
+func postForm(ctx context.Context, client httpClient, endpoint string, values url.Values, intf interface{}, d debug) error {
 	reqBody := strings.NewReader(values.Encode())
 	req, err := http.NewRequest("POST", endpoint, reqBody)
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	if len(token) > 0 {
-		req.Header.Set("Authorization", "Bearer "+token[0])
-	}
 	return doPost(ctx, client, req, newJSONParser(intf), d)
 }
 

--- a/slack.go
+++ b/slack.go
@@ -156,11 +156,6 @@ func (api *Client) postMethod(ctx context.Context, path string, values url.Value
 	return postForm(ctx, api.httpclient, api.endpoint+path, values, intf, api)
 }
 
-// post to a slack web method with a bearer token
-func (api *Client) postMethodWithBearerToken(ctx context.Context, path string, values url.Values, intf interface{}, token string) error {
-	return postForm(ctx, api.httpclient, api.endpoint+path, values, intf, api, token)
-}
-
 // get a slack web method.
 func (api *Client) getMethod(ctx context.Context, path string, values url.Values, intf interface{}) error {
 	return getResource(ctx, api.httpclient, api.endpoint+path, values, intf, api)

--- a/slack.go
+++ b/slack.go
@@ -57,11 +57,12 @@ type authTestResponseFull struct {
 type ParamOption func(*url.Values)
 
 type Client struct {
-	token      string
-	endpoint   string
-	debug      bool
-	log        ilogger
-	httpclient httpClient
+	token         string
+	appLevelToken string
+	endpoint      string
+	debug         bool
+	log           ilogger
+	httpclient    httpClient
 }
 
 // Option defines an option for a Client
@@ -91,6 +92,11 @@ func OptionLog(l logger) func(*Client) {
 // OptionAPIURL set the url for the client. only useful for testing.
 func OptionAPIURL(u string) func(*Client) {
 	return func(c *Client) { c.endpoint = u }
+}
+
+// OptionAppLevelToken sets an app-level token for the client.
+func OptionAppLevelToken(token string) func(*Client) {
+	return func(c *Client) { c.appLevelToken = token }
 }
 
 // New builds a slack client from the provided token and options.
@@ -148,6 +154,11 @@ func (api *Client) Debug() bool {
 // post to a slack web method.
 func (api *Client) postMethod(ctx context.Context, path string, values url.Values, intf interface{}) error {
 	return postForm(ctx, api.httpclient, api.endpoint+path, values, intf, api)
+}
+
+// post to a slack web method with a bearer token
+func (api *Client) postMethodWithBearerToken(ctx context.Context, path string, values url.Values, intf interface{}, token string) error {
+	return postForm(ctx, api.httpclient, api.endpoint+path, values, intf, api, token)
 }
 
 // get a slack web method.

--- a/slackevents/outer_events.go
+++ b/slackevents/outer_events.go
@@ -30,15 +30,16 @@ type ChallengeResponse struct {
 
 // EventsAPICallbackEvent is the main (outer) EventsAPI event.
 type EventsAPICallbackEvent struct {
-	Type        string           `json:"type"`
-	Token       string           `json:"token"`
-	TeamID      string           `json:"team_id"`
-	APIAppID    string           `json:"api_app_id"`
-	InnerEvent  *json.RawMessage `json:"event"`
-	AuthedUsers []string         `json:"authed_users"`
-	AuthedTeams []string         `json:"authed_teams"`
-	EventID     string           `json:"event_id"`
-	EventTime   int              `json:"event_time"`
+	Type         string           `json:"type"`
+	Token        string           `json:"token"`
+	TeamID       string           `json:"team_id"`
+	APIAppID     string           `json:"api_app_id"`
+	InnerEvent   *json.RawMessage `json:"event"`
+	AuthedUsers  []string         `json:"authed_users"`
+	AuthedTeams  []string         `json:"authed_teams"`
+	EventID      string           `json:"event_id"`
+	EventTime    int              `json:"event_time"`
+	EventContext string           `json:"event_context"`
 }
 
 // EventsAPIAppRateLimited indicates your app's event subscriptions are being rate limited


### PR DESCRIPTION
Hello! This PR implements Slack's brand-new flow for retrieving event authorizations, [outlined here](https://api.slack.com/changelog/2020-09-15-events-api-truncate-authed-users).

Here are two unique things about the new [`apps.event.authorizations.list`](https://api.slack.com/methods/apps.event.authorizations.list) method:
1. It requires an [app-level token](https://api.slack.com/authentication/token-types#app) instead of a standard OAuth one. I added an `OptionAppLevelToken` client option, to allow developers to optionally set one. It's not required, and won't affect any existing apps.
2. This method requires that the token be presented in the `Authorization` header, regardless of the content-type. The `postMethodWithBearerToken` function is identical to `postMethod`, except it allows the setting of a bearer token.

This change passes all linting/tests.

##### Pull Request Guidelines

These are recommendations for pull requests.
They are strictly guidelines to help manage expectations.

##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### Examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.
