### PR TITLE
nit: rename channel parameter to channelID for DeleteMessage and DeleteMessageContext

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -85,20 +85,20 @@ func NewPostMessageParameters() PostMessageParameters {
 }
 
 // DeleteMessage deletes a message in a channel
-func (api *Client) DeleteMessage(channel, messageTimestamp string) (string, string, error) {
+func (api *Client) DeleteMessage(channelID, messageTimestamp string) (string, string, error) {
 	respChannel, respTimestamp, _, err := api.SendMessageContext(
 		context.Background(),
-		channel,
+		channelID,
 		MsgOptionDelete(messageTimestamp),
 	)
 	return respChannel, respTimestamp, err
 }
 
 // DeleteMessageContext deletes a message in a channel with a custom context
-func (api *Client) DeleteMessageContext(ctx context.Context, channel, messageTimestamp string) (string, string, error) {
+func (api *Client) DeleteMessageContext(ctx context.Context, channelID, messageTimestamp string) (string, string, error) {
 	respChannel, respTimestamp, _, err := api.SendMessageContext(
 		ctx,
-		channel,
+		channelID,
 		MsgOptionDelete(messageTimestamp),
 	)
 	return respChannel, respTimestamp, err


### PR DESCRIPTION
##### Description
just a nit: by renaming `channel` to `channelID` it will be more clear what is expected.

##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.
**Done**

##### Should this be an issue instead
- [x] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

