### PR TITLE
initial documentation for events example

### DIFF
--- a/examples/eventsapi/README.md
+++ b/examples/eventsapi/README.md
@@ -1,0 +1,39 @@
+# Events Example
+
+The following are the settings you'll need to configure in the Slack UI to get this example to work. In particular, you must disable socket mode to reveal the `reqeust_url` text field in the Slack UI.
+
+```
+_metadata:
+  major_version: 1
+  minor_version: 1
+display_information:
+  name: Name
+  description: Description
+  background_color: "<hexcode>"
+features:
+  app_home:
+    home_tab_enabled: N/A
+    messages_tab_enabled: N/A
+    messages_tab_read_only_enabled: N/A
+  bot_user:
+    display_name: Name
+    always_online: N/A
+oauth_config:
+  scopes:
+    bot:
+      - app_mentions:read *
+      - channels:history *
+settings:
+  allowed_ip_address_ranges:  # <--- Required
+    - xxx.xxx.xxx.xxx/32
+    - xxx.xxx.xxx.xxx/32
+    - xxx.xxx.xxx.xxx/32
+  event_subscriptions:
+    request_url: https://example.com/example-endpoint
+    bot_events:
+      - app_mention
+      - message.channels
+  org_deploy_enabled: N/A
+  socket_mode_enabled: false  # <--- Required
+
+```

--- a/examples/eventsapi/README.md
+++ b/examples/eventsapi/README.md
@@ -21,8 +21,8 @@ features:
 oauth_config:
   scopes:
     bot:
-      - app_mentions:read *
-      - channels:history *
+      - app_mentions:read
+      - channels:history
 settings:
   allowed_ip_address_ranges:  # <--- Required
     - xxx.xxx.xxx.xxx/32


### PR DESCRIPTION
##### This is a Documentation PR

As a new user of slack-go who inherited a slackbot, I found the `examples/eventsapi/events.go` example difficult to get working. This README file will help others avoid the same fate. Could I have posted this as a question in Stackoverflow? Yes. But as a new user I wouldn't have known what to search for. And anyway, it is best to get answers from the source.