### PR TITLE
Reminders list fix

### DIFF
--- a/reminders.go
+++ b/reminders.go
@@ -22,7 +22,7 @@ type reminderResp struct {
 
 type remindersResp struct {
 	SlackResponse
-	Reminders []Reminder `json:"reminders"`
+	Reminders []*Reminder `json:"reminders"`
 }
 
 func (api *Client) doReminder(ctx context.Context, path string, values url.Values) (*Reminder, error) {
@@ -42,7 +42,7 @@ func (api *Client) doReminders(ctx context.Context, path string, values url.Valu
 	// create an array of pointers to reminders
 	var reminders = make([]*Reminder, 0, len(response.Reminders))
 	for _, reminder := range response.Reminders {
-		reminders = append(reminders, &reminder)
+		reminders = append(reminders, reminder)
 	}
 
 	return reminders, response.Err()

--- a/reminders_test.go
+++ b/reminders_test.go
@@ -161,29 +161,30 @@ func TestSlack_DeleteReminder(t *testing.T) {
 type mockRemindersListHTTPClient struct{}
 
 func (m *mockRemindersListHTTPClient) Do(*http.Request) (*http.Response, error) {
-	responseString := "{\n" +
-		"\"ok\": true,\n" +
-		"\"reminders\": [\n" +
-		"{\n" +
-		"\"id\": \"Rm12345678\",\n" +
-		"\"creator\": \"U18888888\",\n" +
-		"\"user\": \"U18888888\",\n" +
-		"\"text\": \"eat a banana\",\n" +
-		"\"recurring\": false,\n" +
-		"\"time\": 1458678068,\n" +
-		"\"complete_ts\": 0\n" +
-		"},\n" +
-		"{\n" +
-		"\"id\": \"Gm12345678\",\n" +
-		"\"creator\": \"U18888888\",\n" +
-		"\"user\": \"U18888888\",\n" +
-		"\"text\": \"drink some water\",\n" +
-		"\"recurring\": false,\n" +
-		"\"time\": 1458678090,\n" +
-		"\"complete_ts\": 0\n" +
-		"}\n" +
-		"]\n" +
-		"}"
+	responseString := `{
+		"ok": true,
+		"reminders": [
+	        {
+				"id": "Rm12345678",
+				"creator": "U18888888",
+				"user": "U18888888",
+				"text": "eat a banana",
+				"recurring": false,
+				"time": 1458678068,
+				"complete_ts": 0,
+			},
+			{
+				"id": "Gm12345678",
+				"creator": "U18888888",
+				"user": "U18888888",
+				"text": "drink some water",
+				"recurring": false,
+				"time": 1458678090,
+				"complete_ts": 0,
+			},
+		],
+	}`
+
 	return &http.Response{StatusCode: 200, Body: ioutil.NopCloser(bytes.NewBufferString(responseString))}, nil
 }
 

--- a/reminders_test.go
+++ b/reminders_test.go
@@ -187,7 +187,7 @@ func (m *mockRemindersListHTTPClient) Do(*http.Request) (*http.Response, error) 
 	return &http.Response{StatusCode: 200, Body: ioutil.NopCloser(bytes.NewBufferString(responseString))}, nil
 }
 
-/*func TestSlack_ListReminders(t *testing.T) {
+func TestSlack_ListReminders(t *testing.T) {
 	expectedIDs := []string{"Rm12345678", "Gm12345678"}
 
 	once.Do(startServer)
@@ -207,4 +207,4 @@ func (m *mockRemindersListHTTPClient) Do(*http.Request) (*http.Response, error) 
 			t.Fatalf("List Reminders data wasn't correctly populated: wanted %v, got %v", expectedIDs[i], reminders[i].ID)
 		}
 	}
-}*/
+}

--- a/reminders_test.go
+++ b/reminders_test.go
@@ -171,7 +171,7 @@ func (m *mockRemindersListHTTPClient) Do(*http.Request) (*http.Response, error) 
 				"text": "eat a banana",
 				"recurring": false,
 				"time": 1458678068,
-				"complete_ts": 0,
+				"complete_ts": 0
 			},
 			{
 				"id": "Gm12345678",
@@ -180,9 +180,9 @@ func (m *mockRemindersListHTTPClient) Do(*http.Request) (*http.Response, error) 
 				"text": "drink some water",
 				"recurring": false,
 				"time": 1458678090,
-				"complete_ts": 0,
-			},
-		],
+				"complete_ts": 0
+			}
+		]
 	}`
 
 	return &http.Response{StatusCode: 200, Body: ioutil.NopCloser(bytes.NewBufferString(responseString))}, nil


### PR DESCRIPTION
##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

Done.

##### Should this be an issue instead

Fix for a bug that appeared in https://github.com/slack-go/slack/pull/812

##### API changes

At the moment the reminders list array is being populated with the same data, this is because of Golang behaviour inside range loops - it copies the values inside its loop and gets rid of it when it's done. This PR fixes it so the data returned is correct.

Updated the test to check for this issue (that's how I confirmed the fix works)
