### PR TITLE
add latest_reply property to Msg struct

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -103,6 +103,7 @@ type Msg struct {
 	ReplyCount   int     `json:"reply_count,omitempty"`
 	Replies      []Reply `json:"replies,omitempty"`
 	ParentUserId string  `json:"parent_user_id,omitempty"`
+	LatestReply  string  `json:"latest_reply,omitempty"`
 
 	// file_share, file_comment, file_mention
 	Files []File `json:"files,omitempty"`


### PR DESCRIPTION
When retrieving a message using [`conversations.History`](https://api.slack.com/methods/conversations.history/test), the Slack API returns a field called `latest_reply` on each message in a thread with the timestamp value in it. This property is not part of the `Msg` struct so I am adding it with this PR.