### PR TITLE
add socket mode example link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,13 @@ func main() {
 }
 ```
 
+## Minimal Socket Mode usage:
+
+See https://github.com/slack-go/slack/blob/master/examples/socketmode/socketmode.go
+
 ## Minimal RTM usage:
+
+(For most applications, Socket Mode is a better way to communicate with Slack)
 
 See https://github.com/slack-go/slack/blob/master/examples/websocket/websocket.go
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ See https://github.com/slack-go/slack/blob/master/examples/socketmode/socketmode
 
 ## Minimal RTM usage:
 
-(For most applications, Socket Mode is a better way to communicate with Slack)
+As mentioned in https://api.slack.com/rtm - for most applications, Socket Mode is a better way to communicate with Slack.
 
 See https://github.com/slack-go/slack/blob/master/examples/websocket/websocket.go
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ func main() {
 
 See https://github.com/slack-go/slack/blob/master/examples/socketmode/socketmode.go
 
+
 ## Minimal RTM usage:
 
 As mentioned in https://api.slack.com/rtm - for most applications, Socket Mode is a better way to communicate with Slack.


### PR DESCRIPTION
As mentioned in the documentation in https://api.slack.com/rtm:
"For most applications, Socket Mode is a better way to communicate with Slack."

Personally, I got confused between RTM and Socket Mode, and I think this might help future developers.
