### PR TITLE
Add include_num_members support to conversation.info request

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -358,16 +358,17 @@ func (api *Client) CreateConversationContext(ctx context.Context, channelName st
 }
 
 // GetConversationInfo retrieves information about a conversation
-func (api *Client) GetConversationInfo(channelID string, includeLocale bool) (*Channel, error) {
-	return api.GetConversationInfoContext(context.Background(), channelID, includeLocale)
+func (api *Client) GetConversationInfo(channelID string, includeLocale, includeNumMembers bool) (*Channel, error) {
+	return api.GetConversationInfoContext(context.Background(), channelID, includeLocale, includeNumMembers)
 }
 
 // GetConversationInfoContext retrieves information about a conversation with a custom context
-func (api *Client) GetConversationInfoContext(ctx context.Context, channelID string, includeLocale bool) (*Channel, error) {
+func (api *Client) GetConversationInfoContext(ctx context.Context, channelID string, includeLocale, includeNumMembers bool) (*Channel, error) {
 	values := url.Values{
-		"token":          {api.token},
-		"channel":        {channelID},
-		"include_locale": {strconv.FormatBool(includeLocale)},
+		"token":               {api.token},
+		"channel":             {channelID},
+		"include_locale":      {strconv.FormatBool(includeLocale)},
+		"include_num_members": {strconv.FormatBool(includeNumMembers)},
 	}
 	response, err := api.channelRequest(ctx, "conversations.info", values)
 	if err != nil {

--- a/conversation.go
+++ b/conversation.go
@@ -359,8 +359,8 @@ func (api *Client) CreateConversationContext(ctx context.Context, channelName st
 
 // GetConversationInfoInput Defines the parameters of a GetConversationInfo and GetConversationInfoContext function
 type GetConversationInfoInput struct {
-	ChannelID string
-	IncludeLocale bool
+	ChannelID         string
+	IncludeLocale     bool
 	IncludeNumMembers bool
 }
 

--- a/conversation.go
+++ b/conversation.go
@@ -357,18 +357,29 @@ func (api *Client) CreateConversationContext(ctx context.Context, channelName st
 	return &response.Channel, nil
 }
 
+// GetConversationInfoInput Defines the parameters of a GetConversationInfo and GetConversationInfoContext function
+type GetConversationInfoInput struct {
+	ChannelID string
+	IncludeLocale bool
+	IncludeNumMembers bool
+}
+
 // GetConversationInfo retrieves information about a conversation
-func (api *Client) GetConversationInfo(channelID string, includeLocale, includeNumMembers bool) (*Channel, error) {
-	return api.GetConversationInfoContext(context.Background(), channelID, includeLocale, includeNumMembers)
+func (api *Client) GetConversationInfo(input *GetConversationInfoInput) (*Channel, error) {
+	return api.GetConversationInfoContext(context.Background(), input)
 }
 
 // GetConversationInfoContext retrieves information about a conversation with a custom context
-func (api *Client) GetConversationInfoContext(ctx context.Context, channelID string, includeLocale, includeNumMembers bool) (*Channel, error) {
+func (api *Client) GetConversationInfoContext(ctx context.Context, input *GetConversationInfoInput) (*Channel, error) {
+	if input == nil {
+		input = &GetConversationInfoInput{}
+	}
+
 	values := url.Values{
 		"token":               {api.token},
-		"channel":             {channelID},
-		"include_locale":      {strconv.FormatBool(includeLocale)},
-		"include_num_members": {strconv.FormatBool(includeNumMembers)},
+		"channel":             {input.ChannelID},
+		"include_locale":      {strconv.FormatBool(input.IncludeLocale)},
+		"include_num_members": {strconv.FormatBool(input.IncludeNumMembers)},
 	}
 	response, err := api.channelRequest(ctx, "conversations.info", values)
 	if err != nil {

--- a/conversation.go
+++ b/conversation.go
@@ -5,6 +5,8 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // Conversation is the foundation for IM and BaseGroupConversation
@@ -372,7 +374,11 @@ func (api *Client) GetConversationInfo(input *GetConversationInfoInput) (*Channe
 // GetConversationInfoContext retrieves information about a conversation with a custom context
 func (api *Client) GetConversationInfoContext(ctx context.Context, input *GetConversationInfoInput) (*Channel, error) {
 	if input == nil {
-		input = &GetConversationInfoInput{}
+		return nil, errors.New("GetConversationInfoInput must not be nil")
+	}
+
+	if input.ChannelID == "" {
+		return nil, errors.New("ChannelID must be defined")
 	}
 
 	values := url.Values{

--- a/conversation.go
+++ b/conversation.go
@@ -2,11 +2,10 @@ package slack
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // Conversation is the foundation for IM and BaseGroupConversation

--- a/conversation_test.go
+++ b/conversation_test.go
@@ -400,7 +400,7 @@ func TestGetConversationInfo(t *testing.T) {
 	http.HandleFunc("/conversations.info", okChannelJsonHandler)
 	once.Do(startServer)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
-	channel, err := api.GetConversationInfo("CXXXXXXXX", false)
+	channel, err := api.GetConversationInfo("CXXXXXXXX", false, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 		return

--- a/conversation_test.go
+++ b/conversation_test.go
@@ -400,7 +400,9 @@ func TestGetConversationInfo(t *testing.T) {
 	http.HandleFunc("/conversations.info", okChannelJsonHandler)
 	once.Do(startServer)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
-	channel, err := api.GetConversationInfo("CXXXXXXXX", false, false)
+	channel, err := api.GetConversationInfo(&GetConversationInfoInput{
+		ChannelID: "CXXXXXXXX",
+	})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 		return

--- a/conversation_test.go
+++ b/conversation_test.go
@@ -411,24 +411,18 @@ func TestGetConversationInfo(t *testing.T) {
 		t.Error("channel should not be nil")
 		return
 	}
-}
 
-func TestGetConversationInfoNilError(t *testing.T) {
-	http.HandleFunc("/conversations.info", okChannelJsonHandler)
-	once.Do(startServer)
-	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
-	_, err := api.GetConversationInfo(nil)
+	// Nil Input Error
+	api = New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
+	_, err = api.GetConversationInfo(nil)
 	if err == nil {
 		t.Errorf("Unexpected pass where there should have been nil input error")
 		return
 	}
-}
 
-func TestGetConversationInfoMissingChannelError(t *testing.T) {
-	http.HandleFunc("/conversations.info", okChannelJsonHandler)
-	once.Do(startServer)
-	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
-	_, err := api.GetConversationInfo(&GetConversationInfoInput{})
+	// No Channel Error
+	api = New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
+	_, err = api.GetConversationInfo(&GetConversationInfoInput{})
 	if err == nil {
 		t.Errorf("Unexpected pass where there should have been missing channel error")
 		return

--- a/conversation_test.go
+++ b/conversation_test.go
@@ -413,6 +413,28 @@ func TestGetConversationInfo(t *testing.T) {
 	}
 }
 
+func TestGetConversationInfoNilError(t *testing.T) {
+	http.HandleFunc("/conversations.info", okChannelJsonHandler)
+	once.Do(startServer)
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
+	_, err := api.GetConversationInfo(nil)
+	if err == nil {
+		t.Errorf("Unexpected pass where there should have been nil input error")
+		return
+	}
+}
+
+func TestGetConversationInfoMissingChannelError(t *testing.T) {
+	http.HandleFunc("/conversations.info", okChannelJsonHandler)
+	once.Do(startServer)
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
+	_, err := api.GetConversationInfo(&GetConversationInfoInput{})
+	if err == nil {
+		t.Errorf("Unexpected pass where there should have been missing channel error")
+		return
+	}
+}
+
 func leaveConversationHandler(rw http.ResponseWriter, r *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
 	response, _ := json.Marshal(struct {


### PR DESCRIPTION
Add [include_num_members](https://api.slack.com/methods/conversations.info#arg_include_num_members) support to [conversation.info](https://api.slack.com/methods/conversations.info) request

