### PR TITLE
Allow message unfurling with auth URL

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -192,11 +192,19 @@ func (api *Client) UnfurlMessage(channelID, timestamp string, unfurls map[string
 }
 
 // UnfurlMessageWithAuthURL sends an unfurl request containing an
-// authentication url.
-// For mor detail, see:
+// authentication URL.
+// For more details see:
 // https://api.slack.com/reference/messaging/link-unfurling#authenticated_unfurls
 func (api *Client) UnfurlMessageWithAuthURL(channelID, timestamp string, userAuthURL string, options ...MsgOption) (string, string, string, error) {
-	return api.SendMessageContext(context.Background(), channelID, MsgOptionUnfurlAuthURL(timestamp, userAuthURL), MsgOptionCompose(options...))
+	return api.UnfurlMessageWithAuthURLContext(context.Background(), channelID, timestamp, userAuthURL, options...)
+}
+
+// UnfurlMessageWithAuthURLContext sends an unfurl request containing an
+// authentication URL.
+// For more details see:
+// https://api.slack.com/reference/messaging/link-unfurling#authenticated_unfurls
+func (api *Client) UnfurlMessageWithAuthURLContext(ctx context.Context, channelID, timestamp string, userAuthURL string, options ...MsgOption) (string, string, string, error) {
+	return api.SendMessageContext(ctx, channelID, MsgOptionUnfurlAuthURL(timestamp, userAuthURL), MsgOptionCompose(options...))
 }
 
 // SendMessage more flexible method for configuring messages.

--- a/chat.go
+++ b/chat.go
@@ -191,6 +191,14 @@ func (api *Client) UnfurlMessage(channelID, timestamp string, unfurls map[string
 	return api.SendMessageContext(context.Background(), channelID, MsgOptionUnfurl(timestamp, unfurls), MsgOptionCompose(options...))
 }
 
+// UnfurlMessageWithAuthURL sends an unfurl request containing an
+// authentication url.
+// For mor detail, see:
+// https://api.slack.com/reference/messaging/link-unfurling#authenticated_unfurls
+func (api *Client) UnfurlMessageWithAuthURL(channelID, timestamp string, userAuthURL string, options ...MsgOption) (string, string, string, error) {
+	return api.SendMessageContext(context.Background(), channelID, MsgOptionUnfurlAuthURL(timestamp, userAuthURL), MsgOptionCompose(options...))
+}
+
 // SendMessage more flexible method for configuring messages.
 func (api *Client) SendMessage(channel string, options ...MsgOption) (string, string, string, error) {
 	return api.SendMessageContext(context.Background(), channel, options...)
@@ -410,6 +418,16 @@ func MsgOptionUnfurl(timestamp string, unfurls map[string]Attachment) MsgOption 
 			config.values.Add("unfurls", string(unfurlsStr))
 		}
 		return err
+	}
+}
+
+// MsgOptionUnfurlAuthURL unfurls a message using an auth url based on the timestamp.
+func MsgOptionUnfurlAuthURL(timestamp string, userAuthURL string) MsgOption {
+	return func(config *sendConfig) error {
+		config.endpoint = config.apiurl + string(chatUnfurl)
+		config.values.Add("ts", timestamp)
+		config.values.Add("user_auth_url", userAuthURL)
+		return nil
 	}
 }
 

--- a/chat.go
+++ b/chat.go
@@ -439,6 +439,17 @@ func MsgOptionUnfurlAuthURL(timestamp string, userAuthURL string) MsgOption {
 	}
 }
 
+// MsgOptionUnfurlAuthRequired requests that the user installs the
+// Slack app for unfurling.
+func MsgOptionUnfurlAuthRequired(timestamp string) MsgOption {
+	return func(config *sendConfig) error {
+		config.endpoint = config.apiurl + string(chatUnfurl)
+		config.values.Add("ts", timestamp)
+		config.values.Add("user_auth_required", "true")
+		return nil
+	}
+}
+
 // MsgOptionResponseURL supplies a url to use as the endpoint.
 func MsgOptionResponseURL(url string, responseType string) MsgOption {
 	return func(config *sendConfig) error {

--- a/chat.go
+++ b/chat.go
@@ -450,6 +450,17 @@ func MsgOptionUnfurlAuthRequired(timestamp string) MsgOption {
 	}
 }
 
+// MsgOptionUnfurlAuthMessage attaches a message inviting the user to
+// authenticate.
+func MsgOptionUnfurlAuthMessage(timestamp string, msg string) MsgOption {
+	return func(config *sendConfig) error {
+		config.endpoint = config.apiurl + string(chatUnfurl)
+		config.values.Add("ts", timestamp)
+		config.values.Add("user_auth_message", msg)
+		return nil
+	}
+}
+
 // MsgOptionResponseURL supplies a url to use as the endpoint.
 func MsgOptionResponseURL(url string, responseType string) MsgOption {
 	return func(config *sendConfig) error {

--- a/chat_test.go
+++ b/chat_test.go
@@ -145,6 +145,18 @@ func TestPostMessage(t *testing.T) {
 				"user_auth_required": []string{"true"},
 			},
 		},
+		"UnfurlAuthMessage": {
+			endpoint: "/chat.unfurl",
+			opt: []MsgOption{
+				MsgOptionUnfurlAuthMessage("123", "Please!"),
+			},
+			expected: url.Values{
+				"channel":           []string{"CXXX"},
+				"token":             []string{"testing-token"},
+				"ts":                []string{"123"},
+				"user_auth_message": []string{"Please!"},
+			},
+		},
 	}
 
 	once.Do(startServer)

--- a/chat_test.go
+++ b/chat_test.go
@@ -133,6 +133,18 @@ func TestPostMessage(t *testing.T) {
 				"user_auth_url": []string{"https://auth-url.com"},
 			},
 		},
+		"UnfurlAuthRequired": {
+			endpoint: "/chat.unfurl",
+			opt: []MsgOption{
+				MsgOptionUnfurlAuthRequired("123"),
+			},
+			expected: url.Values{
+				"channel":            []string{"CXXX"},
+				"token":              []string{"testing-token"},
+				"ts":                 []string{"123"},
+				"user_auth_required": []string{"true"},
+			},
+		},
 	}
 
 	once.Do(startServer)


### PR DESCRIPTION
This PR is basically a continuation of prior work by @kautsig in #839. I've just extracted his change into a separate branch for easier merging and added some test cases.

## API changes

- Adds UnfurlMessageWithAuthURL method to the client
- Adds UnfurlMessageWithAuthURLContext method to the client
- Adds MsgOptionUnfurlAuthURL used within the two methods above

The Unfurl methods were added to be consistent with the UnfurlMessage method already exposed by the client.
