### PR TITLE
reactions.list: support for cursor-based pagination

### DIFF
--- a/reactions_test.go
+++ b/reactions_test.go
@@ -27,12 +27,12 @@ func (rh *reactionsHandler) accumulateFormValue(k string, r *http.Request) {
 
 func (rh *reactionsHandler) handler(w http.ResponseWriter, r *http.Request) {
 	rh.accumulateFormValue("channel", r)
-	rh.accumulateFormValue("count", r)
+	rh.accumulateFormValue("cursor", r)
 	rh.accumulateFormValue("file", r)
 	rh.accumulateFormValue("file_comment", r)
 	rh.accumulateFormValue("full", r)
+	rh.accumulateFormValue("limit", r)
 	rh.accumulateFormValue("name", r)
-	rh.accumulateFormValue("page", r)
 	rh.accumulateFormValue("timestamp", r)
 	rh.accumulateFormValue("user", r)
 	w.Header().Set("Content-Type", "application/json")
@@ -305,11 +305,8 @@ func TestSlack_ListReactions(t *testing.T) {
             }
         }
     ],
-    "paging": {
-        "count": 100,
-        "total": 4,
-        "page": 1,
-        "pages": 1
+    "response_metadata": {
+        "next_cursor": "NextCursor"
     }}`
 	want := []ReactedItem{
 		{
@@ -339,17 +336,18 @@ func TestSlack_ListReactions(t *testing.T) {
 		},
 	}
 	wantParams := map[string]string{
-		"user":  "User",
-		"count": "200",
-		"page":  "2",
-		"full":  "true",
+		"user":   "User",
+		"cursor": "Cursor",
+		"limit":  "200",
+		"full":   "true",
 	}
+	wantCursor := "NextCursor"
 	params := NewListReactionsParameters()
 	params.User = "User"
-	params.Count = 200
-	params.Page = 2
+	params.Cursor = "Cursor"
+	params.Limit = 200
 	params.Full = true
-	got, paging, err := api.ListReactions(params)
+	got, cursor, err := api.ListReactions(params)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -366,7 +364,7 @@ func TestSlack_ListReactions(t *testing.T) {
 	if !reflect.DeepEqual(rh.gotParams, wantParams) {
 		t.Errorf("Got params %#v, want %#v", rh.gotParams, wantParams)
 	}
-	if reflect.DeepEqual(paging, Paging{}) {
-		t.Errorf("Want paging data, got empty struct")
+	if !reflect.DeepEqual(cursor, wantCursor) {
+		t.Errorf("Got %#v, want %#v", cursor, wantCursor)
 	}
 }


### PR DESCRIPTION
## WHAT

Fixes: #825 

SSIA
Note that this PR includes breaking changes about an argument of method.

ref. [Paginating through collections | Slack](https://api.slack.com/docs/pagination)

## WHY

A page-based pagination on the API is not working now.
See #825 for more details.