### PR TITLE
Use golangci-lint and GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: lint
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.32
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+          - '1.12'
+          - '1.13'
+          - '1.14'
+          - '1.15'
+    name: test go-${{ matrix.go }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+      - name: run test
+        run: go test -v -race ./...
+        env:
+          GO111MODULE: on

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,15 @@
+run:
+  timeout: 6m
+  issues-exit-code: 1
+linters:
+  disable-all: true
+  enable:
+    - goimports
+    - govet
+    - interfacer
+    - misspell
+    - structcheck
+    - unconvert
+issues:
+  # TODO(kanata2): fix existing issues
+  new: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,5 +11,4 @@ linters:
     - structcheck
     - unconvert
 issues:
-  # TODO(kanata2): fix existing issues
   new: true

--- a/block_header_test.go
+++ b/block_header_test.go
@@ -12,7 +12,7 @@ func TestNewHeaderBlock(t *testing.T) {
 
 	headerBlock := NewHeaderBlock(textInfo, HeaderBlockOptionBlockID("test_block"))
 	assert.Equal(t, string(headerBlock.Type), "header")
-	assert.Equal(t, string(headerBlock.BlockID), "test_block")
+	assert.Equal(t, headerBlock.BlockID, "test_block")
 	assert.Equal(t, headerBlock.Text.Type, "plain_text")
 	assert.Contains(t, headerBlock.Text.Text, "quite the header")
 }

--- a/block_section_test.go
+++ b/block_section_test.go
@@ -12,7 +12,7 @@ func TestNewSectionBlock(t *testing.T) {
 
 	sectionBlock := NewSectionBlock(textInfo, nil, nil, SectionBlockOptionBlockID("test_block"))
 	assert.Equal(t, string(sectionBlock.Type), "section")
-	assert.Equal(t, string(sectionBlock.BlockID), "test_block")
+	assert.Equal(t, sectionBlock.BlockID, "test_block")
 	assert.Equal(t, len(sectionBlock.Fields), 0)
 	assert.Nil(t, sectionBlock.Accessory)
 	assert.Equal(t, sectionBlock.Text.Type, "mrkdwn")

--- a/reminders_test.go
+++ b/reminders_test.go
@@ -8,7 +8,6 @@ import (
 
 type remindersHandler struct {
 	gotParams map[string]string
-	response  string
 }
 
 func newRemindersHandler() *remindersHandler {

--- a/slacktest/handlers.go
+++ b/slacktest/handlers.go
@@ -62,7 +62,7 @@ func (sts *Server) conversationsInfoHandler(w http.ResponseWriter, r *http.Reque
 	ch := values.Get("channel")
 
 	response := GroupConversationResponse{
-		Ok:      true,
+		Ok: true,
 		Channel: slack.GroupConversation{
 			Conversation: slack.Conversation{
 				ID: ch,

--- a/websocket_managed_conn_test.go
+++ b/websocket_managed_conn_test.go
@@ -101,7 +101,7 @@ func TestRTMGoodbye(t *testing.T) {
 
 	select {
 	case <-done:
-		// magic numbers from emperical testing.
+		// magic numbers from empirical testing.
 		assert.Equal(t, connected <= 7, true)
 		assert.Equal(t, disconnected <= 12, true)
 	case <-time.After(5 * time.Second):
@@ -158,7 +158,7 @@ func TestRTMDeadConnection(t *testing.T) {
 
 	select {
 	case <-done:
-		// magic numbers from emperical testing.
+		// magic numbers from empirical testing.
 		assert.Equal(t, connected <= 7, true)
 		assert.Equal(t, disconnected <= 7, true)
 	case <-time.After(5 * time.Second):


### PR DESCRIPTION
### Description

- Add configuration for golangci-lint
  - gometalinter is no longer maintained
- Use GitHub Actions for Go 1.12+

