### PR TITLE
Add field to inputblock

### DIFF
--- a/block_input.go
+++ b/block_input.go
@@ -19,11 +19,12 @@ func (s InputBlock) BlockType() MessageBlockType {
 }
 
 // NewInputBlock returns a new instance of an input block
-func NewInputBlock(blockID string, label *TextBlockObject, element BlockElement) *InputBlock {
+func NewInputBlock(blockID string, label, hint *TextBlockObject, element BlockElement) *InputBlock {
 	return &InputBlock{
 		Type:    MBTInput,
 		BlockID: blockID,
 		Label:   label,
 		Element: element,
+		Hint:    hint,
 	}
 }

--- a/block_input_test.go
+++ b/block_input_test.go
@@ -9,8 +9,8 @@ import (
 func TestNewInputBlock(t *testing.T) {
 	label := NewTextBlockObject("plain_text", "label", false, false)
 	element := NewDatePickerBlockElement("action_id")
-
-	inputBlock := NewInputBlock("test", label, element)
+	hint := NewTextBlockObject("plain_text", "hint", false, false)
+	inputBlock := NewInputBlock("test", label, hint, element)
 	assert.Equal(t, string(inputBlock.Type), "input")
 	assert.Equal(t, inputBlock.BlockID, "test")
 	assert.Equal(t, inputBlock.Label, label)

--- a/examples/modal/modal.go
+++ b/examples/modal/modal.go
@@ -31,15 +31,17 @@ func generateModalRequest() slack.ModalViewRequest {
 	headerSection := slack.NewSectionBlock(headerText, nil, nil)
 
 	firstNameText := slack.NewTextBlockObject("plain_text", "First Name", false, false)
+	firstNameHint := slack.NewTextBlockObject("plain_text", "First Name Hint", false, false)
 	firstNamePlaceholder := slack.NewTextBlockObject("plain_text", "Enter your first name", false, false)
 	firstNameElement := slack.NewPlainTextInputBlockElement(firstNamePlaceholder, "firstName")
 	// Notice that blockID is a unique identifier for a block
-	firstName := slack.NewInputBlock("First Name", firstNameText, firstNameElement)
+	firstName := slack.NewInputBlock("First Name", firstNameText, firstNameHint, firstNameElement)
 
 	lastNameText := slack.NewTextBlockObject("plain_text", "Last Name", false, false)
+	lastNameHint := slack.NewTextBlockObject("plain_text", "Last Name Hint", false, false)
 	lastNamePlaceholder := slack.NewTextBlockObject("plain_text", "Enter your first name", false, false)
 	lastNameElement := slack.NewPlainTextInputBlockElement(lastNamePlaceholder, "lastName")
-	lastName := slack.NewInputBlock("Last Name", lastNameText, lastNameElement)
+	lastName := slack.NewInputBlock("Last Name", lastNameText, lastNameHint, lastNameElement)
 
 	blocks := slack.Blocks{
 		BlockSet: []slack.Block{

--- a/examples/modal_users/users.go
+++ b/examples/modal_users/users.go
@@ -20,12 +20,12 @@ func main() {
 	// Only the inputs in input blocks will be included in view_submission’s view.state.values: https://slack.dev/java-slack-sdk/guides/modals
 	// This means the inputs will not be interactive either because they do not trigger block_actions messages: https://api.slack.com/surfaces/modals/using#interactions
 	channelNameText := slack.NewTextBlockObject(slack.PlainTextType, "Channel Name", false, false)
+	channelNameHint := slack.NewTextBlockObject(slack.PlainTextType, "Channel names may only contain lowercase letters, numbers, hyphens, and underscores, and must be 80 characters or less", false, false)
 	channelPlaceholder := slack.NewTextBlockObject(slack.PlainTextType, "New channel name", false, false)
 	channelNameElement := slack.NewPlainTextInputBlockElement(channelPlaceholder, "channel_name")
 	// Slack channel names can be maximum 80 characters: https://api.slack.com/methods/conversations.create
 	channelNameElement.MaxLength = 80
-	channelNameBlock := slack.NewInputBlock("channel_name", channelNameText, channelNameElement)
-	channelNameBlock.Hint = slack.NewTextBlockObject(slack.PlainTextType, "Channel names may only contain lowercase letters, numbers, hyphens, and underscores, and must be 80 characters or less", false, false)
+	channelNameBlock := slack.NewInputBlock("channel_name", channelNameText, channelNameHint, channelNameElement)
 
 	// Provide a static list of users to choose from, those provided now are just made up user IDs
 	// Get user IDs by right clicking on them in Slack, select "Copy link", and inspect the last part of the link
@@ -33,7 +33,7 @@ func main() {
 	memberOptions := createOptionBlockObjects([]string{"U9911MMAA", "U2233KKNN", "U00112233"}, true)
 	inviteeText := slack.NewTextBlockObject(slack.PlainTextType, "Invitee from static list", false, false)
 	inviteeOption := slack.NewOptionsSelectBlockElement(slack.OptTypeStatic, nil, "invitee", memberOptions...)
-	inviteeBlock := slack.NewInputBlock("invitee", inviteeText, inviteeOption)
+	inviteeBlock := slack.NewInputBlock("invitee", inviteeText, nil, inviteeOption)
 
 	additionalInviteeText := slack.NewTextBlockObject(slack.PlainTextType, "Invitee from complete list of users", false, false)
 	additionalInviteeOption := slack.NewOptionsSelectBlockElement(slack.OptTypeUser, additionalInviteeText, "")
@@ -42,15 +42,16 @@ func main() {
 	checkboxTxt := slack.NewTextBlockObject(slack.PlainTextType, "Checkbox", false, false)
 	checkboxOptions := createOptionBlockObjects([]string{"option 1", "option 2", "option 3"}, false)
 	checkboxOptionsBlock := slack.NewCheckboxGroupsBlockElement("chkbox", checkboxOptions...)
-	checkboxBlock := slack.NewInputBlock("chkbox", checkboxTxt, checkboxOptionsBlock)
+	checkboxBlock := slack.NewInputBlock("chkbox", checkboxTxt, nil, checkboxOptionsBlock)
 
 	summaryText := slack.NewTextBlockObject(slack.PlainTextType, "Summary", false, false)
+	summaryHint := slack.NewTextBlockObject(slack.PlainTextType, "Summary Hint", false, false)
 	summaryPlaceholder := slack.NewTextBlockObject(slack.PlainTextType, "Summary of reason for creating channel", false, false)
 	summaryElement := slack.NewPlainTextInputBlockElement(summaryPlaceholder, "summary")
 	// Just set an arbitrary max length to avoid too prose summary
 	summaryElement.MaxLength = 200
 	summaryElement.Multiline = true
-	summaryBlock := slack.NewInputBlock("summary", summaryText, summaryElement)
+	summaryBlock := slack.NewInputBlock("summary", summaryText, summaryHint, summaryElement)
 
 	blocks := slack.Blocks{
 		BlockSet: []slack.Block{

--- a/interactions_test.go
+++ b/interactions_test.go
@@ -256,6 +256,7 @@ func TestViewSubmissionCallback(t *testing.T) {
 							false,
 							false,
 						),
+						nil,
 						&PlainTextInputBlockElement{
 							Type:      "plain_text_input",
 							ActionID:  "ml-value",
@@ -270,6 +271,7 @@ func TestViewSubmissionCallback(t *testing.T) {
 							false,
 							false,
 						),
+						nil,
 						&SelectBlockElement{
 							Type:                         "conversations_select",
 							ActionID:                     "target_select",

--- a/views_test.go
+++ b/views_test.go
@@ -172,6 +172,10 @@ func TestSlack_OpenView(t *testing.T) {
 									Type: PlainTextType,
 									Text: "A simple label",
 								},
+								&TextBlockObject{
+									Type: PlainTextType,
+									Text: "A simple hint",
+								},
 								NewPlainTextInputBlockElement(
 									&TextBlockObject{
 										Type: PlainTextType,
@@ -330,6 +334,10 @@ func TestSlack_View_PublishView(t *testing.T) {
 								&TextBlockObject{
 									Type: PlainTextType,
 									Text: "A simple label",
+								},
+								&TextBlockObject{
+									Type: PlainTextType,
+									Text: "A simple hint",
 								},
 								NewPlainTextInputBlockElement(
 									&TextBlockObject{
@@ -502,6 +510,10 @@ func TestSlack_PushView(t *testing.T) {
 								&TextBlockObject{
 									Type: PlainTextType,
 									Text: "A simple label",
+								},
+								&TextBlockObject{
+									Type: PlainTextType,
+									Text: "A simple hint",
 								},
 								NewPlainTextInputBlockElement(
 									&TextBlockObject{
@@ -678,6 +690,10 @@ func TestSlack_UpdateView(t *testing.T) {
 								&TextBlockObject{
 									Type: PlainTextType,
 									Text: "A simple label",
+								},
+								&TextBlockObject{
+									Type: PlainTextType,
+									Text: "A simple hint",
 								},
 								NewPlainTextInputBlockElement(
 									&TextBlockObject{


### PR DESCRIPTION
In this PR, I responded to this issue.[#964](https://github.com/slack-go/slack/issues/964)
With this change, the `NewInputBlock` function has one more argument.