### PR TITLE
added `external` data_source for dynamic data

### DIFF
--- a/dialog_select.go
+++ b/dialog_select.go
@@ -54,8 +54,8 @@ func NewStaticSelectDialogInput(name, label string, options []DialogSelectOption
 	}
 }
 
-// NewDynamicSelectDialogInput constructor for a `external` datasource menu input
-func NewDynamicSelectDialogInput(name, label string, options []DialogSelectOption) *DialogInputSelect {
+// NewExternalSelectDialogInput constructor for a `external` datasource menu input
+func NewExternalSelectDialogInput(name, label string, options []DialogSelectOption) *DialogInputSelect {
 	return &DialogInputSelect{
 		DialogInput: DialogInput{
 			Type:     InputTypeSelect,

--- a/dialog_select.go
+++ b/dialog_select.go
@@ -54,6 +54,20 @@ func NewStaticSelectDialogInput(name, label string, options []DialogSelectOption
 	}
 }
 
+// NewDynamicSelectDialogInput constructor for a `external` datasource menu input
+func NewDynamicSelectDialogInput(name, label string, options []DialogSelectOption) *DialogInputSelect {
+	return &DialogInputSelect{
+		DialogInput: DialogInput{
+			Type:     InputTypeSelect,
+			Name:     name,
+			Label:    label,
+			Optional: true,
+		},
+		DataSource: DialogDataSourceExternal,
+		Options:    options,
+	}
+}
+
 // NewGroupedSelectDialogInput creates grouped options select input for Dialogs.
 func NewGroupedSelectDialogInput(name, label string, options []DialogOptionGroup) *DialogInputSelect {
 	return &DialogInputSelect{


### PR DESCRIPTION
`external` kind of input was missing in the slack api
but makes sense to pass this as option rather than separating into
two funcs; also makes sense to pass Optional as option but not hardcoded

---

Ran `make pr-prep` it passes all, exit status 0.
It’s more a convenience method, couldn’t find a way to make input field as dynamic to pull data from external source regarding [Slack API](https://api.slack.com/dialogs#dynamic_select_elements_external)

No tests, didn’t find tests related to `NewStaticSelectDialogInput` but if needed can create. Tests in `dialog_select_test.go` test main functionality which is shared between `NewStaticSelectDialogInput` and new `NewDynamicSelectDialogInput` implementation.
