### PR TITLE
Add `dispatch_action` to input blocks

### DIFF
--- a/block_input.go
+++ b/block_input.go
@@ -4,12 +4,13 @@ package slack
 //
 // More Information: https://api.slack.com/reference/block-kit/blocks#input
 type InputBlock struct {
-	Type     MessageBlockType `json:"type"`
-	BlockID  string           `json:"block_id,omitempty"`
-	Label    *TextBlockObject `json:"label"`
-	Element  BlockElement     `json:"element"`
-	Hint     *TextBlockObject `json:"hint,omitempty"`
-	Optional bool             `json:"optional,omitempty"`
+	Type           MessageBlockType `json:"type"`
+	BlockID        string           `json:"block_id,omitempty"`
+	Label          *TextBlockObject `json:"label"`
+	Element        BlockElement     `json:"element"`
+	Hint           *TextBlockObject `json:"hint,omitempty"`
+	Optional       bool             `json:"optional,omitempty"`
+	DispatchAction bool             `json:"dispatch_action,omitempty"`
 }
 
 // BlockType returns the type of the block


### PR DESCRIPTION
This PR adds the `dispatch_action` field on InputBlock as described [here](https://api.slack.com/reference/block-kit/blocks#input). Setting this to true results in changes to the block dispatching a block_action payload to the server.