### PR TITLE
Add conversations.list to the slacktest server

### DIFF
--- a/slacktest/handlers.go
+++ b/slacktest/handlers.go
@@ -72,8 +72,8 @@ func (sts *Server) conversationsInfoHandler(w http.ResponseWriter, r *http.Reque
 		},
 	}
 	encoded, err := json.Marshal(&response)
-	if vErr != nil {
-		msg := fmt.Sprintf("Unable to encode response: %s", vErr.Error())
+	if err != nil {
+		msg := fmt.Sprintf("Unable to encode response: %s", err.Error())
 		log.Printf(msg)
 		http.Error(w, msg, http.StatusInternalServerError)
 		return
@@ -82,7 +82,7 @@ func (sts *Server) conversationsInfoHandler(w http.ResponseWriter, r *http.Reque
 	_, _ = w.Write(encoded)
 }
 
-// handle channels.list
+// handle channels.list and conversations.list
 func listChannelsHandler(w http.ResponseWriter, _ *http.Request) {
 	_, _ = w.Write([]byte(defaultChannelsListJSON))
 }

--- a/slacktest/server.go
+++ b/slacktest/server.go
@@ -51,6 +51,7 @@ func NewTestServer(custom ...binder) *Server {
 	s.Handle("/rtm.connect", RTMConnectHandler)
 	s.Handle("/chat.postMessage", s.postMessageHandler)
 	s.Handle("/channels.list", listChannelsHandler)
+	s.Handle("/conversations.list", listChannelsHandler)
 	s.Handle("/conversations.create", createConversationHandler)
 	s.Handle("/conversations.setTopic", setConversationTopicHandler)
 	s.Handle("/conversations.setPurpose", setConversationPurposeHandler)


### PR DESCRIPTION
This commit adds the `conversations.list` endpoint to the testing server.
This endpoint returns JSON shaped the same as `channels.list`, so I just
reused that handler.

I also found what appeared to be a bug with error handling (a misnamed error)
so I fixed that as well.