### PR TITLE
reminders time field fix

### DIFF
--- a/reminders.go
+++ b/reminders.go
@@ -3,17 +3,16 @@ package slack
 import (
 	"context"
 	"net/url"
-	"time"
 )
 
 type Reminder struct {
-	ID         string    `json:"id"`
-	Creator    string    `json:"creator"`
-	User       string    `json:"user"`
-	Text       string    `json:"text"`
-	Recurring  bool      `json:"recurring"`
-	Time       time.Time `json:"time"`
-	CompleteTS int       `json:"complete_ts"`
+	ID         string `json:"id"`
+	Creator    string `json:"creator"`
+	User       string `json:"user"`
+	Text       string `json:"text"`
+	Recurring  bool   `json:"recurring"`
+	Time       int    `json:"time"`
+	CompleteTS int    `json:"complete_ts"`
 }
 
 type reminderResp struct {


### PR DESCRIPTION
##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

Done

##### Should this be an issue instead
It's a bug fix

##### API changes

It's a bug fix for the Reminder struct.

Currently, reminders add and list functions return a parsing error.
This is because the Reminder's struct Time field is set to time.time currently.

If you take a look at reminders calls, the responses are sending us back Unix timestamp (int), not a time object.

```
Response
(Note: only non-recurring reminders will have time and complete_ts field.)

{
	"ok": true,
	"reminder": {
		"id": "Rm12345678",
		"creator": "U18888888",
		"user": "U18888888",
		"text": "eat a banana",
		"recurring": false,
		"time": 1602288000,
		"complete_ts": 0
	}

```