### PR TITLE
remove token from url parameters

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -9,7 +9,7 @@ import (
 
 func (api *Client) adminRequest(ctx context.Context, method string, teamName string, values url.Values) error {
 	resp := &SlackResponse{}
-	err := parseAdminResponse(ctx, api.httpclient, method, teamName, values, resp, api)
+	err := parseAdminResponse(ctx, api.httpclient, method, teamName, api.token, values, resp, api)
 	if err != nil {
 		return err
 	}

--- a/auth.go
+++ b/auth.go
@@ -14,7 +14,7 @@ type AuthRevokeResponse struct {
 // authRequest sends the actual request, and unmarshals the response
 func (api *Client) authRequest(ctx context.Context, path string, values url.Values) (*AuthRevokeResponse, error) {
 	response := &AuthRevokeResponse{}
-	err := api.postMethod(ctx, path, values, response)
+	err := api.postMethod(ctx, path, api.token, values, response)
 	if err != nil {
 		return nil, err
 	}

--- a/bots.go
+++ b/bots.go
@@ -21,9 +21,9 @@ type botResponseFull struct {
 	SlackResponse
 }
 
-func (api *Client) botRequest(ctx context.Context, path string, values url.Values) (*botResponseFull, error) {
+func (api *Client) botRequest(ctx context.Context, path, token string, values url.Values) (*botResponseFull, error) {
 	response := &botResponseFull{}
-	err := api.postMethod(ctx, path, values, response)
+	err := api.postMethod(ctx, path, token, values, response)
 	if err != nil {
 		return nil, err
 	}
@@ -42,15 +42,13 @@ func (api *Client) GetBotInfo(bot string) (*Bot, error) {
 
 // GetBotInfoContext will retrieve the complete bot information using a custom context
 func (api *Client) GetBotInfoContext(ctx context.Context, bot string) (*Bot, error) {
-	values := url.Values{
-		"token": {api.token},
-	}
+	values := url.Values{}
 
 	if bot != "" {
 		values.Add("bot", bot)
 	}
 
-	response, err := api.botRequest(ctx, "bots.info", values)
+	response, err := api.botRequest(ctx, "bots.info", api.token, values)
 	if err != nil {
 		return nil, err
 	}

--- a/channels.go
+++ b/channels.go
@@ -27,7 +27,7 @@ type Channel struct {
 
 func (api *Client) channelRequest(ctx context.Context, path string, values url.Values) (*channelResponseFull, error) {
 	response := &channelResponseFull{}
-	err := postForm(ctx, api.httpclient, api.endpoint+path, values, response, api)
+	err := postForm(ctx, api.httpclient, api.endpoint+path, api.token, values, response, api)
 	if err != nil {
 		return nil, err
 	}

--- a/chat.go
+++ b/chat.go
@@ -780,9 +780,7 @@ func (api *Client) GetScheduledMessages(params *GetScheduledMessagesParameters) 
 
 // GetScheduledMessagesContext returns the list of scheduled messages in a Slack team with a custom context
 func (api *Client) GetScheduledMessagesContext(ctx context.Context, params *GetScheduledMessagesParameters) (channels []ScheduledMessage, nextCursor string, err error) {
-	values := url.Values{
-		"token": {api.token},
-	}
+	values := url.Values{}
 	if params.Channel != "" {
 		values.Add("channel", params.Channel)
 	}
@@ -804,7 +802,7 @@ func (api *Client) GetScheduledMessagesContext(ctx context.Context, params *GetS
 		SlackResponse
 	}{}
 
-	err = api.postMethod(ctx, "chat.scheduledMessages.list", values, &response)
+	err = api.postMethod(ctx, "chat.scheduledMessages.list", api.token, values, &response)
 	if err != nil {
 		return nil, "", err
 	}
@@ -826,7 +824,6 @@ func (api *Client) DeleteScheduledMessage(params *DeleteScheduledMessageParamete
 // DeleteScheduledMessageContext returns the list of scheduled messages in a Slack team with a custom context
 func (api *Client) DeleteScheduledMessageContext(ctx context.Context, params *DeleteScheduledMessageParameters) (bool, error) {
 	values := url.Values{
-		"token":                {api.token},
 		"channel":              {params.Channel},
 		"scheduled_message_id": {params.ScheduledMessageID},
 		"as_user":              {strconv.FormatBool(params.AsUser)},
@@ -835,7 +832,7 @@ func (api *Client) DeleteScheduledMessageContext(ctx context.Context, params *De
 		SlackResponse
 	}{}
 
-	err := api.postMethod(ctx, "chat.deleteScheduledMessage", values, &response)
+	err := api.postMethod(ctx, "chat.deleteScheduledMessage", api.token, values, &response)
 	if err != nil {
 		return false, err
 	}

--- a/conversation.go
+++ b/conversation.go
@@ -85,7 +85,6 @@ func (api *Client) GetUsersInConversation(params *GetUsersInConversationParamete
 // GetUsersInConversationContext returns the list of users in a conversation with a custom context
 func (api *Client) GetUsersInConversationContext(ctx context.Context, params *GetUsersInConversationParameters) ([]string, string, error) {
 	values := url.Values{
-		"token":   {api.token},
 		"channel": {params.ChannelID},
 	}
 	if params.Cursor != "" {
@@ -100,7 +99,7 @@ func (api *Client) GetUsersInConversationContext(ctx context.Context, params *Ge
 		SlackResponse
 	}{}
 
-	err := api.postMethod(ctx, "conversations.members", values, &response)
+	err := api.postMethod(ctx, "conversations.members", api.token, values, &response)
 	if err != nil {
 		return nil, "", err
 	}
@@ -119,9 +118,7 @@ func (api *Client) GetConversationsForUser(params *GetConversationsForUserParame
 
 // GetConversationsForUserContext returns the list conversations for a given user with a custom context
 func (api *Client) GetConversationsForUserContext(ctx context.Context, params *GetConversationsForUserParameters) (channels []Channel, nextCursor string, err error) {
-	values := url.Values{
-		"token": {api.token},
-	}
+	values := url.Values{}
 	if params.UserID != "" {
 		values.Add("user", params.UserID)
 	}
@@ -142,7 +139,7 @@ func (api *Client) GetConversationsForUserContext(ctx context.Context, params *G
 		ResponseMetaData responseMetaData `json:"response_metadata"`
 		SlackResponse
 	}{}
-	err = api.postMethod(ctx, "users.conversations", values, &response)
+	err = api.postMethod(ctx, "users.conversations", api.token, values, &response)
 	if err != nil {
 		return nil, "", err
 	}
@@ -158,12 +155,11 @@ func (api *Client) ArchiveConversation(channelID string) error {
 // ArchiveConversationContext archives a conversation with a custom context
 func (api *Client) ArchiveConversationContext(ctx context.Context, channelID string) error {
 	values := url.Values{
-		"token":   {api.token},
 		"channel": {channelID},
 	}
 
 	response := SlackResponse{}
-	err := api.postMethod(ctx, "conversations.archive", values, &response)
+	err := api.postMethod(ctx, "conversations.archive", api.token, values, &response)
 	if err != nil {
 		return err
 	}
@@ -179,11 +175,10 @@ func (api *Client) UnArchiveConversation(channelID string) error {
 // UnArchiveConversationContext reverses conversation archival with a custom context
 func (api *Client) UnArchiveConversationContext(ctx context.Context, channelID string) error {
 	values := url.Values{
-		"token":   {api.token},
 		"channel": {channelID},
 	}
 	response := SlackResponse{}
-	err := api.postMethod(ctx, "conversations.unarchive", values, &response)
+	err := api.postMethod(ctx, "conversations.unarchive", api.token, values, &response)
 	if err != nil {
 		return err
 	}
@@ -199,7 +194,6 @@ func (api *Client) SetTopicOfConversation(channelID, topic string) (*Channel, er
 // SetTopicOfConversationContext sets the topic for a conversation with a custom context
 func (api *Client) SetTopicOfConversationContext(ctx context.Context, channelID, topic string) (*Channel, error) {
 	values := url.Values{
-		"token":   {api.token},
 		"channel": {channelID},
 		"topic":   {topic},
 	}
@@ -207,7 +201,7 @@ func (api *Client) SetTopicOfConversationContext(ctx context.Context, channelID,
 		SlackResponse
 		Channel *Channel `json:"channel"`
 	}{}
-	err := api.postMethod(ctx, "conversations.setTopic", values, &response)
+	err := api.postMethod(ctx, "conversations.setTopic", api.token, values, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +217,6 @@ func (api *Client) SetPurposeOfConversation(channelID, purpose string) (*Channel
 // SetPurposeOfConversationContext sets the purpose for a conversation with a custom context
 func (api *Client) SetPurposeOfConversationContext(ctx context.Context, channelID, purpose string) (*Channel, error) {
 	values := url.Values{
-		"token":   {api.token},
 		"channel": {channelID},
 		"purpose": {purpose},
 	}
@@ -232,7 +225,7 @@ func (api *Client) SetPurposeOfConversationContext(ctx context.Context, channelI
 		Channel *Channel `json:"channel"`
 	}{}
 
-	err := api.postMethod(ctx, "conversations.setPurpose", values, &response)
+	err := api.postMethod(ctx, "conversations.setPurpose", api.token, values, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +241,6 @@ func (api *Client) RenameConversation(channelID, channelName string) (*Channel, 
 // RenameConversationContext renames a conversation with a custom context
 func (api *Client) RenameConversationContext(ctx context.Context, channelID, channelName string) (*Channel, error) {
 	values := url.Values{
-		"token":   {api.token},
 		"channel": {channelID},
 		"name":    {channelName},
 	}
@@ -257,7 +249,7 @@ func (api *Client) RenameConversationContext(ctx context.Context, channelID, cha
 		Channel *Channel `json:"channel"`
 	}{}
 
-	err := api.postMethod(ctx, "conversations.rename", values, &response)
+	err := api.postMethod(ctx, "conversations.rename", api.token, values, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +265,6 @@ func (api *Client) InviteUsersToConversation(channelID string, users ...string) 
 // InviteUsersToConversationContext invites users to a channel with a custom context
 func (api *Client) InviteUsersToConversationContext(ctx context.Context, channelID string, users ...string) (*Channel, error) {
 	values := url.Values{
-		"token":   {api.token},
 		"channel": {channelID},
 		"users":   {strings.Join(users, ",")},
 	}
@@ -282,7 +273,7 @@ func (api *Client) InviteUsersToConversationContext(ctx context.Context, channel
 		Channel *Channel `json:"channel"`
 	}{}
 
-	err := api.postMethod(ctx, "conversations.invite", values, &response)
+	err := api.postMethod(ctx, "conversations.invite", api.token, values, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -298,13 +289,12 @@ func (api *Client) KickUserFromConversation(channelID string, user string) error
 // KickUserFromConversationContext removes a user from a conversation with a custom context
 func (api *Client) KickUserFromConversationContext(ctx context.Context, channelID string, user string) error {
 	values := url.Values{
-		"token":   {api.token},
 		"channel": {channelID},
 		"user":    {user},
 	}
 
 	response := SlackResponse{}
-	err := api.postMethod(ctx, "conversations.kick", values, &response)
+	err := api.postMethod(ctx, "conversations.kick", api.token, values, &response)
 	if err != nil {
 		return err
 	}
@@ -320,7 +310,6 @@ func (api *Client) CloseConversation(channelID string) (noOp bool, alreadyClosed
 // CloseConversationContext closes a direct message or multi-person direct message with a custom context
 func (api *Client) CloseConversationContext(ctx context.Context, channelID string) (noOp bool, alreadyClosed bool, err error) {
 	values := url.Values{
-		"token":   {api.token},
 		"channel": {channelID},
 	}
 	response := struct {
@@ -329,7 +318,7 @@ func (api *Client) CloseConversationContext(ctx context.Context, channelID strin
 		AlreadyClosed bool `json:"already_closed"`
 	}{}
 
-	err = api.postMethod(ctx, "conversations.close", values, &response)
+	err = api.postMethod(ctx, "conversations.close", api.token, values, &response)
 	if err != nil {
 		return false, false, err
 	}
@@ -415,7 +404,6 @@ func (api *Client) GetConversationReplies(params *GetConversationRepliesParamete
 // GetConversationRepliesContext retrieves a thread of messages posted to a conversation with a custom context
 func (api *Client) GetConversationRepliesContext(ctx context.Context, params *GetConversationRepliesParameters) (msgs []Message, hasMore bool, nextCursor string, err error) {
 	values := url.Values{
-		"token":   {api.token},
 		"channel": {params.ChannelID},
 		"ts":      {params.Timestamp},
 	}
@@ -445,7 +433,7 @@ func (api *Client) GetConversationRepliesContext(ctx context.Context, params *Ge
 		Messages []Message `json:"messages"`
 	}{}
 
-	err = api.postMethod(ctx, "conversations.replies", values, &response)
+	err = api.postMethod(ctx, "conversations.replies", api.token, values, &response)
 	if err != nil {
 		return nil, false, "", err
 	}
@@ -468,9 +456,7 @@ func (api *Client) GetConversations(params *GetConversationsParameters) (channel
 
 // GetConversationsContext returns the list of channels in a Slack team with a custom context
 func (api *Client) GetConversationsContext(ctx context.Context, params *GetConversationsParameters) (channels []Channel, nextCursor string, err error) {
-	values := url.Values{
-		"token": {api.token},
-	}
+	values := url.Values{}
 	if params.Cursor != "" {
 		values.Add("cursor", params.Cursor)
 	}
@@ -493,7 +479,7 @@ func (api *Client) GetConversationsContext(ctx context.Context, params *GetConve
 		SlackResponse
 	}{}
 
-	err = api.postMethod(ctx, "conversations.list", values, &response)
+	err = api.postMethod(ctx, "conversations.list", api.token, values, &response)
 	if err != nil {
 		return nil, "", err
 	}
@@ -515,7 +501,6 @@ func (api *Client) OpenConversation(params *OpenConversationParameters) (*Channe
 // OpenConversationContext opens or resumes a direct message or multi-person direct message with a custom context
 func (api *Client) OpenConversationContext(ctx context.Context, params *OpenConversationParameters) (*Channel, bool, bool, error) {
 	values := url.Values{
-		"token":     {api.token},
 		"return_im": {strconv.FormatBool(params.ReturnIM)},
 	}
 	if params.ChannelID != "" {
@@ -531,7 +516,7 @@ func (api *Client) OpenConversationContext(ctx context.Context, params *OpenConv
 		SlackResponse
 	}{}
 
-	err := api.postMethod(ctx, "conversations.open", values, &response)
+	err := api.postMethod(ctx, "conversations.open", api.token, values, &response)
 	if err != nil {
 		return nil, false, false, err
 	}
@@ -546,7 +531,7 @@ func (api *Client) JoinConversation(channelID string) (*Channel, string, []strin
 
 // JoinConversationContext joins an existing conversation with a custom context
 func (api *Client) JoinConversationContext(ctx context.Context, channelID string) (*Channel, string, []string, error) {
-	values := url.Values{"token": {api.token}, "channel": {channelID}}
+	values := url.Values{"channel": {channelID}}
 	response := struct {
 		Channel          *Channel `json:"channel"`
 		Warning          string   `json:"warning"`
@@ -556,7 +541,7 @@ func (api *Client) JoinConversationContext(ctx context.Context, channelID string
 		SlackResponse
 	}{}
 
-	err := api.postMethod(ctx, "conversations.join", values, &response)
+	err := api.postMethod(ctx, "conversations.join", api.token, values, &response)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -597,7 +582,7 @@ func (api *Client) GetConversationHistory(params *GetConversationHistoryParamete
 
 // GetConversationHistoryContext joins an existing conversation with a custom context
 func (api *Client) GetConversationHistoryContext(ctx context.Context, params *GetConversationHistoryParameters) (*GetConversationHistoryResponse, error) {
-	values := url.Values{"token": {api.token}, "channel": {params.ChannelID}}
+	values := url.Values{"channel": {params.ChannelID}}
 	if params.Cursor != "" {
 		values.Add("cursor", params.Cursor)
 	}
@@ -618,7 +603,7 @@ func (api *Client) GetConversationHistoryContext(ctx context.Context, params *Ge
 
 	response := GetConversationHistoryResponse{}
 
-	err := api.postMethod(ctx, "conversations.history", values, &response)
+	err := api.postMethod(ctx, "conversations.history", api.token, values, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -634,14 +619,13 @@ func (api *Client) MarkConversation(channel, ts string) (err error) {
 // MarkConversationContext sets the read mark of a conversation to a specific point with a custom context
 func (api *Client) MarkConversationContext(ctx context.Context, channel, ts string) error {
 	values := url.Values{
-		"token":   {api.token},
 		"channel": {channel},
 		"ts":      {ts},
 	}
 
 	response := &SlackResponse{}
 
-	err := api.postMethod(ctx, "conversations.mark", values, response)
+	err := api.postMethod(ctx, "conversations.mark", api.token, values, response)
 	if err != nil {
 		return err
 	}

--- a/dnd.go
+++ b/dnd.go
@@ -37,7 +37,7 @@ type dndTeamInfoResponse struct {
 
 func (api *Client) dndRequest(ctx context.Context, path string, values url.Values) (*dndResponseFull, error) {
 	response := &dndResponseFull{}
-	err := api.postMethod(ctx, path, values, response)
+	err := api.postMethod(ctx, path, api.token, values, response)
 	if err != nil {
 		return nil, err
 	}
@@ -52,13 +52,11 @@ func (api *Client) EndDND() error {
 
 // EndDNDContext ends the user's scheduled Do Not Disturb session with a custom context
 func (api *Client) EndDNDContext(ctx context.Context) error {
-	values := url.Values{
-		"token": {api.token},
-	}
+	values := url.Values{}
 
 	response := &SlackResponse{}
 
-	if err := api.postMethod(ctx, "dnd.endDnd", values, response); err != nil {
+	if err := api.postMethod(ctx, "dnd.endDnd", api.token, values, response); err != nil {
 		return err
 	}
 
@@ -112,12 +110,11 @@ func (api *Client) GetDNDTeamInfo(users []string) (map[string]DNDStatus, error) 
 // GetDNDTeamInfoContext provides information about a user's current Do Not Disturb settings with a custom context.
 func (api *Client) GetDNDTeamInfoContext(ctx context.Context, users []string) (map[string]DNDStatus, error) {
 	values := url.Values{
-		"token": {api.token},
 		"users": {strings.Join(users, ",")},
 	}
 	response := &dndTeamInfoResponse{}
 
-	if err := api.postMethod(ctx, "dnd.teamInfo", values, response); err != nil {
+	if err := api.postMethod(ctx, "dnd.teamInfo", api.token, values, response); err != nil {
 		return nil, err
 	}
 

--- a/emoji.go
+++ b/emoji.go
@@ -17,12 +17,10 @@ func (api *Client) GetEmoji() (map[string]string, error) {
 
 // GetEmojiContext retrieves all the emojis with a custom context
 func (api *Client) GetEmojiContext(ctx context.Context) (map[string]string, error) {
-	values := url.Values{
-		"token": {api.token},
-	}
+	values := url.Values{}
 	response := &emojiResponseFull{}
 
-	err := api.postMethod(ctx, "emoji.list", values, response)
+	err := api.postMethod(ctx, "emoji.list", api.token, values, response)
 	if err != nil {
 		return nil, err
 	}

--- a/files.go
+++ b/files.go
@@ -171,7 +171,7 @@ func NewGetFilesParameters() GetFilesParameters {
 
 func (api *Client) fileRequest(ctx context.Context, path string, values url.Values) (*fileResponseFull, error) {
 	response := &fileResponseFull{}
-	err := api.postMethod(ctx, path, values, response)
+	err := api.postMethod(ctx, path, api.token, values, response)
 	if err != nil {
 		return nil, err
 	}
@@ -316,8 +316,7 @@ func (api *Client) UploadFileContext(ctx context.Context, params FileUploadParam
 	}
 	if params.Content != "" {
 		values.Add("content", params.Content)
-		values.Add("token", api.token)
-		err = api.postMethod(ctx, "files.upload", values, response)
+		err = api.postMethod(ctx, "files.upload", api.token, values, response)
 	} else if params.File != "" {
 		err = postLocalWithMultipartResponse(ctx, api.httpclient, api.endpoint+"files.upload", params.File, "file", api.token, values, response, api)
 	} else if params.Reader != nil {

--- a/info.go
+++ b/info.go
@@ -343,10 +343,10 @@ func (api *Client) MuteChat(channelID string) (*UserPrefsCarrier, error) {
 		}
 	}
 	newChnls := prefs.UserPrefs.MutedChannels + "," + channelID
-	values := url.Values{"token": {api.token}, "muted_channels": {newChnls}, "reason": {"update-muted-channels"}}
+	values := url.Values{"muted_channels": {newChnls}, "reason": {"update-muted-channels"}}
 	response := UserPrefsCarrier{}
 
-	err = api.postMethod(context.Background(), "users.prefs.set", values, &response)
+	err = api.postMethod(context.Background(), "users.prefs.set", api.token, values, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -367,10 +367,10 @@ func (api *Client) UnMuteChat(channelID string) (*UserPrefsCarrier, error) {
 		}
 		newChnls[i] = chn
 	}
-	values := url.Values{"token": {api.token}, "muted_channels": {strings.Join(newChnls, ",")}, "reason": {"update-muted-channels"}}
+	values := url.Values{"muted_channels": {strings.Join(newChnls, ",")}, "reason": {"update-muted-channels"}}
 	response := UserPrefsCarrier{}
 
-	err = api.postMethod(context.Background(), "users.prefs.set", values, &response)
+	err = api.postMethod(context.Background(), "users.prefs.set", api.token, values, &response)
 	if err != nil {
 		return nil, err
 	}

--- a/misc.go
+++ b/misc.go
@@ -235,13 +235,14 @@ func postJSON(ctx context.Context, client httpClient, endpoint, token string, js
 }
 
 // post a url encoded form.
-func postForm(ctx context.Context, client httpClient, endpoint string, values url.Values, intf interface{}, d Debug) error {
+func postForm(ctx context.Context, client httpClient, endpoint, token string, values url.Values, intf interface{}, d Debug) error {
 	reqBody := strings.NewReader(values.Encode())
 	req, err := http.NewRequest("POST", endpoint, reqBody)
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	return doPost(ctx, client, req, newJSONParser(intf), d)
 }
 
@@ -258,9 +259,9 @@ func getResource(ctx context.Context, client httpClient, endpoint, token string,
 	return doPost(ctx, client, req, newJSONParser(intf), d)
 }
 
-func parseAdminResponse(ctx context.Context, client httpClient, method string, teamName string, values url.Values, intf interface{}, d Debug) error {
+func parseAdminResponse(ctx context.Context, client httpClient, method, teamName, token string, values url.Values, intf interface{}, d Debug) error {
 	endpoint := fmt.Sprintf(WEBAPIURLFormat, teamName, method, time.Now().Unix())
-	return postForm(ctx, client, endpoint, values, intf, d)
+	return postForm(ctx, client, endpoint, token, values, intf, d)
 }
 
 func logResponse(resp *http.Response, d Debug) error {

--- a/misc_test.go
+++ b/misc_test.go
@@ -41,12 +41,10 @@ func TestParseResponse(t *testing.T) {
 	parseResponseOnce.Do(setParseResponseHandler)
 	once.Do(startServer)
 	APIURL := "http://" + serverAddr + "/"
-	values := url.Values{
-		"token": {validToken},
-	}
+	values := url.Values{}
 
 	responsePartial := &SlackResponse{}
-	err := postForm(context.Background(), http.DefaultClient, APIURL+"parseResponse", values, responsePartial, discard{})
+	err := postForm(context.Background(), http.DefaultClient, APIURL+"parseResponse", validToken, values, responsePartial, discard{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -59,7 +57,7 @@ func TestParseResponseNoToken(t *testing.T) {
 	values := url.Values{}
 
 	responsePartial := &SlackResponse{}
-	err := postForm(context.Background(), http.DefaultClient, APIURL+"parseResponse", values, responsePartial, discard{})
+	err := postForm(context.Background(), http.DefaultClient, APIURL+"parseResponse", validToken, values, responsePartial, discard{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 		return
@@ -75,11 +73,10 @@ func TestParseResponseInvalidToken(t *testing.T) {
 	parseResponseOnce.Do(setParseResponseHandler)
 	once.Do(startServer)
 	APIURL := "http://" + serverAddr + "/"
-	values := url.Values{
-		"token": {"whatever"},
-	}
+	values := url.Values{}
+	token := "whatever"
 	responsePartial := &SlackResponse{}
-	err := postForm(context.Background(), http.DefaultClient, APIURL+"parseResponse", values, responsePartial, discard{})
+	err := postForm(context.Background(), http.DefaultClient, APIURL+"parseResponse", token, values, responsePartial, discard{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 		return

--- a/oauth.go
+++ b/oauth.go
@@ -109,7 +109,7 @@ func GetOAuthResponseContext(ctx context.Context, client httpClient, clientID, c
 		"redirect_uri":  {redirectURI},
 	}
 	response := &OAuthResponse{}
-	if err = postForm(ctx, client, APIURL+"oauth.access", values, response, discard{}); err != nil {
+	if err = postForm(ctx, client, APIURL+"oauth.access", "", values, response, discard{}); err != nil {
 		return nil, err
 	}
 	return response, response.Err()
@@ -129,7 +129,7 @@ func GetOAuthV2ResponseContext(ctx context.Context, client httpClient, clientID,
 		"redirect_uri":  {redirectURI},
 	}
 	response := &OAuthV2Response{}
-	if err = postForm(ctx, client, APIURL+"oauth.v2.access", values, response, discard{}); err != nil {
+	if err = postForm(ctx, client, APIURL+"oauth.v2.access", "", values, response, discard{}); err != nil {
 		return nil, err
 	}
 	return response, response.Err()
@@ -149,7 +149,7 @@ func RefreshOAuthV2TokenContext(ctx context.Context, client httpClient, clientID
 		"grant_type":    {"refresh_token"},
 	}
 	response := &OAuthV2Response{}
-	if err = postForm(ctx, client, APIURL+"oauth.v2.access", values, response, discard{}); err != nil {
+	if err = postForm(ctx, client, APIURL+"oauth.v2.access", "", values, response, discard{}); err != nil {
 		return nil, err
 	}
 	return response, response.Err()

--- a/pins.go
+++ b/pins.go
@@ -21,7 +21,6 @@ func (api *Client) AddPin(channel string, item ItemRef) error {
 func (api *Client) AddPinContext(ctx context.Context, channel string, item ItemRef) error {
 	values := url.Values{
 		"channel": {channel},
-		"token":   {api.token},
 	}
 	if item.Timestamp != "" {
 		values.Set("timestamp", item.Timestamp)
@@ -34,7 +33,7 @@ func (api *Client) AddPinContext(ctx context.Context, channel string, item ItemR
 	}
 
 	response := &SlackResponse{}
-	if err := api.postMethod(ctx, "pins.add", values, response); err != nil {
+	if err := api.postMethod(ctx, "pins.add", api.token, values, response); err != nil {
 		return err
 	}
 
@@ -50,7 +49,6 @@ func (api *Client) RemovePin(channel string, item ItemRef) error {
 func (api *Client) RemovePinContext(ctx context.Context, channel string, item ItemRef) error {
 	values := url.Values{
 		"channel": {channel},
-		"token":   {api.token},
 	}
 	if item.Timestamp != "" {
 		values.Set("timestamp", item.Timestamp)
@@ -63,7 +61,7 @@ func (api *Client) RemovePinContext(ctx context.Context, channel string, item It
 	}
 
 	response := &SlackResponse{}
-	if err := api.postMethod(ctx, "pins.remove", values, response); err != nil {
+	if err := api.postMethod(ctx, "pins.remove", api.token, values, response); err != nil {
 		return err
 	}
 
@@ -79,11 +77,10 @@ func (api *Client) ListPins(channel string) ([]Item, *Paging, error) {
 func (api *Client) ListPinsContext(ctx context.Context, channel string) ([]Item, *Paging, error) {
 	values := url.Values{
 		"channel": {channel},
-		"token":   {api.token},
 	}
 
 	response := &listPinsResponseFull{}
-	err := api.postMethod(ctx, "pins.list", values, response)
+	err := api.postMethod(ctx, "pins.list", api.token, values, response)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/reactions.go
+++ b/reactions.go
@@ -134,9 +134,7 @@ func (api *Client) AddReaction(name string, item ItemRef) error {
 
 // AddReactionContext adds a reaction emoji to a message, file or file comment with a custom context.
 func (api *Client) AddReactionContext(ctx context.Context, name string, item ItemRef) error {
-	values := url.Values{
-		"token": {api.token},
-	}
+	values := url.Values{}
 	if name != "" {
 		values.Set("name", name)
 	}
@@ -154,7 +152,7 @@ func (api *Client) AddReactionContext(ctx context.Context, name string, item Ite
 	}
 
 	response := &SlackResponse{}
-	if err := api.postMethod(ctx, "reactions.add", values, response); err != nil {
+	if err := api.postMethod(ctx, "reactions.add", api.token, values, response); err != nil {
 		return err
 	}
 
@@ -168,9 +166,7 @@ func (api *Client) RemoveReaction(name string, item ItemRef) error {
 
 // RemoveReactionContext removes a reaction emoji from a message, file or file comment with a custom context.
 func (api *Client) RemoveReactionContext(ctx context.Context, name string, item ItemRef) error {
-	values := url.Values{
-		"token": {api.token},
-	}
+	values := url.Values{}
 	if name != "" {
 		values.Set("name", name)
 	}
@@ -188,7 +184,7 @@ func (api *Client) RemoveReactionContext(ctx context.Context, name string, item 
 	}
 
 	response := &SlackResponse{}
-	if err := api.postMethod(ctx, "reactions.remove", values, response); err != nil {
+	if err := api.postMethod(ctx, "reactions.remove", api.token, values, response); err != nil {
 		return err
 	}
 
@@ -202,9 +198,7 @@ func (api *Client) GetReactions(item ItemRef, params GetReactionsParameters) ([]
 
 // GetReactionsContext returns details about the reactions on an item with a custom context
 func (api *Client) GetReactionsContext(ctx context.Context, item ItemRef, params GetReactionsParameters) ([]ItemReaction, error) {
-	values := url.Values{
-		"token": {api.token},
-	}
+	values := url.Values{}
 	if item.Channel != "" {
 		values.Set("channel", item.Channel)
 	}
@@ -222,7 +216,7 @@ func (api *Client) GetReactionsContext(ctx context.Context, item ItemRef, params
 	}
 
 	response := &getReactionsResponseFull{}
-	if err := api.postMethod(ctx, "reactions.get", values, response); err != nil {
+	if err := api.postMethod(ctx, "reactions.get", api.token, values, response); err != nil {
 		return nil, err
 	}
 
@@ -240,9 +234,7 @@ func (api *Client) ListReactions(params ListReactionsParameters) ([]ReactedItem,
 
 // ListReactionsContext returns information about the items a user reacted to with a custom context.
 func (api *Client) ListReactionsContext(ctx context.Context, params ListReactionsParameters) ([]ReactedItem, *Paging, error) {
-	values := url.Values{
-		"token": {api.token},
-	}
+	values := url.Values{}
 	if params.User != DEFAULT_REACTIONS_USER {
 		values.Add("user", params.User)
 	}
@@ -257,7 +249,7 @@ func (api *Client) ListReactionsContext(ctx context.Context, params ListReaction
 	}
 
 	response := &listReactionsResponseFull{}
-	err := api.postMethod(ctx, "reactions.list", values, response)
+	err := api.postMethod(ctx, "reactions.list", api.token, values, response)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/reminders.go
+++ b/reminders.go
@@ -27,7 +27,7 @@ type remindersResp struct {
 
 func (api *Client) doReminder(ctx context.Context, path string, values url.Values) (*Reminder, error) {
 	response := &reminderResp{}
-	if err := api.postMethod(ctx, path, values, response); err != nil {
+	if err := api.postMethod(ctx, path, api.token, values, response); err != nil {
 		return nil, err
 	}
 	return &response.Reminder, response.Err()
@@ -35,7 +35,7 @@ func (api *Client) doReminder(ctx context.Context, path string, values url.Value
 
 func (api *Client) doReminders(ctx context.Context, path string, values url.Values) ([]*Reminder, error) {
 	response := &remindersResp{}
-	if err := api.postMethod(ctx, path, values, response); err != nil {
+	if err := api.postMethod(ctx, path, api.token, values, response); err != nil {
 		return nil, err
 	}
 
@@ -93,11 +93,10 @@ func (api *Client) AddUserReminder(userID, text, time string) (*Reminder, error)
 // See https://api.slack.com/methods/reminders.delete
 func (api *Client) DeleteReminder(id string) error {
 	values := url.Values{
-		"token":    {api.token},
 		"reminder": {id},
 	}
 	response := &SlackResponse{}
-	if err := api.postMethod(context.Background(), "reminders.delete", values, response); err != nil {
+	if err := api.postMethod(context.Background(), "reminders.delete", api.token, values, response); err != nil {
 		return err
 	}
 	return response.Err()

--- a/rtm.go
+++ b/rtm.go
@@ -37,7 +37,7 @@ func (api *Client) StartRTM() (info *Info, websocketURL string, err error) {
 // To have a fully managed Websocket connection, use `NewRTM`, and call `ManageConnection()` on it.
 func (api *Client) StartRTMContext(ctx context.Context) (info *Info, websocketURL string, err error) {
 	response := &infoResponseFull{}
-	err = api.postMethod(ctx, "rtm.start", url.Values{"token": {api.token}}, response)
+	err = api.postMethod(ctx, "rtm.start", api.token, url.Values{}, response)
 	if err != nil {
 		return nil, "", err
 	}
@@ -62,7 +62,7 @@ func (api *Client) ConnectRTM() (info *Info, websocketURL string, err error) {
 // To have a fully managed Websocket connection, use `NewRTM`, and call `ManageConnection()` on it.
 func (api *Client) ConnectRTMContext(ctx context.Context) (info *Info, websocketURL string, err error) {
 	response := &infoResponseFull{}
-	err = api.postMethod(ctx, "rtm.connect", url.Values{"token": {api.token}}, response)
+	err = api.postMethod(ctx, "rtm.connect", api.token, url.Values{}, response)
 	if err != nil {
 		api.Debugf("Failed to connect to RTM: %s", err)
 		return nil, "", err

--- a/search.go
+++ b/search.go
@@ -90,7 +90,6 @@ func NewSearchParameters() SearchParameters {
 
 func (api *Client) _search(ctx context.Context, path, query string, params SearchParameters, files, messages bool) (response *searchResponseFull, error error) {
 	values := url.Values{
-		"token": {api.token},
 		"query": {query},
 	}
 	if params.Sort != DEFAULT_SEARCH_SORT {
@@ -110,7 +109,7 @@ func (api *Client) _search(ctx context.Context, path, query string, params Searc
 	}
 
 	response = &searchResponseFull{}
-	err := api.postMethod(ctx, path, values, response)
+	err := api.postMethod(ctx, path, api.token, values, response)
 	if err != nil {
 		return nil, err
 	}

--- a/slack.go
+++ b/slack.go
@@ -124,7 +124,7 @@ func (api *Client) AuthTest() (response *AuthTestResponse, error error) {
 func (api *Client) AuthTestContext(ctx context.Context) (response *AuthTestResponse, err error) {
 	api.Debugf("Challenging auth...")
 	responseFull := &authTestResponseFull{}
-	err = api.postMethod(ctx, "auth.test", url.Values{"token": {api.token}}, responseFull)
+	err = api.postMethod(ctx, "auth.test", api.token, url.Values{}, responseFull)
 	if err != nil {
 		return nil, err
 	}
@@ -152,11 +152,11 @@ func (api *Client) Debug() bool {
 }
 
 // post to a slack web method.
-func (api *Client) postMethod(ctx context.Context, path string, values url.Values, intf interface{}) error {
-	return postForm(ctx, api.httpclient, api.endpoint+path, values, intf, api)
+func (api *Client) postMethod(ctx context.Context, path, token string, values url.Values, intf interface{}) error {
+	return postForm(ctx, api.httpclient, api.endpoint+path, token, values, intf, api)
 }
 
 // get a slack web method.
-func (api *Client) getMethod(ctx context.Context, path string, token string, values url.Values, intf interface{}) error {
+func (api *Client) getMethod(ctx context.Context, path, token string, values url.Values, intf interface{}) error {
 	return getResource(ctx, api.httpclient, api.endpoint+path, token, values, intf, api)
 }

--- a/stars.go
+++ b/stars.go
@@ -45,7 +45,6 @@ func (api *Client) AddStar(channel string, item ItemRef) error {
 func (api *Client) AddStarContext(ctx context.Context, channel string, item ItemRef) error {
 	values := url.Values{
 		"channel": {channel},
-		"token":   {api.token},
 	}
 	if item.Timestamp != "" {
 		values.Set("timestamp", item.Timestamp)
@@ -58,7 +57,7 @@ func (api *Client) AddStarContext(ctx context.Context, channel string, item Item
 	}
 
 	response := &SlackResponse{}
-	if err := api.postMethod(ctx, "stars.add", values, response); err != nil {
+	if err := api.postMethod(ctx, "stars.add", api.token, values, response); err != nil {
 		return err
 	}
 
@@ -74,7 +73,6 @@ func (api *Client) RemoveStar(channel string, item ItemRef) error {
 func (api *Client) RemoveStarContext(ctx context.Context, channel string, item ItemRef) error {
 	values := url.Values{
 		"channel": {channel},
-		"token":   {api.token},
 	}
 	if item.Timestamp != "" {
 		values.Set("timestamp", item.Timestamp)
@@ -87,7 +85,7 @@ func (api *Client) RemoveStarContext(ctx context.Context, channel string, item I
 	}
 
 	response := &SlackResponse{}
-	if err := api.postMethod(ctx, "stars.remove", values, response); err != nil {
+	if err := api.postMethod(ctx, "stars.remove", api.token, values, response); err != nil {
 		return err
 	}
 
@@ -101,9 +99,7 @@ func (api *Client) ListStars(params StarsParameters) ([]Item, *Paging, error) {
 
 // ListStarsContext returns information about the stars a user added with a custom context
 func (api *Client) ListStarsContext(ctx context.Context, params StarsParameters) ([]Item, *Paging, error) {
-	values := url.Values{
-		"token": {api.token},
-	}
+	values := url.Values{}
 	if params.User != DEFAULT_STARS_USER {
 		values.Add("user", params.User)
 	}
@@ -115,7 +111,7 @@ func (api *Client) ListStarsContext(ctx context.Context, params StarsParameters)
 	}
 
 	response := &listResponseFull{}
-	err := api.postMethod(ctx, "stars.list", values, response)
+	err := api.postMethod(ctx, "stars.list", api.token, values, response)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -248,11 +244,10 @@ func (t StarredItemPagination) next(ctx context.Context) (_ StarredItemPaginatio
 
 	values := url.Values{
 		"limit":  {strconv.Itoa(t.limit)},
-		"token":  {t.c.token},
 		"cursor": {t.previousResp.Cursor},
 	}
 
-	if err = t.c.postMethod(ctx, "stars.list", values, &resp); err != nil {
+	if err = t.c.postMethod(ctx, "stars.list", t.c.token, values, &resp); err != nil {
 		return t, err
 	}
 

--- a/team.go
+++ b/team.go
@@ -68,7 +68,7 @@ func NewAccessLogParameters() AccessLogParameters {
 
 func (api *Client) teamRequest(ctx context.Context, path string, values url.Values) (*TeamResponse, error) {
 	response := &TeamResponse{}
-	err := api.postMethod(ctx, path, values, response)
+	err := api.postMethod(ctx, path, api.token, values, response)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (api *Client) teamRequest(ctx context.Context, path string, values url.Valu
 
 func (api *Client) billableInfoRequest(ctx context.Context, path string, values url.Values) (map[string]BillingActive, error) {
 	response := &BillableInfoResponse{}
-	err := api.postMethod(ctx, path, values, response)
+	err := api.postMethod(ctx, path, api.token, values, response)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (api *Client) billableInfoRequest(ctx context.Context, path string, values 
 
 func (api *Client) accessLogsRequest(ctx context.Context, path string, values url.Values) (*LoginResponse, error) {
 	response := &LoginResponse{}
-	err := api.postMethod(ctx, path, values, response)
+	err := api.postMethod(ctx, path, api.token, values, response)
 	if err != nil {
 		return nil, err
 	}

--- a/usergroups.go
+++ b/usergroups.go
@@ -42,7 +42,7 @@ type userGroupResponseFull struct {
 
 func (api *Client) userGroupRequest(ctx context.Context, path string, values url.Values) (*userGroupResponseFull, error) {
 	response := &userGroupResponseFull{}
-	err := api.postMethod(ctx, path, values, response)
+	err := api.postMethod(ctx, path, api.token, values, response)
 	if err != nil {
 		return nil, err
 	}

--- a/users.go
+++ b/users.go
@@ -208,7 +208,7 @@ func NewUserSetPhotoParams() UserSetPhotoParams {
 
 func (api *Client) userRequest(ctx context.Context, path string, values url.Values) (*userResponseFull, error) {
 	response := &userResponseFull{}
-	err := api.postMethod(ctx, path, values, response)
+	err := api.postMethod(ctx, path, api.token, values, response)
 	if err != nil {
 		return nil, err
 	}
@@ -444,12 +444,11 @@ func (api *Client) GetUserIdentity() (*UserIdentityResponse, error) {
 
 // GetUserIdentityContext will retrieve user info available per identity scopes with a custom context
 func (api *Client) GetUserIdentityContext(ctx context.Context) (response *UserIdentityResponse, err error) {
-	values := url.Values{
-		"token": {api.token},
-	}
+	values := url.Values{}
+
 	response = &UserIdentityResponse{}
 
-	err = api.postMethod(ctx, "users.identity", values, response)
+	err = api.postMethod(ctx, "users.identity", api.token, values, response)
 	if err != nil {
 		return nil, err
 	}
@@ -498,11 +497,9 @@ func (api *Client) DeleteUserPhoto() error {
 // DeleteUserPhotoContext deletes the current authenticated user's profile image with a custom context
 func (api *Client) DeleteUserPhotoContext(ctx context.Context) (err error) {
 	response := &SlackResponse{}
-	values := url.Values{
-		"token": {api.token},
-	}
+	values := url.Values{}
 
-	err = api.postMethod(ctx, "users.deletePhoto", values, response)
+	err = api.postMethod(ctx, "users.deletePhoto", api.token, values, response)
 	if err != nil {
 		return err
 	}
@@ -532,7 +529,6 @@ func (api *Client) SetUserRealNameContextWithUser(ctx context.Context, user, rea
 	}
 
 	values := url.Values{
-		"token":   {api.token},
 		"profile": {string(profile)},
 	}
 
@@ -542,7 +538,7 @@ func (api *Client) SetUserRealNameContextWithUser(ctx context.Context, user, rea
 	}
 
 	response := &userResponseFull{}
-	if err = api.postMethod(ctx, "users.profile.set", values, response); err != nil {
+	if err = api.postMethod(ctx, "users.profile.set", api.token, values, response); err != nil {
 		return err
 	}
 
@@ -603,7 +599,6 @@ func (api *Client) SetUserCustomStatusContextWithUser(ctx context.Context, user,
 	}
 
 	values := url.Values{
-		"token":   {api.token},
 		"profile": {string(profile)},
 	}
 
@@ -613,7 +608,7 @@ func (api *Client) SetUserCustomStatusContextWithUser(ctx context.Context, user,
 	}
 
 	response := &userResponseFull{}
-	if err = api.postMethod(ctx, "users.profile.set", values, response); err != nil {
+	if err = api.postMethod(ctx, "users.profile.set", api.token, values, response); err != nil {
 		return err
 	}
 
@@ -650,7 +645,7 @@ type getUserProfileResponse struct {
 
 // GetUserProfileContext retrieves a user's profile information with a context.
 func (api *Client) GetUserProfileContext(ctx context.Context, params *GetUserProfileParameters) (*UserProfile, error) {
-	values := url.Values{"token": {api.token}}
+	values := url.Values{}
 
 	if params.UserID != "" {
 		values.Add("user", params.UserID)
@@ -660,7 +655,7 @@ func (api *Client) GetUserProfileContext(ctx context.Context, params *GetUserPro
 	}
 	resp := &getUserProfileResponse{}
 
-	err := api.postMethod(ctx, "users.profile.get", values, &resp)
+	err := api.postMethod(ctx, "users.profile.get", api.token, values, &resp)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR resolves the url which is sent in as parameters for several slack calls. This is a deprecated method as of 2021 from Slack documentation and will result in a failed attempt to call there API. Even if the API is sent in URL params and the token is sent in headers the reply will still fail.