### PR TITLE
Omitempty title field of ModelViewRequest to pass validation from Slack

### DIFF
--- a/views.go
+++ b/views.go
@@ -98,7 +98,7 @@ func NewErrorsViewSubmissionResponse(errors map[string]string) *ViewSubmissionRe
 
 type ModalViewRequest struct {
 	Type            ViewType         `json:"type"`
-	Title           *TextBlockObject `json:"title"`
+	Title           *TextBlockObject `json:"title,omitempty"`
 	Blocks          Blocks           `json:"blocks"`
 	Close           *TextBlockObject `json:"close,omitempty"`
 	Submit          *TextBlockObject `json:"submit,omitempty"`

--- a/workflow.go
+++ b/workflow.go
@@ -6,15 +6,21 @@ import (
 )
 
 type WorkflowUpdateRequest struct {
-	EditID  string                      `json:"workflow_step_edit_id"`
-	Inputs  *WorkflowStepInputRequest   `json:"inputs,omitempty"`
-	Outputs []WorkflowStepOutputRequest `json:"outputs,omitempty"`
+	EditID  string                       `json:"workflow_step_edit_id"`
+	Inputs  map[string]WorkflowStepInput `json:"inputs,omitempty"`
+	Outputs []WorkflowStepOutput         `json:"outputs,omitempty"`
 }
 
-type WorkflowStepInputRequest struct {
+type WorkflowStepInput struct {
+	Value                   string                 `json:"value,omitempty"`
+	SkipVariableReplacement bool                   `json:"skip_variable_replacement,omitempty"`
+	Variables               map[string]interface{} `json:"variables,omitempty"`
 }
 
-type WorkflowStepOutputRequest struct {
+type WorkflowStepOutput struct {
+	Name  string `json:"name,omitempty"`
+	Type  string `json:"type,omitempty"`
+	Label string `json:"label,omitempty"`
 }
 
 func (api *Client) UpdateWorkflow(ctx context.Context, req WorkflowUpdateRequest) (*SlackResponse, error) {

--- a/workflow.go
+++ b/workflow.go
@@ -1,0 +1,36 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+)
+
+type WorkflowUpdateRequest struct {
+	EditID  string                      `json:"workflow_step_edit_id"`
+	Inputs  *WorkflowStepInputRequest   `json:"inputs,omitempty"`
+	Outputs []WorkflowStepOutputRequest `json:"outputs,omitempty"`
+}
+
+type WorkflowStepInputRequest struct {
+}
+
+type WorkflowStepOutputRequest struct {
+}
+
+func (api *Client) UpdateWorkflow(ctx context.Context, req WorkflowUpdateRequest) (*SlackResponse, error) {
+	if req.EditID == "" {
+		return nil, ErrParametersMissing
+	}
+
+	encoded, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := api.endpoint + "workflows.updateStep"
+	resp := &SlackResponse{}
+	if err := postJSON(ctx, api.httpclient, endpoint, api.token, encoded, resp, api); err != nil {
+		return nil, err
+	}
+	return resp, resp.Err()
+}


### PR DESCRIPTION
As below doc, when sending a ViewRequest for configuration modal, the title fields must not be set.
But currently, that field is missing `omitempty` tag so its JSON will contain "null" value even the title was not given.
So this PR adds that missing `omitempty` tag to that field.

https://api.slack.com/workflows/steps#variables

##### Pull Request Guidelines

These are recommendations for pull requests.
They are strictly guidelines to help manage expectations.

##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### Examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.
