### PR TITLE
Add deprecation comments to channels.*, groups.*, im.*

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -19,6 +19,12 @@ type channelResponseFull struct {
 }
 
 // Channel contains information about the channel
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 type Channel struct {
 	GroupConversation
 	IsChannel bool   `json:"is_channel"`
@@ -38,9 +44,21 @@ func (api *Client) channelRequest(ctx context.Context, path string, values url.V
 }
 
 // GetChannelsOption option provided when getting channels.
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 type GetChannelsOption func(*ChannelPagination) error
 
 // GetChannelsOptionExcludeMembers excludes the members collection from each channel.
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func GetChannelsOptionExcludeMembers() GetChannelsOption {
 	return func(p *ChannelPagination) error {
 		p.excludeMembers = true
@@ -49,6 +67,12 @@ func GetChannelsOptionExcludeMembers() GetChannelsOption {
 }
 
 // GetChannelsOptionExcludeArchived excludes archived channels from results.
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func GetChannelsOptionExcludeArchived() GetChannelsOption {
 	return func(p *ChannelPagination) error {
 		p.excludeArchived = true
@@ -58,12 +82,24 @@ func GetChannelsOptionExcludeArchived() GetChannelsOption {
 
 // ArchiveChannel archives the given channel
 // see https://api.slack.com/methods/channels.archive
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) ArchiveChannel(channelID string) error {
 	return api.ArchiveChannelContext(context.Background(), channelID)
 }
 
 // ArchiveChannelContext archives the given channel with a custom context
 // see https://api.slack.com/methods/channels.archive
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) ArchiveChannelContext(ctx context.Context, channelID string) (err error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -76,12 +112,24 @@ func (api *Client) ArchiveChannelContext(ctx context.Context, channelID string) 
 
 // UnarchiveChannel unarchives the given channel
 // see https://api.slack.com/methods/channels.unarchive
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) UnarchiveChannel(channelID string) error {
 	return api.UnarchiveChannelContext(context.Background(), channelID)
 }
 
 // UnarchiveChannelContext unarchives the given channel with a custom context
 // see https://api.slack.com/methods/channels.unarchive
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) UnarchiveChannelContext(ctx context.Context, channelID string) (err error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -94,12 +142,24 @@ func (api *Client) UnarchiveChannelContext(ctx context.Context, channelID string
 
 // CreateChannel creates a channel with the given name and returns a *Channel
 // see https://api.slack.com/methods/channels.create
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) CreateChannel(channelName string) (*Channel, error) {
 	return api.CreateChannelContext(context.Background(), channelName)
 }
 
 // CreateChannelContext creates a channel with the given name and returns a *Channel with a custom context
 // see https://api.slack.com/methods/channels.create
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) CreateChannelContext(ctx context.Context, channelName string) (*Channel, error) {
 	values := url.Values{
 		"token": {api.token},
@@ -115,12 +175,24 @@ func (api *Client) CreateChannelContext(ctx context.Context, channelName string)
 
 // GetChannelHistory retrieves the channel history
 // see https://api.slack.com/methods/channels.history
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) GetChannelHistory(channelID string, params HistoryParameters) (*History, error) {
 	return api.GetChannelHistoryContext(context.Background(), channelID, params)
 }
 
 // GetChannelHistoryContext retrieves the channel history with a custom context
 // see https://api.slack.com/methods/channels.history
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) GetChannelHistoryContext(ctx context.Context, channelID string, params HistoryParameters) (*History, error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -160,12 +232,24 @@ func (api *Client) GetChannelHistoryContext(ctx context.Context, channelID strin
 
 // GetChannelInfo retrieves the given channel
 // see https://api.slack.com/methods/channels.info
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) GetChannelInfo(channelID string) (*Channel, error) {
 	return api.GetChannelInfoContext(context.Background(), channelID)
 }
 
 // GetChannelInfoContext retrieves the given channel with a custom context
 // see https://api.slack.com/methods/channels.info
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) GetChannelInfoContext(ctx context.Context, channelID string) (*Channel, error) {
 	values := url.Values{
 		"token":          {api.token},
@@ -182,12 +266,24 @@ func (api *Client) GetChannelInfoContext(ctx context.Context, channelID string) 
 
 // InviteUserToChannel invites a user to a given channel and returns a *Channel
 // see https://api.slack.com/methods/channels.invite
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) InviteUserToChannel(channelID, user string) (*Channel, error) {
 	return api.InviteUserToChannelContext(context.Background(), channelID, user)
 }
 
 // InviteUserToChannelContext invites a user to a given channel and returns a *Channel with a custom context
 // see https://api.slack.com/methods/channels.invite
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) InviteUserToChannelContext(ctx context.Context, channelID, user string) (*Channel, error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -204,12 +300,24 @@ func (api *Client) InviteUserToChannelContext(ctx context.Context, channelID, us
 
 // JoinChannel joins the currently authenticated user to a channel
 // see https://api.slack.com/methods/channels.join
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) JoinChannel(channelName string) (*Channel, error) {
 	return api.JoinChannelContext(context.Background(), channelName)
 }
 
 // JoinChannelContext joins the currently authenticated user to a channel with a custom context
 // see https://api.slack.com/methods/channels.join
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) JoinChannelContext(ctx context.Context, channelName string) (*Channel, error) {
 	values := url.Values{
 		"token": {api.token},
@@ -225,12 +333,24 @@ func (api *Client) JoinChannelContext(ctx context.Context, channelName string) (
 
 // LeaveChannel makes the authenticated user leave the given channel
 // see https://api.slack.com/methods/channels.leave
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) LeaveChannel(channelID string) (bool, error) {
 	return api.LeaveChannelContext(context.Background(), channelID)
 }
 
 // LeaveChannelContext makes the authenticated user leave the given channel with a custom context
 // see https://api.slack.com/methods/channels.leave
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) LeaveChannelContext(ctx context.Context, channelID string) (bool, error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -247,12 +367,24 @@ func (api *Client) LeaveChannelContext(ctx context.Context, channelID string) (b
 
 // KickUserFromChannel kicks a user from a given channel
 // see https://api.slack.com/methods/channels.kick
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) KickUserFromChannel(channelID, user string) error {
 	return api.KickUserFromChannelContext(context.Background(), channelID, user)
 }
 
 // KickUserFromChannelContext kicks a user from a given channel with a custom context
 // see https://api.slack.com/methods/channels.kick
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) KickUserFromChannelContext(ctx context.Context, channelID, user string) (err error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -278,6 +410,12 @@ func newChannelPagination(c *Client, options ...GetChannelsOption) (cp ChannelPa
 }
 
 // ChannelPagination allows for paginating over the channels
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 type ChannelPagination struct {
 	Channels        []Channel
 	limit           int
@@ -288,11 +426,23 @@ type ChannelPagination struct {
 }
 
 // Done checks if the pagination has completed
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (ChannelPagination) Done(err error) bool {
 	return err == errPaginationComplete
 }
 
 // Failure checks if pagination failed.
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (t ChannelPagination) Failure(err error) error {
 	if t.Done(err) {
 		return nil
@@ -301,6 +451,11 @@ func (t ChannelPagination) Failure(err error) error {
 	return err
 }
 
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (t ChannelPagination) Next(ctx context.Context) (_ ChannelPagination, err error) {
 	var (
 		resp *channelResponseFull
@@ -332,18 +487,36 @@ func (t ChannelPagination) Next(ctx context.Context) (_ ChannelPagination, err e
 }
 
 // GetChannelsPaginated fetches channels in a paginated fashion, see GetChannelsContext for usage.
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) GetChannelsPaginated(options ...GetChannelsOption) ChannelPagination {
 	return newChannelPagination(api, options...)
 }
 
 // GetChannels retrieves all the channels
 // see https://api.slack.com/methods/channels.list
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) GetChannels(excludeArchived bool, options ...GetChannelsOption) ([]Channel, error) {
 	return api.GetChannelsContext(context.Background(), excludeArchived, options...)
 }
 
 // GetChannelsContext retrieves all the channels with a custom context
 // see https://api.slack.com/methods/channels.list
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) GetChannelsContext(ctx context.Context, excludeArchived bool, options ...GetChannelsOption) (results []Channel, err error) {
 	if excludeArchived {
 		options = append(options, GetChannelsOptionExcludeArchived())
@@ -373,6 +546,12 @@ func (api *Client) GetChannelsContext(ctx context.Context, excludeArchived bool,
 // (just one per channel). This is useful for when reading scroll-back history, or following a busy live channel. A
 // timeout of 5 seconds is a good starting point. Be sure to flush these calls on shutdown/logout.
 // see https://api.slack.com/methods/channels.mark
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) SetChannelReadMark(channelID, ts string) error {
 	return api.SetChannelReadMarkContext(context.Background(), channelID, ts)
 }
@@ -380,6 +559,12 @@ func (api *Client) SetChannelReadMark(channelID, ts string) error {
 // SetChannelReadMarkContext sets the read mark of a given channel to a specific point with a custom context
 // For more details see SetChannelReadMark documentation
 // see https://api.slack.com/methods/channels.mark
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) SetChannelReadMarkContext(ctx context.Context, channelID, ts string) (err error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -393,12 +578,24 @@ func (api *Client) SetChannelReadMarkContext(ctx context.Context, channelID, ts 
 
 // RenameChannel renames a given channel
 // see https://api.slack.com/methods/channels.rename
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) RenameChannel(channelID, name string) (*Channel, error) {
 	return api.RenameChannelContext(context.Background(), channelID, name)
 }
 
 // RenameChannelContext renames a given channel with a custom context
 // see https://api.slack.com/methods/channels.rename
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) RenameChannelContext(ctx context.Context, channelID, name string) (*Channel, error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -417,12 +614,24 @@ func (api *Client) RenameChannelContext(ctx context.Context, channelID, name str
 
 // SetChannelPurpose sets the channel purpose and returns the purpose that was successfully set
 // see https://api.slack.com/methods/channels.setPurpose
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) SetChannelPurpose(channelID, purpose string) (string, error) {
 	return api.SetChannelPurposeContext(context.Background(), channelID, purpose)
 }
 
 // SetChannelPurposeContext sets the channel purpose and returns the purpose that was successfully set with a custom context
 // see https://api.slack.com/methods/channels.setPurpose
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) SetChannelPurposeContext(ctx context.Context, channelID, purpose string) (string, error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -439,12 +648,24 @@ func (api *Client) SetChannelPurposeContext(ctx context.Context, channelID, purp
 
 // SetChannelTopic sets the channel topic and returns the topic that was successfully set
 // see https://api.slack.com/methods/channels.setTopic
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) SetChannelTopic(channelID, topic string) (string, error) {
 	return api.SetChannelTopicContext(context.Background(), channelID, topic)
 }
 
 // SetChannelTopicContext sets the channel topic and returns the topic that was successfully set with a custom context
 // see https://api.slack.com/methods/channels.setTopic
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) SetChannelTopicContext(ctx context.Context, channelID, topic string) (string, error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -461,12 +682,24 @@ func (api *Client) SetChannelTopicContext(ctx context.Context, channelID, topic 
 
 // GetChannelReplies gets an entire thread (a message plus all the messages in reply to it).
 // see https://api.slack.com/methods/channels.replies
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) GetChannelReplies(channelID, thread_ts string) ([]Message, error) {
 	return api.GetChannelRepliesContext(context.Background(), channelID, thread_ts)
 }
 
 // GetChannelRepliesContext gets an entire thread (a message plus all the messages in reply to it) with a custom context
 // see https://api.slack.com/methods/channels.replies
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) GetChannelRepliesContext(ctx context.Context, channelID, thread_ts string) ([]Message, error) {
 	values := url.Values{
 		"token":     {api.token},

--- a/groups.go
+++ b/groups.go
@@ -7,6 +7,12 @@ import (
 )
 
 // Group contains all the information for a group
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 type Group struct {
 	GroupConversation
 	IsGroup bool `json:"is_group"`
@@ -38,11 +44,23 @@ func (api *Client) groupRequest(ctx context.Context, path string, values url.Val
 }
 
 // ArchiveGroup archives a private group
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) ArchiveGroup(group string) error {
 	return api.ArchiveGroupContext(context.Background(), group)
 }
 
 // ArchiveGroupContext archives a private group
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) ArchiveGroupContext(ctx context.Context, group string) error {
 	values := url.Values{
 		"token":   {api.token},
@@ -54,11 +72,23 @@ func (api *Client) ArchiveGroupContext(ctx context.Context, group string) error 
 }
 
 // UnarchiveGroup unarchives a private group
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) UnarchiveGroup(group string) error {
 	return api.UnarchiveGroupContext(context.Background(), group)
 }
 
 // UnarchiveGroupContext unarchives a private group
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) UnarchiveGroupContext(ctx context.Context, group string) error {
 	values := url.Values{
 		"token":   {api.token},
@@ -70,11 +100,23 @@ func (api *Client) UnarchiveGroupContext(ctx context.Context, group string) erro
 }
 
 // CreateGroup creates a private group
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) CreateGroup(group string) (*Group, error) {
 	return api.CreateGroupContext(context.Background(), group)
 }
 
 // CreateGroupContext creates a private group
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) CreateGroupContext(ctx context.Context, group string) (*Group, error) {
 	values := url.Values{
 		"token": {api.token},
@@ -94,12 +136,24 @@ func (api *Client) CreateGroupContext(ctx context.Context, group string) (*Group
 //   2. Archives the existing group.
 //   3. Creates a new group with the name of the existing group.
 //   4. Adds all members of the existing group to the new group.
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) CreateChildGroup(group string) (*Group, error) {
 	return api.CreateChildGroupContext(context.Background(), group)
 }
 
 // CreateChildGroupContext creates a new private group archiving the old one with a custom context
 // For more information see CreateChildGroup
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) CreateChildGroupContext(ctx context.Context, group string) (*Group, error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -114,11 +168,23 @@ func (api *Client) CreateChildGroupContext(ctx context.Context, group string) (*
 }
 
 // GetGroupHistory fetches all the history for a private group
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) GetGroupHistory(group string, params HistoryParameters) (*History, error) {
 	return api.GetGroupHistoryContext(context.Background(), group, params)
 }
 
 // GetGroupHistoryContext fetches all the history for a private group with a custom context
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) GetGroupHistoryContext(ctx context.Context, group string, params HistoryParameters) (*History, error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -156,11 +222,23 @@ func (api *Client) GetGroupHistoryContext(ctx context.Context, group string, par
 }
 
 // InviteUserToGroup invites a specific user to a private group
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) InviteUserToGroup(group, user string) (*Group, bool, error) {
 	return api.InviteUserToGroupContext(context.Background(), group, user)
 }
 
 // InviteUserToGroupContext invites a specific user to a private group with a custom context
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) InviteUserToGroupContext(ctx context.Context, group, user string) (*Group, bool, error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -176,11 +254,23 @@ func (api *Client) InviteUserToGroupContext(ctx context.Context, group, user str
 }
 
 // LeaveGroup makes authenticated user leave the group
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) LeaveGroup(group string) error {
 	return api.LeaveGroupContext(context.Background(), group)
 }
 
 // LeaveGroupContext makes authenticated user leave the group with a custom context
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) LeaveGroupContext(ctx context.Context, group string) (err error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -192,11 +282,23 @@ func (api *Client) LeaveGroupContext(ctx context.Context, group string) (err err
 }
 
 // KickUserFromGroup kicks a user from a group
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) KickUserFromGroup(group, user string) error {
 	return api.KickUserFromGroupContext(context.Background(), group, user)
 }
 
 // KickUserFromGroupContext kicks a user from a group with a custom context
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) KickUserFromGroupContext(ctx context.Context, group, user string) (err error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -209,11 +311,23 @@ func (api *Client) KickUserFromGroupContext(ctx context.Context, group, user str
 }
 
 // GetGroups retrieves all groups
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) GetGroups(excludeArchived bool) ([]Group, error) {
 	return api.GetGroupsContext(context.Background(), excludeArchived)
 }
 
 // GetGroupsContext retrieves all groups with a custom context
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) GetGroupsContext(ctx context.Context, excludeArchived bool) ([]Group, error) {
 	values := url.Values{
 		"token": {api.token},
@@ -230,11 +344,23 @@ func (api *Client) GetGroupsContext(ctx context.Context, excludeArchived bool) (
 }
 
 // GetGroupInfo retrieves the given group
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) GetGroupInfo(group string) (*Group, error) {
 	return api.GetGroupInfoContext(context.Background(), group)
 }
 
 // GetGroupInfoContext retrieves the given group with a custom context
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) GetGroupInfoContext(ctx context.Context, group string) (*Group, error) {
 	values := url.Values{
 		"token":          {api.token},
@@ -254,12 +380,24 @@ func (api *Client) GetGroupInfoContext(ctx context.Context, group string) (*Grou
 // timer before making the call. In this way, any further updates needed during the timeout will not generate extra
 // calls (just one per channel). This is useful for when reading scroll-back history, or following a busy live
 // channel. A timeout of 5 seconds is a good starting point. Be sure to flush these calls on shutdown/logout.
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) SetGroupReadMark(group, ts string) error {
 	return api.SetGroupReadMarkContext(context.Background(), group, ts)
 }
 
 // SetGroupReadMarkContext sets the read mark on a private group with a custom context
 // For more details see SetGroupReadMark
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) SetGroupReadMarkContext(ctx context.Context, group, ts string) (err error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -272,11 +410,23 @@ func (api *Client) SetGroupReadMarkContext(ctx context.Context, group, ts string
 }
 
 // OpenGroup opens a private group
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) OpenGroup(group string) (bool, bool, error) {
 	return api.OpenGroupContext(context.Background(), group)
 }
 
 // OpenGroupContext opens a private group with a custom context
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) OpenGroupContext(ctx context.Context, group string) (bool, bool, error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -293,11 +443,23 @@ func (api *Client) OpenGroupContext(ctx context.Context, group string) (bool, bo
 // RenameGroup renames a group
 // XXX: They return a channel, not a group. What is this crap? :(
 // Inconsistent api it seems.
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) RenameGroup(group, name string) (*Channel, error) {
 	return api.RenameGroupContext(context.Background(), group, name)
 }
 
 // RenameGroupContext renames a group with a custom context
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) RenameGroupContext(ctx context.Context, group, name string) (*Channel, error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -315,11 +477,23 @@ func (api *Client) RenameGroupContext(ctx context.Context, group, name string) (
 }
 
 // SetGroupPurpose sets the group purpose
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) SetGroupPurpose(group, purpose string) (string, error) {
 	return api.SetGroupPurposeContext(context.Background(), group, purpose)
 }
 
 // SetGroupPurposeContext sets the group purpose with a custom context
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) SetGroupPurposeContext(ctx context.Context, group, purpose string) (string, error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -335,11 +509,23 @@ func (api *Client) SetGroupPurposeContext(ctx context.Context, group, purpose st
 }
 
 // SetGroupTopic sets the group topic
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) SetGroupTopic(group, topic string) (string, error) {
 	return api.SetGroupTopicContext(context.Background(), group, topic)
 }
 
 // SetGroupTopicContext sets the group topic with a custom context
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) SetGroupTopicContext(ctx context.Context, group, topic string) (string, error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -356,12 +542,24 @@ func (api *Client) SetGroupTopicContext(ctx context.Context, group, topic string
 
 // GetGroupReplies gets an entire thread (a message plus all the messages in reply to it).
 // see https://api.slack.com/methods/groups.replies
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) GetGroupReplies(channelID, thread_ts string) ([]Message, error) {
 	return api.GetGroupRepliesContext(context.Background(), channelID, thread_ts)
 }
 
 // GetGroupRepliesContext gets an entire thread (a message plus all the messages in reply to it) with a custom context
 // see https://api.slack.com/methods/groups.replies
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) GetGroupRepliesContext(ctx context.Context, channelID, thread_ts string) ([]Message, error) {
 	values := url.Values{
 		"token":     {api.token},

--- a/im.go
+++ b/im.go
@@ -21,6 +21,12 @@ type imResponseFull struct {
 }
 
 // IM contains information related to the Direct Message channel
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 type IM struct {
 	Conversation
 	IsUserDeleted bool `json:"is_user_deleted"`
@@ -37,11 +43,23 @@ func (api *Client) imRequest(ctx context.Context, path string, values url.Values
 }
 
 // CloseIMChannel closes the direct message channel
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) CloseIMChannel(channel string) (bool, bool, error) {
 	return api.CloseIMChannelContext(context.Background(), channel)
 }
 
 // CloseIMChannelContext closes the direct message channel with a custom context
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) CloseIMChannelContext(ctx context.Context, channel string) (bool, bool, error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -57,12 +75,24 @@ func (api *Client) CloseIMChannelContext(ctx context.Context, channel string) (b
 
 // OpenIMChannel opens a direct message channel to the user provided as argument
 // Returns some status and the channel ID
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) OpenIMChannel(user string) (bool, bool, string, error) {
 	return api.OpenIMChannelContext(context.Background(), user)
 }
 
 // OpenIMChannelContext opens a direct message channel to the user provided as argument with a custom context
 // Returns some status and the channel ID
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) OpenIMChannelContext(ctx context.Context, user string) (bool, bool, string, error) {
 	values := url.Values{
 		"token": {api.token},
@@ -77,11 +107,23 @@ func (api *Client) OpenIMChannelContext(ctx context.Context, user string) (bool,
 }
 
 // MarkIMChannel sets the read mark of a direct message channel to a specific point
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) MarkIMChannel(channel, ts string) (err error) {
 	return api.MarkIMChannelContext(context.Background(), channel, ts)
 }
 
 // MarkIMChannelContext sets the read mark of a direct message channel to a specific point with a custom context
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) MarkIMChannelContext(ctx context.Context, channel, ts string) error {
 	values := url.Values{
 		"token":   {api.token},
@@ -94,11 +136,23 @@ func (api *Client) MarkIMChannelContext(ctx context.Context, channel, ts string)
 }
 
 // GetIMHistory retrieves the direct message channel history
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) GetIMHistory(channel string, params HistoryParameters) (*History, error) {
 	return api.GetIMHistoryContext(context.Background(), channel, params)
 }
 
 // GetIMHistoryContext retrieves the direct message channel history with a custom context
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) GetIMHistoryContext(ctx context.Context, channel string, params HistoryParameters) (*History, error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -136,11 +190,23 @@ func (api *Client) GetIMHistoryContext(ctx context.Context, channel string, para
 }
 
 // GetIMChannels returns the list of direct message channels
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) GetIMChannels() ([]IM, error) {
 	return api.GetIMChannelsContext(context.Background())
 }
 
 // GetIMChannelsContext returns the list of direct message channels with a custom context
+//
+// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
+// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
+// Also, existing applications will not be able to use these APIs after February 24th, 2021.
+//
+// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 func (api *Client) GetIMChannelsContext(ctx context.Context) ([]IM, error) {
 	values := url.Values{
 		"token": {api.token},


### PR DESCRIPTION
Add the following paragraph to doc comment of deprecated methods for the purpose of announcement.
We want to delete these APIs at the next minor version(or the major version).

```
//
// Deprecated: channels.*, groups.* im.* and mpim.* methods will be deprecated in the next version.
// In Slack, these API are no longer available for  newly Apps created after June 10th, 2020.
// Also, existing applications will not be able to use these APIs after February 24th, 2021.
//
// See also: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
```

See: 
- https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
- https://github.com/slack-go/slack/issues/748