### PR TITLE
Add support for "channel_created" in the Events API.

### DIFF
--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -306,7 +306,7 @@ const (
 	AppHomeOpened = "app_home_opened"
 	// AppUninstalled Your Slack app was uninstalled.
 	AppUninstalled = "app_uninstalled"
-	// ChannelCreated
+	// ChannelCreated is sent when a new channel is created.
 	ChannelCreated = "channel_created"
 	// GridMigrationFinished An enterprise grid migration has finished on this workspace.
 	GridMigrationFinished = "grid_migration_finished"

--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -47,6 +47,22 @@ type AppUninstalledEvent struct {
 	Type string `json:"type"`
 }
 
+// ChannelCreatedEvent represents the Channel created event
+type ChannelCreatedEvent struct {
+	Type           string             `json:"type"`
+	Channel        ChannelCreatedInfo `json:"channel"`
+	EventTimestamp string             `json:"event_ts"`
+}
+
+// ChannelCreatedInfo represents the information associated with the Channel created event
+type ChannelCreatedInfo struct {
+	ID        string `json:"id"`
+	IsChannel bool   `json:"is_channel"`
+	Name      string `json:"name"`
+	Created   int    `json:"created"`
+	Creator   string `json:"creator"`
+}
+
 // GridMigrationFinishedEvent An enterprise grid migration has finished on this workspace.
 type GridMigrationFinishedEvent struct {
 	Type         string `json:"type"`
@@ -290,6 +306,8 @@ const (
 	AppHomeOpened = "app_home_opened"
 	// AppUninstalled Your Slack app was uninstalled.
 	AppUninstalled = "app_uninstalled"
+	// ChannelCreated
+	ChannelCreated = "channel_created"
 	// GridMigrationFinished An enterprise grid migration has finished on this workspace.
 	GridMigrationFinished = "grid_migration_finished"
 	// GridMigrationStarted An enterprise grid migration has started on this workspace.
@@ -321,6 +339,7 @@ var EventsAPIInnerEventMapping = map[string]interface{}{
 	AppMention:            AppMentionEvent{},
 	AppHomeOpened:         AppHomeOpenedEvent{},
 	AppUninstalled:        AppUninstalledEvent{},
+	ChannelCreated:        ChannelCreatedEvent{},
 	GridMigrationFinished: GridMigrationFinishedEvent{},
 	GridMigrationStarted:  GridMigrationStartedEvent{},
 	LinkShared:            LinkSharedEvent{},


### PR DESCRIPTION
The events API support is missing a number of callback events. This PR adds support for the "channel_created" event.