### PR TITLE
Avoid returning correct signature

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -18,12 +18,12 @@ type ilogger interface {
 	Println(...interface{})
 }
 
-type debug interface {
+type Debug interface {
 	Debug() bool
 
-	// Debugf print a formatted debug line.
+	// Debugf print a formatted Debug line.
 	Debugf(format string, v ...interface{})
-	// Debugln print a debug line.
+	// Debugln print a Debug line.
 	Debugln(v ...interface{})
 }
 
@@ -53,8 +53,8 @@ func (t discard) Debug() bool {
 	return false
 }
 
-// Debugf print a formatted debug line.
+// Debugf print a formatted Debug line.
 func (t discard) Debugf(format string, v ...interface{}) {}
 
-// Debugln print a debug line.
+// Debugln print a Debug line.
 func (t discard) Debugln(v ...interface{}) {}

--- a/logger.go
+++ b/logger.go
@@ -21,9 +21,9 @@ type ilogger interface {
 type Debug interface {
 	Debug() bool
 
-	// Debugf print a formatted Debug line.
+	// Debugf print a formatted debug line.
 	Debugf(format string, v ...interface{})
-	// Debugln print a Debug line.
+	// Debugln print a debug line.
 	Debugln(v ...interface{})
 }
 
@@ -53,8 +53,8 @@ func (t discard) Debug() bool {
 	return false
 }
 
-// Debugf print a formatted Debug line.
+// Debugf print a formatted debug line.
 func (t discard) Debugf(format string, v ...interface{}) {}
 
-// Debugln print a Debug line.
+// Debugln print a debug line.
 func (t discard) Debugln(v ...interface{}) {}

--- a/misc.go
+++ b/misc.go
@@ -88,7 +88,7 @@ func fileUploadReq(ctx context.Context, path string, values url.Values, r io.Rea
 	return req, nil
 }
 
-func downloadFile(client httpClient, token string, downloadURL string, writer io.Writer, d debug) error {
+func downloadFile(client httpClient, token string, downloadURL string, writer io.Writer, d Debug) error {
 	if downloadURL == "" {
 		return fmt.Errorf("received empty download URL")
 	}
@@ -142,7 +142,7 @@ func jsonReq(endpoint string, body interface{}) (req *http.Request, err error) {
 	return req, nil
 }
 
-func parseResponseBody(body io.ReadCloser, intf interface{}, d debug) error {
+func parseResponseBody(body io.ReadCloser, intf interface{}, d Debug) error {
 	response, err := ioutil.ReadAll(body)
 	if err != nil {
 		return err
@@ -155,7 +155,7 @@ func parseResponseBody(body io.ReadCloser, intf interface{}, d debug) error {
 	return json.Unmarshal(response, intf)
 }
 
-func postLocalWithMultipartResponse(ctx context.Context, client httpClient, method, fpath, fieldname string, values url.Values, intf interface{}, d debug) error {
+func postLocalWithMultipartResponse(ctx context.Context, client httpClient, method, fpath, fieldname string, values url.Values, intf interface{}, d Debug) error {
 	fullpath, err := filepath.Abs(fpath)
 	if err != nil {
 		return err
@@ -169,7 +169,7 @@ func postLocalWithMultipartResponse(ctx context.Context, client httpClient, meth
 	return postWithMultipartResponse(ctx, client, method, filepath.Base(fpath), fieldname, values, file, intf, d)
 }
 
-func postWithMultipartResponse(ctx context.Context, client httpClient, path, name, fieldname string, values url.Values, r io.Reader, intf interface{}, d debug) error {
+func postWithMultipartResponse(ctx context.Context, client httpClient, path, name, fieldname string, values url.Values, r io.Reader, intf interface{}, d Debug) error {
 	pipeReader, pipeWriter := io.Pipe()
 	wr := multipart.NewWriter(pipeWriter)
 	errc := make(chan error)
@@ -216,7 +216,7 @@ func postWithMultipartResponse(ctx context.Context, client httpClient, path, nam
 	}
 }
 
-func doPost(ctx context.Context, client httpClient, req *http.Request, parser responseParser, d debug) error {
+func doPost(ctx context.Context, client httpClient, req *http.Request, parser responseParser, d Debug) error {
 	req = req.WithContext(ctx)
 	resp, err := client.Do(req)
 	if err != nil {
@@ -233,7 +233,7 @@ func doPost(ctx context.Context, client httpClient, req *http.Request, parser re
 }
 
 // post JSON.
-func postJSON(ctx context.Context, client httpClient, endpoint, token string, json []byte, intf interface{}, d debug) error {
+func postJSON(ctx context.Context, client httpClient, endpoint, token string, json []byte, intf interface{}, d Debug) error {
 	reqBody := bytes.NewBuffer(json)
 	req, err := http.NewRequest("POST", endpoint, reqBody)
 	if err != nil {
@@ -246,7 +246,7 @@ func postJSON(ctx context.Context, client httpClient, endpoint, token string, js
 }
 
 // post a url encoded form.
-func postForm(ctx context.Context, client httpClient, endpoint string, values url.Values, intf interface{}, d debug) error {
+func postForm(ctx context.Context, client httpClient, endpoint string, values url.Values, intf interface{}, d Debug) error {
 	reqBody := strings.NewReader(values.Encode())
 	req, err := http.NewRequest("POST", endpoint, reqBody)
 	if err != nil {
@@ -256,7 +256,7 @@ func postForm(ctx context.Context, client httpClient, endpoint string, values ur
 	return doPost(ctx, client, req, newJSONParser(intf), d)
 }
 
-func getResource(ctx context.Context, client httpClient, endpoint string, values url.Values, intf interface{}, d debug) error {
+func getResource(ctx context.Context, client httpClient, endpoint string, values url.Values, intf interface{}, d Debug) error {
 	req, err := http.NewRequest("GET", endpoint, nil)
 	if err != nil {
 		return err
@@ -267,12 +267,12 @@ func getResource(ctx context.Context, client httpClient, endpoint string, values
 	return doPost(ctx, client, req, newJSONParser(intf), d)
 }
 
-func parseAdminResponse(ctx context.Context, client httpClient, method string, teamName string, values url.Values, intf interface{}, d debug) error {
+func parseAdminResponse(ctx context.Context, client httpClient, method string, teamName string, values url.Values, intf interface{}, d Debug) error {
 	endpoint := fmt.Sprintf(WEBAPIURLFormat, teamName, method, time.Now().Unix())
 	return postForm(ctx, client, endpoint, values, intf, d)
 }
 
-func logResponse(resp *http.Response, d debug) error {
+func logResponse(resp *http.Response, d Debug) error {
 	if d.Debug() {
 		text, err := httputil.DumpResponse(resp, true)
 		if err != nil {
@@ -300,7 +300,7 @@ func timerReset(t *time.Timer, d time.Duration) {
 	t.Reset(d)
 }
 
-func checkStatusCode(resp *http.Response, d debug) error {
+func checkStatusCode(resp *http.Response, d Debug) error {
 	if resp.StatusCode == http.StatusTooManyRequests {
 		retry, err := strconv.ParseInt(resp.Header.Get("Retry-After"), 10, 64)
 		if err != nil {

--- a/slack.go
+++ b/slack.go
@@ -132,21 +132,21 @@ func (api *Client) AuthTestContext(ctx context.Context) (response *AuthTestRespo
 	return &responseFull.AuthTestResponse, responseFull.Err()
 }
 
-// Debugf print a formatted debug line.
+// Debugf print a formatted Debug line.
 func (api *Client) Debugf(format string, v ...interface{}) {
 	if api.debug {
 		api.log.Output(2, fmt.Sprintf(format, v...))
 	}
 }
 
-// Debugln print a debug line.
+// Debugln print a Debug line.
 func (api *Client) Debugln(v ...interface{}) {
 	if api.debug {
 		api.log.Output(2, fmt.Sprintln(v...))
 	}
 }
 
-// Debug returns if debug is enabled.
+// Debug returns if Debug is enabled.
 func (api *Client) Debug() bool {
 	return api.debug
 }

--- a/slack.go
+++ b/slack.go
@@ -132,21 +132,21 @@ func (api *Client) AuthTestContext(ctx context.Context) (response *AuthTestRespo
 	return &responseFull.AuthTestResponse, responseFull.Err()
 }
 
-// Debugf print a formatted Debug line.
+// Debugf print a formatted debug line.
 func (api *Client) Debugf(format string, v ...interface{}) {
 	if api.debug {
 		api.log.Output(2, fmt.Sprintf(format, v...))
 	}
 }
 
-// Debugln print a Debug line.
+// Debugln print a debug line.
 func (api *Client) Debugln(v ...interface{}) {
 	if api.debug {
 		api.log.Output(2, fmt.Sprintln(v...))
 	}
 }
 
-// Debug returns if Debug is enabled.
+// Debug returns if debug is enabled.
 func (api *Client) Debug() bool {
 	return api.debug
 }


### PR DESCRIPTION
Closes #849 

This PR updates the code to avoid returning the correct signature. This prevents a malicious caller from viewing the error, updating their signature to the now known correct one, and re-executing the call.

A maintainer stated that if we were to remove the explicitly correct signature, it would be nice to also log the correct one at the debug level. To do that without changing the signature of the `NewSecretsVerifier` method, I added a `WithDebug` method that could be optionally called when creating the verifier, which follows [the Builder pattern](https://en.wikipedia.org/wiki/Builder_pattern). It would have been strange to take an argument that was an unexported interface, so I also exported the `Debug` interface. That makes this change is 100% backwards compatible. 

Happy to change my approach, add tests, or anything else that might help. A big thank-you to this repo's maintainers! 😄 