### PR TITLE
Add Enterprise Grid related property

### DIFF
--- a/interactions.go
+++ b/interactions.go
@@ -53,6 +53,7 @@ type InteractionCallback struct {
 	APIAppID        string          `json:"api_app_id"`
 	BlockID         string          `json:"block_id"`
 	Container       Container       `json:"container"`
+	Enterprise      Enterprise      `json:"enterprise"`
 	DialogSubmissionCallback
 	ViewSubmissionCallback
 	ViewClosedCallback
@@ -126,6 +127,11 @@ type Container struct {
 	ChannelID    string      `json:"channel_id"`
 	IsEphemeral  bool        `json:"is_ephemeral"`
 	IsAppUnfurl  bool        `json:"is_app_unfurl"`
+}
+
+type Enterprise struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 // ActionCallback is a convenience struct defined to allow dynamic unmarshalling of

--- a/slackevents/outer_events.go
+++ b/slackevents/outer_events.go
@@ -8,12 +8,13 @@ import (
 
 // EventsAPIEvent is the base EventsAPIEvent
 type EventsAPIEvent struct {
-	Token      string `json:"token"`
-	TeamID     string `json:"team_id"`
-	Type       string `json:"type"`
-	APIAppID   string `json:"api_app_id"`
-	Data       interface{}
-	InnerEvent EventsAPIInnerEvent
+	Token        string `json:"token"`
+	TeamID       string `json:"team_id"`
+	Type         string `json:"type"`
+	APIAppID     string `json:"api_app_id"`
+	EnterpriseID string `json:"enterprise_id"`
+	Data         interface{}
+	InnerEvent   EventsAPIInnerEvent
 }
 
 // EventsAPIURLVerificationEvent received when configuring a EventsAPI driven app

--- a/slackevents/parsers.go
+++ b/slackevents/parsers.go
@@ -39,6 +39,7 @@ func parseOuterEvent(rawE json.RawMessage) (EventsAPIEvent, error) {
 			"",
 			"unmarshalling_error",
 			"",
+			"",
 			&slack.UnmarshallingErrorEvent{ErrorObj: err},
 			EventsAPIInnerEvent{},
 		}, err
@@ -52,6 +53,7 @@ func parseOuterEvent(rawE json.RawMessage) (EventsAPIEvent, error) {
 				"",
 				"unmarshalling_error",
 				"",
+				"",
 				&slack.UnmarshallingErrorEvent{ErrorObj: err},
 				EventsAPIInnerEvent{},
 			}, err
@@ -61,6 +63,7 @@ func parseOuterEvent(rawE json.RawMessage) (EventsAPIEvent, error) {
 			e.TeamID,
 			e.Type,
 			e.APIAppID,
+			e.EnterpriseID,
 			cbEvent,
 			EventsAPIInnerEvent{},
 		}, nil
@@ -73,6 +76,7 @@ func parseOuterEvent(rawE json.RawMessage) (EventsAPIEvent, error) {
 			"",
 			"unmarshalling_error",
 			"",
+			"",
 			&slack.UnmarshallingErrorEvent{ErrorObj: err},
 			EventsAPIInnerEvent{},
 		}, err
@@ -82,6 +86,7 @@ func parseOuterEvent(rawE json.RawMessage) (EventsAPIEvent, error) {
 		e.TeamID,
 		e.Type,
 		e.APIAppID,
+		e.EnterpriseID,
 		urlVE,
 		EventsAPIInnerEvent{},
 	}, nil
@@ -97,6 +102,7 @@ func parseInnerEvent(e *EventsAPICallbackEvent) (EventsAPIEvent, error) {
 			e.TeamID,
 			"unmarshalling_error",
 			e.APIAppID,
+			"",
 			&slack.UnmarshallingErrorEvent{ErrorObj: err},
 			EventsAPIInnerEvent{},
 		}, err
@@ -108,6 +114,7 @@ func parseInnerEvent(e *EventsAPICallbackEvent) (EventsAPIEvent, error) {
 			e.TeamID,
 			iE.Type,
 			e.APIAppID,
+			"",
 			nil,
 			EventsAPIInnerEvent{},
 		}, fmt.Errorf("Inner Event does not exist! %s", iE.Type)
@@ -121,6 +128,7 @@ func parseInnerEvent(e *EventsAPICallbackEvent) (EventsAPIEvent, error) {
 			e.TeamID,
 			"unmarshalling_error",
 			e.APIAppID,
+			"",
 			&slack.UnmarshallingErrorEvent{ErrorObj: err},
 			EventsAPIInnerEvent{},
 		}, err
@@ -130,6 +138,7 @@ func parseInnerEvent(e *EventsAPICallbackEvent) (EventsAPIEvent, error) {
 		e.TeamID,
 		e.Type,
 		e.APIAppID,
+		"",
 		e,
 		EventsAPIInnerEvent{iE.Type, recvEvent},
 	}, nil
@@ -196,6 +205,7 @@ func ParseEvent(rawEvent json.RawMessage, opts ...Option) (EventsAPIEvent, error
 				"",
 				"unmarshalling_error",
 				"",
+				"",
 				&slack.UnmarshallingErrorEvent{ErrorObj: err},
 				EventsAPIInnerEvent{},
 			}, err
@@ -210,6 +220,7 @@ func ParseEvent(rawEvent json.RawMessage, opts ...Option) (EventsAPIEvent, error
 			"",
 			"unmarshalling_error",
 			"",
+			"",
 			&slack.UnmarshallingErrorEvent{ErrorObj: err},
 			EventsAPIInnerEvent{},
 		}, err
@@ -219,6 +230,7 @@ func ParseEvent(rawEvent json.RawMessage, opts ...Option) (EventsAPIEvent, error
 		e.TeamID,
 		e.Type,
 		e.APIAppID,
+		e.EnterpriseID,
 		urlVerificationEvent,
 		EventsAPIInnerEvent{},
 	}, nil


### PR DESCRIPTION
Hello!

I'm developing slack app for Enterprise Grid organization and realized enterprise related property is missing for some requests coming from slack.

I created this PR to parse those json requests to structure.

##### Pull Request Guidelines

These are recommendations for pull requests.
They are strictly guidelines to help manage expectations.

##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### Examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.
