### PR TITLE
Add the new condition to the validation func for TextBlockObject

### DIFF
--- a/block_object.go
+++ b/block_object.go
@@ -138,6 +138,10 @@ func (s TextBlockObject) MixedElementType() MixedElementType {
 
 // Validate checks if TextBlockObject has valid values
 func (s TextBlockObject) Validate() error {
+	if s.Type != "plain_text" && s.Type != "mrkdwn" {
+		return errors.New("type must be either of plain_text or mrkdwn")
+	}
+
 	// https://github.com/slack-go/slack/issues/881
 	if s.Type == "mrkdwn" && s.Emoji {
 		return errors.New("emoji cannot be true in mrkdown")

--- a/block_object_test.go
+++ b/block_object_test.go
@@ -103,6 +103,24 @@ func TestValidateTextBlockObject(t *testing.T) {
 			input: TextBlockObject{
 				Type:     "mrkdwn",
 				Text:     "testText",
+				Emoji:    false,
+				Verbatim: false,
+			},
+			expected: nil,
+		},
+		{
+			input: TextBlockObject{
+				Type:     "invalid",
+				Text:     "testText",
+				Emoji:    false,
+				Verbatim: false,
+			},
+			expected: errors.New("type must be either of plain_text or mrkdwn"),
+		},
+		{
+			input: TextBlockObject{
+				Type:     "mrkdwn",
+				Text:     "testText",
 				Emoji:    true,
 				Verbatim: false,
 			},


### PR DESCRIPTION
# What
- Add the new validation condition that checks whether the value in the `Type` field is valid to the validation func for the `TextBlockObject`

# Why
- There may be a case that a user puts invalid value to this field such as mistaking it for other Struct or having a simple typo. 

# Ref
 [official API doc](https://api.slack.com/reference/block-kit/composition-objects#text)