### PR TITLE
Add refresh_token and token_type to OAuthV2Response fields

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -61,10 +61,12 @@ type OAuthV2ResponseEnterprise struct {
 
 // OAuthV2ResponseAuthedUser ...
 type OAuthV2ResponseAuthedUser struct {
-	ID          string `json:"id"`
-	Scope       string `json:"scope"`
-	AccessToken string `json:"access_token"`
-	TokenType   string `json:"token_type"`
+	ID           string `json:"id"`
+	Scope        string `json:"scope"`
+	AccessToken  string `json:"access_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	RefreshToken string `json:"refresh_token"`
+	TokenType    string `json:"token_type"`
 }
 
 // GetOAuthToken retrieves an AccessToken


### PR DESCRIPTION
Added missing parameters (`refresh_token` and `token_type`) to the `AuthedUser` block of `OAuthV2Response`.

https://api.slack.com/methods/oauth.v2.access