### PR TITLE
Make possible to get authorized user's profile providing empty userID to GetUserProfileContext

### DIFF
--- a/users.go
+++ b/users.go
@@ -635,9 +635,12 @@ type getUserProfileResponse struct {
 
 // GetUserProfileContext retrieves a user's profile information with a context.
 func (api *Client) GetUserProfileContext(ctx context.Context, userID string, includeLabels bool) (*UserProfile, error) {
-	values := url.Values{"token": {api.token}, "user": {userID}}
+	values := url.Values{"token": {api.token}}
 	if includeLabels {
 		values.Add("include_labels", "true")
+	}
+	if userID != "" {
+		values.Add("user", userID)
 	}
 	resp := &getUserProfileResponse{}
 


### PR DESCRIPTION
The thing is that until some time api considered empty userID value as lack of value but currently for successful execution you must to not provide query string argument at all.