### PR TITLE
[CI] Add test setup for Go1.17 environment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
           - '1.14'
           - '1.15'
           - '1.16'
+          - '1.17'
     name: test go-${{ matrix.go }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
# What
Updated the CI to execute the tests in the Go1.17 environment as well.

# Why
I'm not sure about the policy of this repository for Go1.17, but I think we should ensure that the build and tests work fine even in this version.