### PR TITLE
Optimize NewSafeID using atomic

### DIFF
--- a/messageID.go
+++ b/messageID.go
@@ -19,9 +19,8 @@ type safeID struct {
 	nextID int64
 }
 
-func (s *safeID) Next() (id int) {
-	id = int(atomic.LoadInt64(&s.nextID))
-	atomic.AddInt64(&s.nextID, 1)
+func (s *safeID) Next() int {
+	id := atomic.AddInt64(&s.nextID, 1)
 
-	return id
+	return int(id)
 }

--- a/messageID.go
+++ b/messageID.go
@@ -19,6 +19,10 @@ type safeID struct {
 	nextID int64
 }
 
+// make sure safeID implements the IDGenerator interface.
+var _ IDGenerator = (*safeID)(nil)
+
+// Next implements IDGenerator.Next.
 func (s *safeID) Next() int {
 	id := atomic.AddInt64(&s.nextID, 1)
 

--- a/messageID_test.go
+++ b/messageID_test.go
@@ -1,0 +1,27 @@
+package slack
+
+import (
+	"testing"
+)
+
+var id int
+
+func BenchmarkNewSafeID(b *testing.B) {
+	b.ReportAllocs()
+
+	idgen := NewSafeID(1)
+	for i := 0; i < b.N; i++ {
+		id = idgen.Next()
+	}
+}
+
+func BenchmarkNewSafeIDParallel(b *testing.B) {
+	b.ReportAllocs()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			idgen := NewSafeID(1)
+			id = idgen.Next()
+		}
+	})
+}

--- a/messageID_test.go
+++ b/messageID_test.go
@@ -4,6 +4,25 @@ import (
 	"testing"
 )
 
+func TestNewSafeID(t *testing.T) {
+	idgen := NewSafeID(1)
+	id1 := idgen.Next()
+	id2 := idgen.Next()
+	if id1 == id2 {
+		t.Fatalf("id1 and id2 are same: id1: %d, id2: %d", id1, id2)
+	}
+
+	idgen = NewSafeID(100)
+	id100 := idgen.Next()
+	id101 := idgen.Next()
+	if id2 == id100 {
+		t.Fatalf("except id2 and id100 not same: id2: %d, id101: %d", id2, id100)
+	}
+	if id100 == id101 {
+		t.Fatalf("id1 and id2 are same: id100: %d, id101: %d", id100, id101)
+	}
+}
+
 var id int
 
 func BenchmarkNewSafeID(b *testing.B) {


### PR DESCRIPTION
Optimize NewSafeID using atomic instead of a mutex lock.

- [x] is it performance related

---

```
name                  old time/op    new time/op    delta
NewSafeID-20            14.0ns ± 1%     5.9ns ± 1%  -57.76%  (p=0.008 n=5+5)
NewSafeIDParallel-20    23.8ns ± 1%    21.0ns ± 2%  -12.08%  (p=0.008 n=5+5)

name                  old alloc/op   new alloc/op   delta
NewSafeID-20             0.00B          0.00B          ~     (all equal)
NewSafeIDParallel-20     8.00B ± 0%     8.00B ± 0%     ~     (all equal)

name                  old allocs/op  new allocs/op  delta
NewSafeID-20              0.00           0.00          ~     (all equal)
NewSafeIDParallel-20      1.00 ± 0%      1.00 ± 0%     ~     (all equal)
```