### PR TITLE
[socketmode] Add methods with passing context

### DIFF
--- a/socketmode/client.go
+++ b/socketmode/client.go
@@ -28,7 +28,7 @@ type ConnectionInfo struct {
 }
 
 type SocketModeMessagePayload struct {
-	Event json.RawMessage `json:"´event"`
+	Event json.RawMessage `json:"event"`
 }
 
 // Client is a Socket Mode client that allows programs to use [Events API](https://api.slack.com/events-api)

--- a/socketmode/socket_mode_managed_conn.go
+++ b/socketmode/socket_mode_managed_conn.go
@@ -267,7 +267,7 @@ func (smc *Client) openAndDial(ctx context.Context, additionalPingHandler func(s
 	if smc.dialer != nil {
 		dialer = smc.dialer
 	}
-	conn, _, err := dialer.Dial(url, upgradeHeader)
+	conn, _, err := dialer.DialContext(ctx, url, upgradeHeader)
 	if err != nil {
 		smc.Debugf("Failed to dial to the websocket: %s", err)
 		return nil, nil, err

--- a/socketmode/socket_mode_managed_conn_test.go
+++ b/socketmode/socket_mode_managed_conn_test.go
@@ -1,0 +1,43 @@
+package socketmode
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slacktest"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_passContext(t *testing.T) {
+	s := slacktest.NewTestServer()
+	go s.Start()
+
+	api := slack.New("ABCDEFG", slack.OptionAPIURL(s.GetAPIURL()))
+	cli := New(api)
+
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Nanosecond)
+	defer cancel()
+
+	t.Run("RunWithContext", func(t *testing.T) {
+		// should fail imidiatly.
+		assert.EqualError(t, cli.RunContext(ctx), context.DeadlineExceeded.Error())
+	})
+
+	t.Run("openAndDial", func(t *testing.T) {
+		_, _, err := cli.openAndDial(ctx, func(_ string) error { return nil })
+
+		// should fail imidiatly.
+		assert.EqualError(t, errors.Unwrap(err), context.DeadlineExceeded.Error())
+	})
+
+	t.Run("OpenWithContext", func(t *testing.T) {
+		_, _, err := cli.OpenContext(ctx)
+
+		// should fail imidiatly.
+		assert.EqualError(t, errors.Unwrap(err), context.DeadlineExceeded.Error())
+	})
+}

--- a/socketmode/socket_mode_managed_conn_test.go
+++ b/socketmode/socket_mode_managed_conn_test.go
@@ -1,3 +1,5 @@
+// +build go1.13
+
 package socketmode
 
 import (

--- a/socketmode/socketmode.go
+++ b/socketmode/socketmode.go
@@ -61,6 +61,13 @@ func (smc *Client) Open() (info *slack.SocketModeConnection, websocketURL string
 	return smc.apiClient.StartSocketModeContext(ctx)
 }
 
+// OpenContext calls the "apps.connections.open" endpoint and returns the provided URL and the full Info block.
+//
+// To have a fully managed Websocket connection, use `New`, and call `Run()` on it.
+func (smc *Client) OpenContext(ctx context.Context) (info *slack.SocketModeConnection, websocketURL string, err error) {
+	return smc.apiClient.StartSocketModeContext(ctx)
+}
+
 // Option options for the managed Client.
 type Option func(client *Client)
 


### PR DESCRIPTION
There's no chance to gracefully shutdown `socketmode.Client`. (bug?)

- Add methods with passing context
  - added socketmode.Client.RunContext
  - added socketmode.Client.OpenContext
  - changed socketmode.Client.openAndDial to pass context
  - added test coverage for socketmode.Client.openAndDial
  - added test coverage for socketmode.Client.RunContext
  - added test coverage for socketmode.Client.OpenContext

- Use DialContext instead of Dial

- Graceful shutdown websocket.Conn  (websocket connection freeze on conn.ReadJSON)
  - returned context errors to stop reconnect
  - closed channel of messages when exit from Client.run
  - closed websocket connection when context canceled

- mark test only for go 1.13 and higher
- fix typo in json tag

##### Pull Request Guidelines

These are recommendations for pull requests.
They are strictly guidelines to help manage expectations.

##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### Examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.