### PR TITLE
[Patch] Completed RTM Info

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -77,8 +77,11 @@ type Attachment struct {
 	Pretext   string `json:"pretext,omitempty"`
 	Text      string `json:"text,omitempty"`
 
-	ImageURL string `json:"image_url,omitempty"`
-	ThumbURL string `json:"thumb_url,omitempty"`
+	ImageURL    string `json:"image_url,omitempty"`
+	ImageSize   int    `json:"image_bytes,omitempty"`
+	ImageHeight int    `json:"image_height,omitempty"`
+	ImageWidth  int    `json:"image_width,omitempty"`
+	ThumbURL    string `json:"thumb_url,omitempty"`
 
 	Fields     []AttachmentField  `json:"fields,omitempty"`
 	Actions    []AttachmentAction `json:"actions,omitempty"`

--- a/info.go
+++ b/info.go
@@ -431,6 +431,15 @@ type Icons struct {
 
 // Info contains various details about the authenticated user and team.
 // It is returned by StartRTM or included in the "ConnectedEvent" RTM event.
+// It should be noted that in order to optimise the sync speed, RTMConnect
+// (which uses "rtm.connect") does not get all the account information. Namely,
+// channels, groups, mpims, ims, users and bots are left empty.
+// If you want to have access these fields populated, you should use "rtm.start"
+// instead. Sample code bellow:
+// ```
+//    rtm := slack.NewRTM(slack.RTMOptionUseStart(true))
+//    go rtm.ManageConnection()
+// ```
 type Info struct {
 	URL      string       `json:"url,omitempty"`
 	User     *UserDetails `json:"self,omitempty"`

--- a/info.go
+++ b/info.go
@@ -432,9 +432,15 @@ type Icons struct {
 // Info contains various details about the authenticated user and team.
 // It is returned by StartRTM or included in the "ConnectedEvent" RTM event.
 type Info struct {
-	URL  string       `json:"url,omitempty"`
-	User *UserDetails `json:"self,omitempty"`
-	Team *Team        `json:"team,omitempty"`
+	URL      string       `json:"url,omitempty"`
+	User     *UserDetails `json:"self,omitempty"`
+	Team     *Team        `json:"team,omitempty"`
+	Channels []*Channel   `json:"channels",omitempty`
+	Groups   []*Channel   `json:"groups",omitempty`
+	MPIMs    []*Channel   `json:"mpims",omitempty`
+	IMs      []*Channel   `json:"ims",omitempty`
+	Users    []*User      `json:"users,omitempty"`
+	Bots     []*User      `json:"bots,omitempty"`
 }
 
 type infoResponseFull struct {

--- a/info.go
+++ b/info.go
@@ -444,10 +444,10 @@ type Info struct {
 	URL      string       `json:"url,omitempty"`
 	User     *UserDetails `json:"self,omitempty"`
 	Team     *Team        `json:"team,omitempty"`
-	Channels []*Channel   `json:"channels",omitempty`
-	Groups   []*Channel   `json:"groups",omitempty`
-	MPIMs    []*Channel   `json:"mpims",omitempty`
-	IMs      []*Channel   `json:"ims",omitempty`
+	Channels []*Channel   `json:"channels,omitempty"`
+	Groups   []*Channel   `json:"groups,omitempty"`
+	MPIMs    []*Channel   `json:"mpims,omitempty"`
+	IMs      []*Channel   `json:"ims,omitempty"`
 	Users    []*User      `json:"users,omitempty"`
 	Bots     []*User      `json:"bots,omitempty"`
 }

--- a/info.go
+++ b/info.go
@@ -449,7 +449,7 @@ type Info struct {
 	MPIMs    []*Channel   `json:"mpims,omitempty"`
 	IMs      []*Channel   `json:"ims,omitempty"`
 	Users    []*User      `json:"users,omitempty"`
-	Bots     []*User      `json:"bots,omitempty"`
+	Bots     []*Bot       `json:"bots,omitempty"`
 }
 
 type infoResponseFull struct {


### PR DESCRIPTION
PR Content:
- Added missing information collected from `rtm.start` (info is generated when creating a new rtm using `RTMOptionUseStart` option)