### PR TITLE
Change ActionType to public

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -17,7 +17,7 @@ type AttachmentAction struct {
 	Name            string                        `json:"name"`                       // Required.
 	Text            string                        `json:"text"`                       // Required.
 	Style           string                        `json:"style,omitempty"`            // Optional. Allowed values: "default", "primary", "danger".
-	Type            actionType                    `json:"type"`                       // Required. Must be set to "button" or "select".
+	Type            ActionType                    `json:"type"`                       // Required. Must be set to "button" or "select".
 	Value           string                        `json:"value,omitempty"`            // Optional.
 	DataSource      string                        `json:"data_source,omitempty"`      // Optional.
 	MinQueryLength  int                           `json:"min_query_length,omitempty"` // Optional. Default value is 1.
@@ -29,7 +29,7 @@ type AttachmentAction struct {
 }
 
 // actionType returns the type of the action
-func (a AttachmentAction) actionType() actionType {
+func (a AttachmentAction) actionType() ActionType {
 	return a.Type
 }
 

--- a/block.go
+++ b/block.go
@@ -35,7 +35,7 @@ type Blocks struct {
 type BlockAction struct {
 	ActionID              string              `json:"action_id"`
 	BlockID               string              `json:"block_id"`
-	Type                  actionType          `json:"type"`
+	Type                  ActionType          `json:"type"`
 	Text                  TextBlockObject     `json:"text"`
 	Value                 string              `json:"value"`
 	ActionTs              string              `json:"action_ts"`
@@ -56,7 +56,7 @@ type BlockAction struct {
 }
 
 // actionType returns the type of the action
-func (b BlockAction) actionType() actionType {
+func (b BlockAction) actionType() ActionType {
 	return b.Type
 }
 

--- a/interactions.go
+++ b/interactions.go
@@ -9,11 +9,11 @@ import (
 type InteractionType string
 
 // ActionType type represents the type of action (attachment, block, etc.)
-type actionType string
+type ActionType string
 
 // action is an interface that should be implemented by all callback action types
 type action interface {
-	actionType() actionType
+	actionType() ActionType
 }
 
 // Types of interactions that can be received.

--- a/interactions_test.go
+++ b/interactions_test.go
@@ -386,7 +386,7 @@ func TestInteractionCallback_InteractionTypeBlockActions_Unmarshal(t *testing.T)
 	assert.Equal(t, cb.State, "")
 	assert.Equal(t,
 		cb.BlockActionState.Values["section_block_id"]["multi_convos"].actionType(),
-		actionType(MultiOptTypeConversations))
+		ActionType(MultiOptTypeConversations))
 	assert.Equal(t,
 		cb.BlockActionState.Values["section_block_id"]["multi_convos"].SelectedConversations,
 		[]string{"G12345"})


### PR DESCRIPTION
## PR Content

This PR changes the **ActionType** to a public type. I couldn't find a reason why this type is private.
So as reported in #607 that this is not intuitive I've created this PR to change it.