### PR TITLE
fix: Don't add API token as a query string in `users.setPhoto` 

### DIFF
--- a/users.go
+++ b/users.go
@@ -469,9 +469,7 @@ func (api *Client) SetUserPhoto(image string, params UserSetPhotoParams) error {
 // SetUserPhotoContext changes the currently authenticated user's profile image using a custom context
 func (api *Client) SetUserPhotoContext(ctx context.Context, image string, params UserSetPhotoParams) (err error) {
 	response := &SlackResponse{}
-	values := url.Values{
-		"token": {api.token},
-	}
+	values := url.Values{}
 	if params.CropX != DEFAULT_USER_PHOTO_CROP_X {
 		values.Add("crop_x", strconv.Itoa(params.CropX))
 	}

--- a/users_test.go
+++ b/users_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 )
@@ -509,7 +510,8 @@ func setUserPhotoHandler(wantBytes []byte, wantParams UserSetPhotoParams) http.H
 		}
 
 		// Test for expected token
-		if v := r.Form.Get("token"); v != validToken {
+		actualToken := strings.Split(r.Header.Get("Authorization"), "Bearer ")[1]
+		if actualToken != validToken {
 			httpTestErrReply(w, true, fmt.Sprintf("expected multipart form value token=%v", validToken))
 			return
 		}


### PR DESCRIPTION
This PR resolves #992.
It seems return `invalid_auth` error when request's query string contains token even if Authorization header is set in request.

### Refs
- https://api.slack.com/changelog/2020-11-no-more-tokens-in-querystrings-for-newly-created-apps