### PR TITLE
Convert Header block correctly

### DIFF
--- a/block_conv.go
+++ b/block_conv.go
@@ -59,6 +59,8 @@ func (b *Blocks) UnmarshalJSON(data []byte) error {
 			block = &DividerBlock{}
 		case "file":
 			block = &FileBlock{}
+		case "header":
+			block = &HeaderBlock{}
 		case "image":
 			block = &ImageBlock{}
 		case "input":


### PR DESCRIPTION
# Background

Header block was added https://github.com/slack-go/slack/pull/767 but not converted correctly and treated as `slack.UnknownBlock`. This commit convert blocks to the Header block if they have 'header' type by block converter.

# Goal

* Fix a bug and support **Header** block

# Related information

* https://github.com/slack-go/slack/pull/767