### PR TITLE
Allow message unfurling with auth url

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -75,7 +75,7 @@ type Attachment struct {
 	Title     string `json:"title,omitempty"`
 	TitleLink string `json:"title_link,omitempty"`
 	Pretext   string `json:"pretext,omitempty"`
-	Text      string `json:"text"` // Required
+	Text      string `json:"text,omitempty"`
 
 	ImageURL string `json:"image_url,omitempty"`
 	ThumbURL string `json:"thumb_url,omitempty"`

--- a/chat.go
+++ b/chat.go
@@ -191,6 +191,14 @@ func (api *Client) UnfurlMessage(channelID, timestamp string, unfurls map[string
 	return api.SendMessageContext(context.Background(), channelID, MsgOptionUnfurl(timestamp, unfurls), MsgOptionCompose(options...))
 }
 
+// UnfurlMessageWithAuthURL sends an unfurl request containing an
+// authentication url.
+// For mor detail, see:
+// https://api.slack.com/reference/messaging/link-unfurling#authenticated_unfurls
+func (api *Client) UnfurlMessageWithAuthURL(channelID, timestamp string, userAuthURL string, options ...MsgOption) (string, string, string, error) {
+	return api.SendMessageContext(context.Background(), channelID, MsgOptionUnfurlAuthURL(timestamp, userAuthURL), MsgOptionCompose(options...))
+}
+
 // SendMessage more flexible method for configuring messages.
 func (api *Client) SendMessage(channel string, options ...MsgOption) (string, string, string, error) {
 	return api.SendMessageContext(context.Background(), channel, options...)
@@ -410,6 +418,16 @@ func MsgOptionUnfurl(timestamp string, unfurls map[string]Attachment) MsgOption 
 			config.values.Add("unfurls", string(unfurlsStr))
 		}
 		return err
+	}
+}
+
+// MsgOptionUnfurlAuthURL unfurls a message using an auth url based on the timestamp.
+func MsgOptionUnfurlAuthURL(timestamp string, userAuthURL string) MsgOption {
+	return func(config *sendConfig) error {
+		config.endpoint = config.apiurl + string(chatUnfurl)
+		config.values.Add("ts", timestamp)
+		config.values.Add("user_auth_url", userAuthURL)
+		return nil
 	}
 }
 


### PR DESCRIPTION
This PR adds a method for unfurling a message with an authentication url to initiate a custom authentication flow with the unfurling component.

See: https://api.slack.com/reference/messaging/link-unfurling#authenticated_unfurls

The slack user will be presented with the message:

```
Hi there!  Linking your slack account to <app> you to use <app> in slack (and it only takes a click or two). Would you like to set it up?

- Yes allow. - No
```