### PR TITLE
slacktest: Save thread_ts to message

### DIFF
--- a/slacktest/handlers.go
+++ b/slacktest/handlers.go
@@ -142,6 +142,7 @@ func (sts *Server) postMessageHandler(w http.ResponseWriter, r *http.Request) {
 	m.Channel = values.Get("channel")
 	m.Timestamp = fmt.Sprintf("%d", ts)
 	m.Text = values.Get("text")
+	m.ThreadTimestamp = values.Get("thread_ts")
 	if values.Get("as_user") != "true" {
 		m.User = defaultNonBotUserID
 		m.Username = defaultNonBotUserName


### PR DESCRIPTION
**Problem**: There is no way to check if message was sent to thread.

I just save `thread_ts` to message struct so we'll be able to check it later with `GetSeenOutboundMessages()`