### PR TITLE
Add MaxSelectedItems field to MultiSelectBlockElement

### DIFF
--- a/block_element.go
+++ b/block_element.go
@@ -262,6 +262,7 @@ type MultiSelectBlockElement struct {
 	InitialConversations []string                  `json:"initial_conversations,omitempty"`
 	InitialChannels      []string                  `json:"initial_channels,omitempty"`
 	MinQueryLength       *int                      `json:"min_query_length,omitempty"`
+	MaxSelectedItems     *int                      `json:"max_selected_items,omitempty"`
 	Confirm              *ConfirmationBlockObject  `json:"confirm,omitempty"`
 }
 


### PR DESCRIPTION
## Description

This PR just added missing fields to `MultiSelectBlockElement`.
The missing fields spec is here:

```
Field: max_selected_items
Type: Integer
Required?: No
Description:  Specifies the maximum number of items that can be selected in the menu. Minimum number is 1.
```

## Links
https://api.slack.com/reference/block-kit/block-elements#multi_select
