### PR TITLE
Fix authorization on methods which uses get requests

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -45,14 +45,13 @@ func (api *Client) ListEventAuthorizationsContext(ctx context.Context, eventCont
 
 func (api *Client) UninstallApp(clientID, clientSecret string) error {
 	values := url.Values{
-		"token":         {api.token},
 		"client_id":     {clientID},
 		"client_secret": {clientSecret},
 	}
 
 	response := SlackResponse{}
 
-	err := api.getMethod(context.Background(), "apps.uninstall", values, &response)
+	err := api.getMethod(context.Background(), "apps.uninstall", api.token, values, &response)
 	if err != nil {
 		return err
 	}

--- a/chat.go
+++ b/chat.go
@@ -744,7 +744,6 @@ func (api *Client) GetPermalink(params *PermalinkParameters) (string, error) {
 // GetPermalinkContext returns the permalink for a message using a custom context.
 func (api *Client) GetPermalinkContext(ctx context.Context, params *PermalinkParameters) (string, error) {
 	values := url.Values{
-		"token":      {api.token},
 		"channel":    {params.Channel},
 		"message_ts": {params.Ts},
 	}
@@ -754,7 +753,7 @@ func (api *Client) GetPermalinkContext(ctx context.Context, params *PermalinkPar
 		Permalink string `json:"permalink"`
 		SlackResponse
 	}{}
-	err := api.getMethod(ctx, "chat.getPermalink", values, &response)
+	err := api.getMethod(ctx, "chat.getPermalink", api.token, values, &response)
 	if err != nil {
 		return "", err
 	}

--- a/info.go
+++ b/info.go
@@ -321,10 +321,9 @@ type UserPrefs struct {
 }
 
 func (api *Client) GetUserPrefs() (*UserPrefsCarrier, error) {
-	values := url.Values{"token": {api.token}}
 	response := UserPrefsCarrier{}
 
-	err := api.getMethod(context.Background(), "users.prefs.get", values, &response)
+	err := api.getMethod(context.Background(), "users.prefs.get", api.token, url.Values{}, &response)
 	if err != nil {
 		return nil, err
 	}

--- a/misc.go
+++ b/misc.go
@@ -236,12 +236,14 @@ func postForm(ctx context.Context, client httpClient, endpoint string, values ur
 	return doPost(ctx, client, req, newJSONParser(intf), d)
 }
 
-func getResource(ctx context.Context, client httpClient, endpoint string, values url.Values, intf interface{}, d Debug) error {
+func getResource(ctx context.Context, client httpClient, endpoint, token string, values url.Values, intf interface{}, d Debug) error {
 	req, err := http.NewRequest("GET", endpoint, nil)
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
 	req.URL.RawQuery = values.Encode()
 
 	return doPost(ctx, client, req, newJSONParser(intf), d)

--- a/slack.go
+++ b/slack.go
@@ -157,6 +157,6 @@ func (api *Client) postMethod(ctx context.Context, path string, values url.Value
 }
 
 // get a slack web method.
-func (api *Client) getMethod(ctx context.Context, path string, values url.Values, intf interface{}) error {
-	return getResource(ctx, api.httpclient, api.endpoint+path, values, intf, api)
+func (api *Client) getMethod(ctx context.Context, path string, token string, values url.Values, intf interface{}) error {
+	return getResource(ctx, api.httpclient, api.endpoint+path, token, values, intf, api)
 }


### PR DESCRIPTION
Hi! Not sure how long these methods don't work, according to the Slack API docs passing tokens as get parameters isn't allowed
https://api.slack.com/web#slack-web-api__authentication

When I migrated my application to the new Slack application I started getting auth errors on chat.getPermalink method. Looks like they force this rule in new apps.
