### PR TITLE
Adding apps.uninstall method

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"context"
 	"encoding/json"
+	"net/url"
 )
 
 type listEventAuthorizationsResponse struct {
@@ -40,4 +41,21 @@ func (api *Client) ListEventAuthorizationsContext(ctx context.Context, eventCont
 	}
 
 	return resp.Authorizations, nil
+}
+
+func (api *Client) UninstallApp(clientID string, clientSecret string) error {
+	values := url.Values{
+		"token":         {api.token},
+		"client_id":     {clientID},
+		"client_secret": {clientSecret},
+	}
+
+	response := SlackResponse{}
+
+	err := api.getMethod(context.Background(), "apps.uninstall", values, &response)
+	if err != nil {
+		return err
+	}
+
+	return response.Err()
 }

--- a/apps.go
+++ b/apps.go
@@ -43,7 +43,7 @@ func (api *Client) ListEventAuthorizationsContext(ctx context.Context, eventCont
 	return resp.Authorizations, nil
 }
 
-func (api *Client) UninstallApp(clientID string, clientSecret string) error {
+func (api *Client) UninstallApp(clientID, clientSecret string) error {
 	values := url.Values{
 		"token":         {api.token},
 		"client_id":     {clientID},

--- a/apps_test.go
+++ b/apps_test.go
@@ -36,3 +36,22 @@ func testListEventAuthorizationsHandler(w http.ResponseWriter, r *http.Request) 
 	})
 	w.Write(response)
 }
+
+func TestUninstallApp(t *testing.T) {
+	http.HandleFunc("/apps.uninstall", testUninstallAppHandler)
+	once.Do(startServer)
+
+	api := New("test-token", OptionAPIURL("http://"+serverAddr+"/"))
+
+	err := api.UninstallApp("", "")
+
+	if err != nil {
+		t.Errorf("Failed, but should have succeeded")
+	}
+}
+
+func testUninstallAppHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	response, _ := json.Marshal(SlackResponse{Ok: true})
+	w.Write(response)
+}


### PR DESCRIPTION
##### Changes
Adding the `apps.uninstall` method, which completely removes a Slack app installation from its workspace (revoking any and all tokens in the process).

##### Docs
https://api.slack.com/methods/apps.uninstall

