### PR TITLE
slacktest: fix license issue

### DIFF
--- a/slacktest/README.md
+++ b/slacktest/README.md
@@ -1,5 +1,14 @@
 # slacktest
 
-code in this package was shamelessly copied from https://github.com/lusis/slack-test.
-since we were unable to get a response from the maintainer and its lack of license
-have left us in an odd state. but wanted to move it here for maintenance purposes.
+This package was copied from https://github.com/lusis/slack-test for historical reasons.  
+This package's license is the following.
+
+---
+
+Copyright 2018 @lusis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Add notice about slack-test's licenses.
However, since I am not familiar with the license notation, I do not know exactly if this is the proper notation.

Resolved: #625, #948, #979