### PR TITLE
Make more examples directly runnable by taking values from the environment

### DIFF
--- a/examples/buttons/buttons.go
+++ b/examples/buttons/buttons.go
@@ -4,12 +4,25 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/slack-go/slack"
 )
 
 func main() {
-	api := slack.New("YOUR_TOKEN_HERE")
+	var token, channel string
+	var ok bool
+	token, ok = os.LookupEnv("SLACK_TOKEN")
+	if !ok {
+		fmt.Println("Missing SLACK_TOKEN in environment")
+		os.Exit(1)
+	}
+	channel, ok = os.LookupEnv("SLACK_CHANNEL")
+	if !ok {
+		fmt.Println("Missing SLACK_CHANNEL in environment")
+		os.Exit(1)
+	}
+	api := slack.New(token)
 	attachment := slack.Attachment{
 		Pretext:    "pretext",
 		Fallback:   "We don't currently support your client",
@@ -33,7 +46,7 @@ func main() {
 	}
 
 	message := slack.MsgOptionAttachments(attachment)
-	channelID, timestamp, err := api.PostMessage("CHANNEL_ID", slack.MsgOptionText("", false), message)
+	channelID, timestamp, err := api.PostMessage(channel, slack.MsgOptionText("", false), message)
 	if err != nil {
 		fmt.Printf("Could not send message: %v", err)
 	}

--- a/examples/channels/channels.go
+++ b/examples/channels/channels.go
@@ -2,12 +2,18 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/slack-go/slack"
 )
 
 func main() {
-	api := slack.New("YOUR_TOKEN_HERE")
+	token, ok := os.LookupEnv("SLACK_TOKEN")
+	if !ok {
+		fmt.Println("Missing SLACK_TOKEN in environment")
+		os.Exit(1)
+	}
+	api := slack.New(token)
 	channels, err := api.GetChannels(false)
 	if err != nil {
 		fmt.Printf("%s\n", err)

--- a/examples/connparams/connparams.go
+++ b/examples/connparams/connparams.go
@@ -10,8 +10,13 @@ import (
 )
 
 func main() {
+	token, ok := os.LookupEnv("SLACK_TOKEN")
+	if !ok {
+		fmt.Println("Missing SLACK_TOKEN in environment")
+		os.Exit(1)
+	}
 	api := slack.New(
-		"YOUR TOKEN HERE",
+		token,
 		slack.OptionDebug(true),
 		slack.OptionLog(log.New(os.Stdout, "slack-bot: ", log.Lshortfile|log.LstdFlags)),
 	)

--- a/examples/websocket/websocket.go
+++ b/examples/websocket/websocket.go
@@ -9,8 +9,13 @@ import (
 )
 
 func main() {
+	token, ok := os.LookupEnv("SLACK_TOKEN")
+	if !ok {
+		fmt.Println("Missing SLACK_TOKEN in environment")
+		os.Exit(1)
+	}
 	api := slack.New(
-		"YOUR TOKEN HERE",
+		token,
 		slack.OptionDebug(true),
 		slack.OptionLog(log.New(os.Stdout, "slack-bot: ", log.Lshortfile|log.LstdFlags)),
 	)


### PR DESCRIPTION
I noticed several of the examples were already looking for values in the environment. I made these changes so I could run a few examples directly without having to copy and paste in my secrets, which I think is a good thing anyway because really, secrets almost never belong in code.