### PR TITLE
Make UserID optional in GetUserProfile()

### DIFF
--- a/users.go
+++ b/users.go
@@ -632,9 +632,15 @@ func (api *Client) UnsetUserCustomStatusContext(ctx context.Context) error {
 	return api.SetUserCustomStatusContext(ctx, "", "", 0)
 }
 
+// GetUserProfileParameters are the parameters required to get user profile
+type GetUserProfileParameters struct {
+	UserID        string
+	IncludeLabels bool
+}
+
 // GetUserProfile retrieves a user's profile information.
-func (api *Client) GetUserProfile(userID string, includeLabels bool) (*UserProfile, error) {
-	return api.GetUserProfileContext(context.Background(), userID, includeLabels)
+func (api *Client) GetUserProfile(params *GetUserProfileParameters) (*UserProfile, error) {
+	return api.GetUserProfileContext(context.Background(), params)
 }
 
 type getUserProfileResponse struct {
@@ -643,9 +649,13 @@ type getUserProfileResponse struct {
 }
 
 // GetUserProfileContext retrieves a user's profile information with a context.
-func (api *Client) GetUserProfileContext(ctx context.Context, userID string, includeLabels bool) (*UserProfile, error) {
-	values := url.Values{"token": {api.token}, "user": {userID}}
-	if includeLabels {
+func (api *Client) GetUserProfileContext(ctx context.Context, params *GetUserProfileParameters) (*UserProfile, error) {
+	values := url.Values{"token": {api.token}}
+
+	if params.UserID != "" {
+		values.Add("user", params.UserID)
+	}
+	if params.IncludeLabels {
 		values.Add("include_labels", "true")
 	}
 	resp := &getUserProfileResponse{}

--- a/users_test.go
+++ b/users_test.go
@@ -598,7 +598,7 @@ func TestGetUserProfile(t *testing.T) {
 	http.HandleFunc("/users.profile.get", getUserProfileHandler)
 	once.Do(startServer)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
-	profile, err := api.GetUserProfile("UXXXXXXXX", false)
+	profile, err := api.GetUserProfile(&GetUserProfileParameters{UserID: "UXXXXXXXX"})
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}


### PR DESCRIPTION
`users.profile.get` API takes user parameter as optional.
https://api.slack.com/methods/users.profile.get

This change breaks GetUserProfile interface.
The current interface does not allow the bot to retrieve
its own user profile.

##### Pull Request Guidelines

These are recommendations for pull requests.
They are strictly guidelines to help manage expectations.

##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### Examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.
