### PR TITLE
Missing fields in Attachment struct

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -80,6 +80,11 @@ type Attachment struct {
 	ImageURL string `json:"image_url,omitempty"`
 	ThumbURL string `json:"thumb_url,omitempty"`
 
+	ServiceName string `json:"service_name,omitempty"`
+	ServiceIcon string `json:"service_icon,omitempty"`
+	FromURL     string `json:"from_url,omitempty"`
+	OriginalURL string `json:"original_url,omitempty"`
+
 	Fields     []AttachmentField  `json:"fields,omitempty"`
 	Actions    []AttachmentAction `json:"actions,omitempty"`
 	MarkdownIn []string           `json:"mrkdwn_in,omitempty"`


### PR DESCRIPTION
When a link is added to a message, slack add an attachment containing specific fields. Those fields are missing from the current implementation of attachment

PR Content:
     * Add 4 fields to struct Attachment

