### PR TITLE
Expose ReplyTo information in ack error events.

### DIFF
--- a/websocket_internals.go
+++ b/websocket_internals.go
@@ -94,6 +94,7 @@ func (i *IncomingEventError) Error() string {
 // AckErrorEvent i
 type AckErrorEvent struct {
 	ErrorObj error
+	ReplyTo  int
 }
 
 func (a *AckErrorEvent) Error() string {

--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -438,10 +438,10 @@ func (rtm *RTM) handleAck(event json.RawMessage) {
 		if ack.RTMResponse.Error.Code == -1 && ack.RTMResponse.Error.Msg == "slow down, too many messages..." {
 			rtm.IncomingEvents <- RTMEvent{"ack_error", &RateLimitEvent{}}
 		} else {
-			rtm.IncomingEvents <- RTMEvent{"ack_error", &AckErrorEvent{ack.Error}}
+			rtm.IncomingEvents <- RTMEvent{"ack_error", &AckErrorEvent{ack.Error, ack.ReplyTo}}
 		}
 	} else {
-		rtm.IncomingEvents <- RTMEvent{"ack_error", &AckErrorEvent{fmt.Errorf("ack decode failure")}}
+		rtm.IncomingEvents <- RTMEvent{"ack_error", &AckErrorEvent{ErrorObj: fmt.Errorf("ack decode failure")}}
 	}
 }
 


### PR DESCRIPTION
This allows clients to better handle ack errors by linking them to the original outbound message. Clients can then implement their own retry/backoff logic using this information.