### PR TITLE
Add missing `Image512` field in `UserProfile`

### DIFF
--- a/users.go
+++ b/users.go
@@ -31,6 +31,7 @@ type UserProfile struct {
 	Image48               string                  `json:"image_48"`
 	Image72               string                  `json:"image_72"`
 	Image192              string                  `json:"image_192"`
+	Image512              string                  `json:"image_512"`
 	ImageOriginal         string                  `json:"image_original"`
 	Title                 string                  `json:"title"`
 	BotID                 string                  `json:"bot_id,omitempty"`

--- a/users_test.go
+++ b/users_test.go
@@ -46,6 +46,7 @@ func getTestUserProfile() UserProfile {
 		Image48:               "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2016-10-18/92962080834_ef14c1469fc0741caea1_48.jpg",
 		Image72:               "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2016-10-18/92962080834_ef14c1469fc0741caea1_72.jpg",
 		Image192:              "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2016-10-18/92962080834_ef14c1469fc0741caea1_192.jpg",
+		Image512:              "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2016-10-18/92962080834_ef14c1469fc0741caea1_512.jpg",
 		Fields:                getTestUserProfileCustomFields(),
 	}
 }


### PR DESCRIPTION
##### PR preparation
> Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

🙆 



##### API changes

> Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

Added `Image512` field in `UserProfile`.


ref: https://api.slack.com/types/user


