### PR TITLE
Make private channel handleable as well as public channel in usergroup's default channels

### DIFF
--- a/usergroups.go
+++ b/usergroups.go
@@ -208,7 +208,7 @@ func (api *Client) UpdateUserGroupContext(ctx context.Context, userGroup UserGro
 	}
 
 	if len(userGroup.Prefs.Channels) > 0 {
-		values["channels"] = []string{strings.Join(userGroup.Prefs.Channels, ",")}
+		values["channels"] = []string{strings.Join(append(userGroup.Prefs.Channels, userGroup.Prefs.Groups...), ",")}
 	}
 
 	response, err := api.userGroupRequest(ctx, "usergroups.update", values)

--- a/usergroups.go
+++ b/usergroups.go
@@ -207,7 +207,7 @@ func (api *Client) UpdateUserGroupContext(ctx context.Context, userGroup UserGro
 		values["description"] = []string{userGroup.Description}
 	}
 
-	if len(userGroup.Prefs.Channels) > 0 {
+	if len(userGroup.Prefs.Channels) > 0 || len(userGroup.Prefs.Groups) > 0 {
 		values["channels"] = []string{strings.Join(append(userGroup.Prefs.Channels, userGroup.Prefs.Groups...), ",")}
 	}
 


### PR DESCRIPTION
Slack treats private channels (Groups) differently from public channels (Channels) when getting usergroup details (https://api.slack.com/types/usergroup) storing them in two separate slices (prefs.channels and prefs.groups), but then treats them as a single value ("channels") when pushing an update to the usergroup via the usergroup.update method (https://api.slack.com/methods/usergroups.update).

2 years ago when I added this, I mistakenly only accounted for the public channels which are stored in the Prefs.Channels value when combining to update the default channels in a usergroup.  Really what needs to be done is to combine the public channels and private channel ID's (Prefs.Channels and Prefs.Groups) together before pushing that back to Slack or you could inadvertently remove private channels (groups) from a usergroup.

##### Pull Request Guidelines

These are recommendations for pull requests.
They are strictly guidelines to help manage expectations.

##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### Examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.
