### PR TITLE
oauth: add `refresh_token` and  `expires_in` to OAuthV2Response

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -61,10 +61,12 @@ type OAuthV2ResponseEnterprise struct {
 
 // OAuthV2ResponseAuthedUser ...
 type OAuthV2ResponseAuthedUser struct {
-	ID          string `json:"id"`
-	Scope       string `json:"scope"`
-	AccessToken string `json:"access_token"`
-	TokenType   string `json:"token_type"`
+	ID           string `json:"id"`
+	Scope        string `json:"scope"`
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	ExpiresIn    int    `json:"expires_in,omitempty"`
 }
 
 // GetOAuthToken retrieves an AccessToken


### PR DESCRIPTION
Add `refresh_token` and  `expires_in` to OAuthV2Response.

ref:
https://github.com/slackapi/node-slack-sdk/blob/88f9abe72089bad3b10f31c823a71fa8cc8a019d/packages/oauth/src/index.ts#L645-L709