### PR TITLE
Change type of `ExcludeArchived` field to bool in `GetConversationsParameters`

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -455,7 +455,7 @@ func (api *Client) GetConversationRepliesContext(ctx context.Context, params *Ge
 
 type GetConversationsParameters struct {
 	Cursor          string
-	ExcludeArchived string
+	ExcludeArchived bool
 	Limit           int
 	Types           []string
 }
@@ -479,8 +479,8 @@ func (api *Client) GetConversationsContext(ctx context.Context, params *GetConve
 	if params.Types != nil {
 		values.Add("types", strings.Join(params.Types, ","))
 	}
-	if params.ExcludeArchived == "true" {
-		values.Add("exclude_archived", "true")
+	if params.ExcludeArchived {
+		values.Add("exclude_archived", strconv.FormatBool(params.ExcludeArchived))
 	}
 
 	response := struct {


### PR DESCRIPTION
I believe the type `GetConversationsParameters` by mistake has a `string` type for `ExcludeArchived` property while in the style of this library is to use `bool` values for flags and then convert it using `strconv.FormatBool()`.

The fix is quite simple, but it's a breaking change, so I'm not sure what would be the proper flow to incorporate this PR in the terms of the repository.