### PR TITLE
Update ExcludeArchived type to bool & match others

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -455,7 +455,7 @@ func (api *Client) GetConversationRepliesContext(ctx context.Context, params *Ge
 
 type GetConversationsParameters struct {
 	Cursor          string
-	ExcludeArchived string
+	ExcludeArchived bool
 	Limit           int
 	Types           []string
 }
@@ -479,7 +479,7 @@ func (api *Client) GetConversationsContext(ctx context.Context, params *GetConve
 	if params.Types != nil {
 		values.Add("types", strings.Join(params.Types, ","))
 	}
-	if params.ExcludeArchived == "true" {
+	if params.ExcludeArchived {
 		values.Add("exclude_archived", "true")
 	}
 


### PR DESCRIPTION
Small PR to update `ExcludeArchived`'s type in `GetConversationsParameters` in `conversation.go` to bool so that it matches all other instances of `ExcludeArchived` in the package. It changes the signature of `GetConversationsParameters` but makes it more communicative as to what the value should be.