### PR TITLE
Add context aware UnfurlMessage

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -188,7 +188,12 @@ func (api *Client) UpdateMessageContext(ctx context.Context, channelID, timestam
 
 // UnfurlMessage unfurls a message in a channel
 func (api *Client) UnfurlMessage(channelID, timestamp string, unfurls map[string]Attachment, options ...MsgOption) (string, string, string, error) {
-	return api.SendMessageContext(context.Background(), channelID, MsgOptionUnfurl(timestamp, unfurls), MsgOptionCompose(options...))
+	return api.UnfurlMessageContext(context.Background(), channelID, timestamp, unfurls, options...)
+}
+
+// UnfurlMessageContext unfurls a message in a channel with a custom context
+func (api *Client) UnfurlMessageContext(ctx context.Context, channelID, timestamp string, unfurls map[string]Attachment, options ...MsgOption) (string, string, string, error) {
+	return api.SendMessageContext(ctx, channelID, MsgOptionUnfurl(timestamp, unfurls), MsgOptionCompose(options...))
 }
 
 // UnfurlMessageWithAuthURL sends an unfurl request containing an

--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -165,7 +165,7 @@ type LinkSharedEvent struct {
 	User             string        `json:"user"`
 	TimeStamp        string        `json:"ts"`
 	Channel          string        `json:"channel"`
-	MessageTimeStamp string        `json:"message_ts"`
+	MessageTimeStamp json.Number   `json:"message_ts"`
 	ThreadTimeStamp  string        `json:"thread_ts"`
 	Links            []sharedLinks `json:"links"`
 }

--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -165,7 +165,7 @@ type LinkSharedEvent struct {
 	User             string        `json:"user"`
 	TimeStamp        string        `json:"ts"`
 	Channel          string        `json:"channel"`
-	MessageTimeStamp json.Number   `json:"message_ts"`
+	MessageTimeStamp string        `json:"message_ts"`
 	ThreadTimeStamp  string        `json:"thread_ts"`
 	Links            []sharedLinks `json:"links"`
 }


### PR DESCRIPTION
The MessageTimeStamp was incorrectly marked as a number. It should be
a string as any other timestamp, and it required for Unfurl to work
