### PR TITLE
webhooks: add additional fields

### DIFF
--- a/webhooks.go
+++ b/webhooks.go
@@ -15,6 +15,9 @@ type WebhookMessage struct {
 	Attachments     []Attachment `json:"attachments,omitempty"`
 	Parse           string       `json:"parse,omitempty"`
 	Blocks          *Blocks      `json:"blocks,omitempty"`
+	ResponseType    string       `json:"response_type,omitempty"`
+	ReplaceOriginal bool         `json:"replace_original,omitempty"`
+	DeleteOriginal  bool         `json:"delete_original,omitempty"`
 }
 
 func PostWebhook(url string, msg *WebhookMessage) error {


### PR DESCRIPTION
These fields allow users to replace original messages sent by bots through webhooks.

For example first response to a slash command is an ephemeral message and the second response (eg to a button press) sends back a `ResponseType` of `slack.ResponseTypeInChannel` replacing it with one thats in-channel visible to all.

I've run `make pr-prep` and the only changes seem to be to unrelated files:

```diff
diff --git a/webhooks_go112.go b/webhooks_go112.go
index 4e0db0e..b27c342 100644
--- a/webhooks_go112.go
+++ b/webhooks_go112.go
@@ -1,3 +1,4 @@
+//go:build !go1.13
 // +build !go1.13

 package slack
diff --git a/webhooks_go113.go b/webhooks_go113.go
index 99c243f..869105d 100644
--- a/webhooks_go113.go
+++ b/webhooks_go113.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13

 package slack
```