### PR TITLE
fix invalid context block error

### DIFF
--- a/block_context.go
+++ b/block_context.go
@@ -11,7 +11,7 @@ type ContextBlock struct {
 }
 
 // BlockType returns the type of the block
-func (s ContextBlock) BlockType() MessageBlockType {
+func (s *ContextBlock) BlockType() MessageBlockType {
 	return s.Type
 }
 


### PR DESCRIPTION
This fixes #559 by making a compile time error for adding a non-pointer `ContextBlock` to a slice of blocks