### PR TITLE
link_shared `message_ts` field isn't always a number

### DIFF
--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -161,10 +161,13 @@ type GridMigrationStartedEvent struct {
 
 // LinkSharedEvent A message was posted containing one or more links relevant to your application
 type LinkSharedEvent struct {
-	Type             string        `json:"type"`
-	User             string        `json:"user"`
-	TimeStamp        string        `json:"ts"`
-	Channel          string        `json:"channel"`
+	Type      string `json:"type"`
+	User      string `json:"user"`
+	TimeStamp string `json:"ts"`
+	Channel   string `json:"channel"`
+	// MessageTimeStamp can be both a numeric timestamp if the LinkSharedEvent corresponds to a sent
+	// message and (contrary to the field name) a uuid if the LinkSharedEvent is generated in the
+	// compose text area.
 	MessageTimeStamp string        `json:"message_ts"`
 	ThreadTimeStamp  string        `json:"thread_ts"`
 	Links            []sharedLinks `json:"links"`

--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -165,7 +165,7 @@ type LinkSharedEvent struct {
 	User             string        `json:"user"`
 	TimeStamp        string        `json:"ts"`
 	Channel          string        `json:"channel"`
-	MessageTimeStamp json.Number   `json:"message_ts"`
+	MessageTimeStamp string        `json:"message_ts"`
 	ThreadTimeStamp  string        `json:"thread_ts"`
 	Links            []sharedLinks `json:"links"`
 }

--- a/slackevents/inner_events_test.go
+++ b/slackevents/inner_events_test.go
@@ -103,6 +103,38 @@ func TestLinkSharedEvent(t *testing.T) {
 	}
 }
 
+func TestLinkSharedComposerEvent(t *testing.T) {
+	rawE := []byte(`
+			{
+				"type": "link_shared",
+				"channel": "COMPOSER",
+				"is_bot_user_member": true,
+				"user": "Uxxxxxxx",
+				"message_ts": "Uxxxxxxx-909b5454-75f8-4ac4-b325-1b40e230bbd8-gryl3kb80b3wm49ihzoo35fyqoq08n2y",
+				"unfurl_id": "Uxxxxxxx-909b5454-75f8-4ac4-b325-1b40e230bbd8-gryl3kb80b3wm49ihzoo35fyqoq08n2y",
+				"source": "composer",
+				"links": [
+					{
+						"domain": "example.com",
+						"url": "https://example.com/12345"
+					},
+					{
+						"domain": "example.com",
+						"url": "https://example.com/67890"
+					},
+					{
+						"domain": "another-example.com",
+						"url": "https://yet.another-example.com/v/abcde"
+					}
+				]
+			}
+	`)
+	err := json.Unmarshal(rawE, &LinkSharedEvent{})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func TestMessageEvent(t *testing.T) {
 	rawE := []byte(`
 			{


### PR DESCRIPTION
This is a one-liner, but a breaking change.

As documented in https://api.slack.com/events/link_shared, the `message_ts` field will not be a number if the event is generated from an unfurl in the compose message area (the feature was announced here: https://api.slack.com/changelog/2021-08-changes-to-unfurls).

Includes a new test, which is the example payload from the `link_shared` url above.

Fixes #998
