### PR TITLE
Fix button style defenition and add test for that

### DIFF
--- a/block_element.go
+++ b/block_element.go
@@ -127,10 +127,12 @@ func NewImageBlockElement(imageURL, altText string) *ImageBlockElement {
 	}
 }
 
+// Style is a style of Button element
+// https://api.slack.com/reference/block-kit/block-elements#button__fields
 type Style string
 
 const (
-	StyleDefault Style = "default"
+	StyleDefault Style = ""
 	StylePrimary Style = "primary"
 	StyleDanger  Style = "danger"
 )
@@ -155,7 +157,7 @@ func (s ButtonBlockElement) ElementType() MessageElementType {
 	return s.Type
 }
 
-// WithStyling adds styling to the button object and returns the modified ButtonBlockElement
+// WithStyle adds styling to the button object and returns the modified ButtonBlockElement
 func (s *ButtonBlockElement) WithStyle(style Style) *ButtonBlockElement {
 	s.Style = style
 	return s

--- a/block_element_test.go
+++ b/block_element_test.go
@@ -28,6 +28,21 @@ func TestNewButtonBlockElement(t *testing.T) {
 
 }
 
+func TestWithStyleForButtonElement(t *testing.T) {
+
+	// these values are irrelevant in this test
+	btnTxt := NewTextBlockObject("plain_text", "Next 2 Results", false, false)
+	btnElement := NewButtonBlockElement("test", "click_me_123", btnTxt)
+
+	btnElement.WithStyle(StyleDefault)
+	assert.Equal(t, btnElement.Style, Style(""))
+	btnElement.WithStyle(StylePrimary)
+	assert.Equal(t, btnElement.Style, Style("primary"))
+	btnElement.WithStyle(StyleDanger)
+	assert.Equal(t, btnElement.Style, Style("danger"))
+
+}
+
 func TestNewOptionsSelectBlockElement(t *testing.T) {
 
 	testOptionText := NewTextBlockObject("plain_text", "Option One", false, false)

--- a/block_object.go
+++ b/block_object.go
@@ -171,7 +171,7 @@ func (s ConfirmationBlockObject) validateType() MessageObjectType {
 	return motConfirmation
 }
 
-// add styling to confirmation object
+// WithStyle add styling to confirmation object
 func (s *ConfirmationBlockObject) WithStyle(style Style) {
 	s.Style = style
 }

--- a/block_object_test.go
+++ b/block_object_test.go
@@ -42,6 +42,23 @@ func TestNewConfirmationBlockObject(t *testing.T) {
 
 }
 
+func TestWithStyleForConfirmation(t *testing.T) {
+
+	// these values are irrelevant in this test
+	titleObj := NewTextBlockObject("plain_text", "testTitle", false, false)
+	textObj := NewTextBlockObject("plain_text", "testText", false, false)
+	confirmObj := NewTextBlockObject("plain_text", "testConfirm", false, false)
+	confirmation := NewConfirmationBlockObject(titleObj, textObj, confirmObj, nil)
+
+	confirmation.WithStyle(StyleDefault)
+	assert.Equal(t, confirmation.Style, Style(""))
+	confirmation.WithStyle(StylePrimary)
+	assert.Equal(t, confirmation.Style, Style("primary"))
+	confirmation.WithStyle(StyleDanger)
+	assert.Equal(t, confirmation.Style, Style("danger"))
+
+}
+
 func TestNewOptionBlockObject(t *testing.T) {
 
 	valTextObj := NewTextBlockObject("plain_text", "testText", false, false)


### PR DESCRIPTION
# Description
- Fixes #871 
- Creates new tests to confirm `Style` values
- adds and updates related comments to be user-friendly and compliant with Go standard conventions

# Note
I found a minor difference of the default value handling between Block Element and Confirmation Dialog and had some concern about this `Style` type.
But, if I had done the related update, I would have updated an exported API and constant and made that backward incompatible.
So, raised the suggestion issue #874 instead.