### PR TITLE
Change the regular field `apiClient` in `socketmode.Client` to an embedded struct.

### DIFF
--- a/socketmode/client.go
+++ b/socketmode/client.go
@@ -44,7 +44,7 @@ type SocketModeMessagePayload struct {
 // Client's New() and call Run() to start it. Please see examples/socketmode for the usage.
 type Client struct {
 	// Client is the main API, embedded
-	apiClient slack.Client
+	slack.Client
 
 	// maxPingInterval is the maximum duration elapsed after the last WebSocket PING sent from Slack
 	// until Client considers the WebSocket connection is dead and needs to be reopened.

--- a/socketmode/socketmode.go
+++ b/socketmode/socketmode.go
@@ -58,14 +58,14 @@ func (smc *Client) Open() (info *slack.SocketModeConnection, websocketURL string
 	ctx, cancel := context.WithTimeout(context.Background(), websocketDefaultTimeout)
 	defer cancel()
 
-	return smc.apiClient.StartSocketModeContext(ctx)
+	return smc.StartSocketModeContext(ctx)
 }
 
 // OpenContext calls the "apps.connections.open" endpoint and returns the provided URL and the full Info block.
 //
 // To have a fully managed Websocket connection, use `New`, and call `Run()` on it.
 func (smc *Client) OpenContext(ctx context.Context) (info *slack.SocketModeConnection, websocketURL string, err error) {
-	return smc.apiClient.StartSocketModeContext(ctx)
+	return smc.StartSocketModeContext(ctx)
 }
 
 // Option options for the managed Client.
@@ -106,7 +106,7 @@ func OptionLog(l logger) func(*Client) {
 // Slack's Websocket-based Socket Mode.
 func New(api *slack.Client, options ...Option) *Client {
 	result := &Client{
-		apiClient:           *api,
+		Client:              *api,
 		Events:              make(chan Event, 50),
 		socketModeResponses: make(chan *Response, 20),
 		maxPingInterval:     defaultMaxPingInterval,


### PR DESCRIPTION
Hi! As explained in #963, it seems natural for socketmode client struct to provide main API via embedded struct `slack.Client` like an RTM struct.

This pull request changes the regular field `apiClient` in `socketmode.Client` to an embedded struct.