### PR TITLE
Implement an error-comparing method to errorsx String

### DIFF
--- a/internal/errorsx/errorsx.go
+++ b/internal/errorsx/errorsx.go
@@ -6,3 +6,12 @@ type String string
 func (t String) Error() string {
 	return string(t)
 }
+
+// Is reports whether String matches with the target error
+func (t String) Is(target error) bool {
+	if target == nil {
+		return false
+	}
+
+	return t.Error() == target.Error()
+}

--- a/internal/errorsx/errrorsx_test.go
+++ b/internal/errorsx/errrorsx_test.go
@@ -1,0 +1,18 @@
+package errorsx
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIs(t *testing.T) {
+	test := func(receiver String, target error, expected bool) {
+		if result := receiver.Is(target); result != expected {
+			t.Errorf(`expected "%s Is %s" should be %t , got: %t`, receiver, target, expected, result)
+		}
+	}
+
+	test(String("test error"), errors.New("test error"), true)
+	test(String("test error"), errors.New("different error"), false)
+	test(String("test error"), nil, false)
+}


### PR DESCRIPTION
##### PR preparation
**What**
- implemented an error-comparing method `Is()` to the struct `String` in the package `errorsx`
- create a test file for `errorsx` on the way to make a test for this func

**Why**
To make it possible to compare the custom error (`String` in `errorsx`) with all the struct implementing `error` interface by `errors.Is`.
That enables users of this package to check returned exported errors in their own applications by the latest Go standard error comparing way.

For example, the package user can handle the returned error like this


```example.go
if errors.Is(err, slack.ErrRTMDisconnected) {
  // do something
}
```

From Go1.13, `errors.Is` is provided as a function of a Go standard package. 
And, to make the custom error comparable by this func, we need to implement `Is` method to that.
 From [the package description of errors](https://golang.org/pkg/errors/#example_Is) 
>An error is considered to match a target if it is equal to that target or if it implements a method Is(error) bool such that Is(target) returns true.
>
>An error type might provide an Is method so it can be treated as equivalent to an existing error. For example, if MyError defines
>
>```
>func (m MyError) Is(target error) bool { return target == os.ErrExist }
>```
>then Is(MyError{}, os.ErrExist) returns true. See syscall.Errno.Is for an example in the standard library.


**Note**
Firstly I meant and tried to update result evaluation in some test files by this func, but it was too early considering the consistency for the old Go version. So, now I propose this func just for increasing the package user's options to check the returned error from this package.



