### PR TITLE
Add support for admin.emoji.list

### DIFF
--- a/admin_emoji.go
+++ b/admin_emoji.go
@@ -1,0 +1,41 @@
+package slack
+
+import (
+	"context"
+	"net/url"
+)
+
+type adminEmojiResponseFull struct {
+	Emoji map[string]*Emoji `json:"emoji"`
+	SlackResponse
+}
+
+type Emoji struct {
+	URL         string `json:"url"`
+	DateCreated int    `json:"date_created"`
+	UploadedBy  string `json:"uploaded_by"`
+}
+
+// GetAdminEmoji retrieves all the emojis
+func (api *Client) GetAdminEmoji() (map[string]*Emoji, error) {
+	return api.GetAdminEmojiContext(context.Background())
+}
+
+// GetAdminEmojiContext retrieves all the emojis with a custom context
+func (api *Client) GetAdminEmojiContext(ctx context.Context) (map[string]*Emoji, error) {
+	values := url.Values{
+		"token": {api.token},
+	}
+	response := &adminEmojiResponseFull{}
+
+	err := api.postMethod(ctx, "admin.emoji.list", values, response)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.Err() != nil {
+		return nil, response.Err()
+	}
+
+	return response.Emoji, nil
+}

--- a/admin_emoji_test.go
+++ b/admin_emoji_test.go
@@ -1,0 +1,51 @@
+package slack
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func getAdminEmojiHandler(rw http.ResponseWriter, r *http.Request) {
+	rw.Header().Set("Content-Type", "application/json")
+	response := []byte(`{"ok": true, "emoji": {
+			"bowtie": {"url":"https://my.slack.com/emoji/bowtie/46ec6f2bb0.png","date_created":1644445892,"uploaded_by":"Churchill"},
+			"squirrel": {"url":"https://my.slack.com/emoji/squirrel/f35f40c0e0.png","date_created":1644445893,"uploaded_by":"TheSquirrelHimself"},
+			"shipit": {"url":"alias:squirrel","date_created":1644445894,"uploaded_by":"BoredGuy"}
+		}}`)
+	rw.Write(response)
+}
+
+func TestGetAdminEmoji(t *testing.T) {
+	http.HandleFunc("/admin.emoji.list", getAdminEmojiHandler)
+
+	once.Do(startServer)
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
+	emojisResponse := map[string]*Emoji{
+		"bowtie": {
+			URL:         "https://my.slack.com/emoji/bowtie/46ec6f2bb0.png",
+			DateCreated: 1644445892,
+			UploadedBy:  "Churchill",
+		},
+		"squirrel": {
+			URL:         "https://my.slack.com/emoji/squirrel/f35f40c0e0.png",
+			DateCreated: 1644445893,
+			UploadedBy:  "TheSquirrelHimself",
+		},
+		"shipit": {
+			URL:         "alias:squirrel",
+			DateCreated: 1644445894,
+			UploadedBy:  "BoredGuy",
+		},
+	}
+
+	emojis, err := api.GetAdminEmoji()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+	eq := reflect.DeepEqual(emojis, emojisResponse)
+	if !eq {
+		t.Errorf("got %v; want %v", emojis, emojisResponse)
+	}
+}


### PR DESCRIPTION
This PR adds functions to call admin.emoji.list endpoint and it adds a test for it. This code is modeled after the code for the emoji.list (non-admin) endpoint.
I have run `make pr-prep`, and it changed the files `webhooks_go112.go` and `webhooks_go113.go` which I have opted not include.