### PR TITLE
Create a validation function to check TextBlockObject values

### DIFF
--- a/block_object.go
+++ b/block_object.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"encoding/json"
+	"errors"
 )
 
 // Block Objects are also known as Composition Objects
@@ -133,6 +134,16 @@ func (s TextBlockObject) validateType() MessageObjectType {
 // validateType enforces block objects for element and block parameters
 func (s TextBlockObject) MixedElementType() MixedElementType {
 	return MixedElementText
+}
+
+// Validate checks if TextBlockObject has valid values
+func (s TextBlockObject) Validate() error {
+	// https://github.com/slack-go/slack/issues/881
+	if s.Type == "mrkdwn" && s.Emoji {
+		return errors.New("emoji cannot be true in mrkdown")
+	}
+
+	return nil
 }
 
 // NewTextBlockObject returns an instance of a new Text Block Object

--- a/block_object_test.go
+++ b/block_object_test.go
@@ -1,6 +1,7 @@
 package slack
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -82,4 +83,35 @@ func TestNewOptionGroupBlockElement(t *testing.T) {
 	assert.Equal(t, optGroup.Label.Text, "testLabel")
 	assert.Len(t, optGroup.Options, 1, "Options should contain one element")
 
+}
+
+func TestValidateTextBlockObject(t *testing.T) {
+	tests := []struct {
+		input    TextBlockObject
+		expected error
+	}{
+		{
+			input: TextBlockObject{
+				Type:     "plain_text",
+				Text:     "testText",
+				Emoji:    false,
+				Verbatim: false,
+			},
+			expected: nil,
+		},
+		{
+			input: TextBlockObject{
+				Type:     "mrkdwn",
+				Text:     "testText",
+				Emoji:    true,
+				Verbatim: false,
+			},
+			expected: errors.New("emoji cannot be true in mrkdown"),
+		},
+	}
+
+	for _, test := range tests {
+		err := test.input.Validate()
+		assert.Equal(t, err, test.expected)
+	}
 }


### PR DESCRIPTION
##### Description
**What**
Created a new validation function that can be optionally used to validate the fields in TextBlockObject

**Why**
1. Updates #881 
If we want to catch this problem absolutely like adding the validation like when initializing TextBlockObject, we need to change the IO of the existing API. So, it's a suggestion of the workaround to catch this.

2. It's also useful to catch other problems in TextBlockObject values
For example, we can add a new validation that picks up an unexpected value is in `Type` field by typo.
Even without using this in the production code, the client can make it useful in their unit test codes.

##### Should this be an issue instead
- [x] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes
It just created a new public function that doesn't mutate any data or states. Also, no change for the any existing API.