### PR TITLE
Audit log fixes 

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -115,7 +115,7 @@ func (api *Client) GetAuditLogsContext(ctx context.Context, params AuditLogParam
 		"token": {api.token},
 	}
 	if params.Limit != 0 {
-		values.Add("count", strconv.Itoa(params.Limit))
+		values.Add("limit", strconv.Itoa(params.Limit))
 	}
 	if params.Oldest != 0 {
 		values.Add("oldest", strconv.Itoa(params.Oldest))

--- a/audit.go
+++ b/audit.go
@@ -111,9 +111,7 @@ func (api *Client) GetAuditLogs(params AuditLogParameters) (entries []AuditEntry
 
 // GetAuditLogsContext retrieves a page of audit entries according to the parameters given with a custom context
 func (api *Client) GetAuditLogsContext(ctx context.Context, params AuditLogParameters) (entries []AuditEntry, nextCursor string, err error) {
-	values := url.Values{
-		"token": {api.token},
-	}
+	values := url.Values{}
 	if params.Limit != 0 {
 		values.Add("limit", strconv.Itoa(params.Limit))
 	}


### PR DESCRIPTION
Fixes a couple things wrt to audit logs:

1) Fix "Limit" option. The Number of results returned is specified by the `limit` URL param, previously this was getting switched to `count` so the API would always return the default ( https://api.slack.com/admins/audit-logs ).

2) Stop adding token to request URL params. This was passing a token in both the request Headers and as a URL param.  Based on other issues here, it sounds like Slack deprecated including tokens in URLs, so here it was being included and probably ignored.  Requests would still work though as the token was also being included in the header. 


##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

✅ 

##### Should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

N/A. Just a couple fixes
