### PR TITLE
Add support for `cookie` header

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -9,7 +9,7 @@ import (
 
 func (api *Client) adminRequest(ctx context.Context, method string, teamName string, values url.Values) error {
 	resp := &SlackResponse{}
-	err := parseAdminResponse(ctx, api.httpclient, method, teamName, values, resp, api)
+	err := parseAdminResponse(ctx, api.httpclient, method, teamName, values, resp, api, api.cookie)
 	if err != nil {
 		return err
 	}

--- a/apps.go
+++ b/apps.go
@@ -31,7 +31,7 @@ func (api *Client) ListEventAuthorizationsContext(ctx context.Context, eventCont
 		"event_context": eventContext,
 	})
 
-	err := postJSON(ctx, api.httpclient, api.endpoint+"apps.event.authorizations.list", api.appLevelToken, request, &resp, api)
+	err := postJSON(ctx, api.httpclient, api.endpoint+"apps.event.authorizations.list", api.appLevelToken, request, &resp, api, api.cookie)
 
 	if err != nil {
 		return nil, err

--- a/channels.go
+++ b/channels.go
@@ -27,7 +27,7 @@ type Channel struct {
 
 func (api *Client) channelRequest(ctx context.Context, path string, values url.Values) (*channelResponseFull, error) {
 	response := &channelResponseFull{}
-	err := postForm(ctx, api.httpclient, api.endpoint+path, values, response, api)
+	err := postForm(ctx, api.httpclient, api.endpoint+path, values, response, api, api.cookie)
 	if err != nil {
 		return nil, err
 	}

--- a/dialog.go
+++ b/dialog.go
@@ -107,7 +107,7 @@ func (api *Client) OpenDialogContext(ctx context.Context, triggerID string, dial
 
 	response := &DialogOpenResponse{}
 	endpoint := api.endpoint + "dialog.open"
-	if err := postJSON(ctx, api.httpclient, endpoint, api.token, encoded, response, api); err != nil {
+	if err := postJSON(ctx, api.httpclient, endpoint, api.token, encoded, response, api, api.cookie); err != nil {
 		return err
 	}
 

--- a/examples/presence_cookie/presence.go
+++ b/examples/presence_cookie/presence.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/slack-go/slack"
+)
+
+func main() {
+	token := os.Getenv("SLACK_TOKEN")
+	cookie := os.Getenv("SLACK_COOKIE")
+
+	api := slack.NewWithCookie(token, cookie)
+	pres, err := api.GetUserPresence("")
+	if err != nil {
+		fmt.Printf("%s\n", err)
+		return
+	}
+	fmt.Printf("Presence: %s, Online: %t, AutoAway: %t, ManualAway: %t, ConnectionCount: %d, LastActivity: %v\n", pres.Presence, pres.Online, pres.AutoAway, pres.ManualAway, pres.ConnectionCount, pres.LastActivity)
+}

--- a/examples/presence_cookie/presense_rtm.go
+++ b/examples/presence_cookie/presense_rtm.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/slack-go/slack"
+)
+
+func main() {
+	// Build Slack client with proper auth
+	token, ok := os.LookupEnv("SLACK_TOKEN")
+	if !ok {
+		fmt.Println("Missing SLACK_TOKEN in environment")
+		os.Exit(1)
+	}
+	cookie, ok := os.LookupEnv("SLACK_COOKIE")
+	if !ok {
+		fmt.Println("Missing SLACK_COOKIE in environment")
+		os.Exit(1)
+	}
+	api := slack.NewWithCookie(token, cookie)
+
+	// Periodically query for current user presence in the background
+	go func() {
+		for {
+			pres, err := api.GetUserPresence("")
+			if err != nil {
+				fmt.Printf("%s\n", err)
+				continue
+			}
+			fmt.Printf("Presence: %s, Online: %t, AutoAway: %t, ManualAway: %t, ConnectionCount: %d, LastActivity: %v\n", pres.Presence, pres.Online, pres.AutoAway, pres.ManualAway, pres.ConnectionCount, pres.LastActivity)
+			time.Sleep(10 * time.Second)
+		}
+	}()
+
+	// Initiate RTM connection to Slack in the background
+	rtm := api.NewRTM()
+	go rtm.ManageConnection()
+
+	// Handle incoming RTM events
+	for msg := range rtm.IncomingEvents {
+		switch ev := msg.Data.(type) {
+
+		case *slack.ConnectedEvent:
+			fmt.Printf("[ConnectedEvent] Info: %v; ConnectionCount: %d\n", ev.Info, ev.ConnectionCount)
+
+		case *slack.RTMError:
+			fmt.Printf("[RTMError] Error: %s\n", ev.Error())
+
+		case *slack.InvalidAuthEvent:
+			fmt.Printf("[InvalidAuthEvent] Invalid credentials\n")
+			return
+
+		default:
+			// Ignore other events..
+			// fmt.Printf("Unexpected: %v\n", msg.Data)
+		}
+	}
+}

--- a/files.go
+++ b/files.go
@@ -319,12 +319,12 @@ func (api *Client) UploadFileContext(ctx context.Context, params FileUploadParam
 		values.Add("token", api.token)
 		err = api.postMethod(ctx, "files.upload", values, response)
 	} else if params.File != "" {
-		err = postLocalWithMultipartResponse(ctx, api.httpclient, api.endpoint+"files.upload", params.File, "file", api.token, values, response, api)
+		err = postLocalWithMultipartResponse(ctx, api.httpclient, api.endpoint+"files.upload", params.File, "file", api.token, values, response, api, api.cookie)
 	} else if params.Reader != nil {
 		if params.Filename == "" {
 			return nil, fmt.Errorf("files.upload: FileUploadParameters.Filename is mandatory when using FileUploadParameters.Reader")
 		}
-		err = postWithMultipartResponse(ctx, api.httpclient, api.endpoint+"files.upload", params.Filename, "file", api.token, values, params.Reader, response, api)
+		err = postWithMultipartResponse(ctx, api.httpclient, api.endpoint+"files.upload", params.Filename, "file", api.token, values, params.Reader, response, api, api.cookie)
 	}
 
 	if err != nil {

--- a/misc_test.go
+++ b/misc_test.go
@@ -46,7 +46,7 @@ func TestParseResponse(t *testing.T) {
 	}
 
 	responsePartial := &SlackResponse{}
-	err := postForm(context.Background(), http.DefaultClient, APIURL+"parseResponse", values, responsePartial, discard{})
+	err := postForm(context.Background(), http.DefaultClient, APIURL+"parseResponse", values, responsePartial, discard{}, "")
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -59,7 +59,7 @@ func TestParseResponseNoToken(t *testing.T) {
 	values := url.Values{}
 
 	responsePartial := &SlackResponse{}
-	err := postForm(context.Background(), http.DefaultClient, APIURL+"parseResponse", values, responsePartial, discard{})
+	err := postForm(context.Background(), http.DefaultClient, APIURL+"parseResponse", values, responsePartial, discard{}, "")
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 		return
@@ -79,7 +79,7 @@ func TestParseResponseInvalidToken(t *testing.T) {
 		"token": {"whatever"},
 	}
 	responsePartial := &SlackResponse{}
-	err := postForm(context.Background(), http.DefaultClient, APIURL+"parseResponse", values, responsePartial, discard{})
+	err := postForm(context.Background(), http.DefaultClient, APIURL+"parseResponse", values, responsePartial, discard{}, "")
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 		return

--- a/oauth.go
+++ b/oauth.go
@@ -109,7 +109,7 @@ func GetOAuthResponseContext(ctx context.Context, client httpClient, clientID, c
 		"redirect_uri":  {redirectURI},
 	}
 	response := &OAuthResponse{}
-	if err = postForm(ctx, client, APIURL+"oauth.access", values, response, discard{}); err != nil {
+	if err = postForm(ctx, client, APIURL+"oauth.access", values, response, discard{}, ""); err != nil {
 		return nil, err
 	}
 	return response, response.Err()
@@ -129,7 +129,7 @@ func GetOAuthV2ResponseContext(ctx context.Context, client httpClient, clientID,
 		"redirect_uri":  {redirectURI},
 	}
 	response := &OAuthV2Response{}
-	if err = postForm(ctx, client, APIURL+"oauth.v2.access", values, response, discard{}); err != nil {
+	if err = postForm(ctx, client, APIURL+"oauth.v2.access", values, response, discard{}, ""); err != nil {
 		return nil, err
 	}
 	return response, response.Err()
@@ -149,7 +149,7 @@ func RefreshOAuthV2TokenContext(ctx context.Context, client httpClient, clientID
 		"grant_type":    {"refresh_token"},
 	}
 	response := &OAuthV2Response{}
-	if err = postForm(ctx, client, APIURL+"oauth.v2.access", values, response, discard{}); err != nil {
+	if err = postForm(ctx, client, APIURL+"oauth.v2.access", values, response, discard{}, ""); err != nil {
 		return nil, err
 	}
 	return response, response.Err()

--- a/slack.go
+++ b/slack.go
@@ -63,6 +63,7 @@ type Client struct {
 	debug         bool
 	log           ilogger
 	httpclient    httpClient
+	cookie        string
 }
 
 // Option defines an option for a Client
@@ -115,6 +116,12 @@ func New(token string, options ...Option) *Client {
 	return s
 }
 
+func NewWithCookie(token, cookie string, options ...Option) *Client{
+	s := New(token, options...)
+	s.cookie = cookie
+	return s
+}
+
 // AuthTest tests if the user is able to do authenticated requests or not
 func (api *Client) AuthTest() (response *AuthTestResponse, error error) {
 	return api.AuthTestContext(context.Background())
@@ -153,10 +160,10 @@ func (api *Client) Debug() bool {
 
 // post to a slack web method.
 func (api *Client) postMethod(ctx context.Context, path string, values url.Values, intf interface{}) error {
-	return postForm(ctx, api.httpclient, api.endpoint+path, values, intf, api)
+	return postForm(ctx, api.httpclient, api.endpoint+path, values, intf, api, api.cookie)
 }
 
 // get a slack web method.
 func (api *Client) getMethod(ctx context.Context, path string, token string, values url.Values, intf interface{}) error {
-	return getResource(ctx, api.httpclient, api.endpoint+path, token, values, intf, api)
+	return getResource(ctx, api.httpclient, api.endpoint+path, token, values, intf, api, api.cookie)
 }

--- a/socket_mode.go
+++ b/socket_mode.go
@@ -21,7 +21,7 @@ type openResponseFull struct {
 // To have a fully managed Socket Mode connection, use `socketmode.New()`, and call `Run()` on it.
 func (api *Client) StartSocketModeContext(ctx context.Context) (info *SocketModeConnection, websocketURL string, err error) {
 	response := &openResponseFull{}
-	err = postJSON(ctx, api.httpclient, api.endpoint+"apps.connections.open", api.appLevelToken, nil, response, api)
+	err = postJSON(ctx, api.httpclient, api.endpoint+"apps.connections.open", api.appLevelToken, nil, response, api, api.cookie)
 	if err != nil {
 		return nil, "", err
 	}

--- a/users.go
+++ b/users.go
@@ -227,6 +227,9 @@ func (api *Client) GetUserPresenceContext(ctx context.Context, user string) (*Us
 		"token": {api.token},
 		"user":  {user},
 	}
+	if user == "" {
+		values.Del("user")
+	}
 
 	response, err := api.userRequest(ctx, "users.getPresence", values)
 	if err != nil {
@@ -480,7 +483,7 @@ func (api *Client) SetUserPhotoContext(ctx context.Context, image string, params
 		values.Add("crop_w", strconv.Itoa(params.CropW))
 	}
 
-	err = postLocalWithMultipartResponse(ctx, api.httpclient, api.endpoint+"users.setPhoto", image, "image", api.token, values, response, api)
+	err = postLocalWithMultipartResponse(ctx, api.httpclient, api.endpoint+"users.setPhoto", image, "image", api.token, values, response, api, api.cookie)
 	if err != nil {
 		return err
 	}

--- a/views.go
+++ b/views.go
@@ -199,7 +199,7 @@ func (api *Client) OpenViewContext(
 	}
 	endpoint := api.endpoint + "views.open"
 	resp := &ViewResponse{}
-	err = postJSON(ctx, api.httpclient, endpoint, api.token, encoded, resp, api)
+	err = postJSON(ctx, api.httpclient, endpoint, api.token, encoded, resp, api, api.cookie)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +232,7 @@ func (api *Client) PublishViewContext(
 	}
 	endpoint := api.endpoint + "views.publish"
 	resp := &ViewResponse{}
-	err = postJSON(ctx, api.httpclient, endpoint, api.token, encoded, resp, api)
+	err = postJSON(ctx, api.httpclient, endpoint, api.token, encoded, resp, api, api.cookie)
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +263,7 @@ func (api *Client) PushViewContext(
 	}
 	endpoint := api.endpoint + "views.push"
 	resp := &ViewResponse{}
-	err = postJSON(ctx, api.httpclient, endpoint, api.token, encoded, resp, api)
+	err = postJSON(ctx, api.httpclient, endpoint, api.token, encoded, resp, api, api.cookie)
 	if err != nil {
 		return nil, err
 	}
@@ -297,7 +297,7 @@ func (api *Client) UpdateViewContext(
 	}
 	endpoint := api.endpoint + "views.update"
 	resp := &ViewResponse{}
-	err = postJSON(ctx, api.httpclient, endpoint, api.token, encoded, resp, api)
+	err = postJSON(ctx, api.httpclient, endpoint, api.token, encoded, resp, api, api.cookie)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Adds a new constructor called `NewWithCookie`
- Adds a `cookie` propery to the `Client` - this must be in urlencoded form already
- If `cookie` is not an empty string, adds it as an HTTP request header on all actions except OAuth
- (Bug fix) Allows getPresence API to be passed an empty string, implying current user
- Adds example showing a token+cookie being used with getPresence

Implements #996 