### PR TITLE
Use custom ctx on SetUserCustomStatusContext

### DIFF
--- a/users.go
+++ b/users.go
@@ -557,7 +557,7 @@ func (api *Client) SetUserCustomStatus(statusText, statusEmoji string, statusExp
 //
 // For more information see SetUserCustomStatus
 func (api *Client) SetUserCustomStatusContext(ctx context.Context, statusText, statusEmoji string, statusExpiration int64) error {
-	return api.SetUserCustomStatusContextWithUser(context.Background(), "", statusText, statusEmoji, statusExpiration)
+	return api.SetUserCustomStatusContextWithUser(ctx, "", statusText, statusEmoji, statusExpiration)
 }
 
 // SetUserCustomStatusWithUser will set a custom status and emoji for the provided user.


### PR DESCRIPTION
## PR Content

This PR changes the function **SetUserCustomStatusContext** that was not calling **SetUserCustomStatusContextWithUser** with a custom context, but with a **context.Background()**. So the parameter **ctx** was not being used.