### PR TITLE
optimize slackutilsx.EscapeMessage function

### DIFF
--- a/slackutilsx/slackutilsx.go
+++ b/slackutilsx/slackutilsx.go
@@ -50,10 +50,12 @@ func DetectChannelType(channelID string) ChannelType {
 	}
 }
 
+// initialize replacer only once (if needed)
+var escapeReplacer = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;")
+
 // EscapeMessage text
 func EscapeMessage(message string) string {
-	replacer := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;")
-	return replacer.Replace(message)
+	return escapeReplacer.Replace(message)
 }
 
 // Retryable errors return true.

--- a/slackutilsx/slackutilsx_test.go
+++ b/slackutilsx/slackutilsx_test.go
@@ -28,3 +28,9 @@ func TestEscapeMessage(t *testing.T) {
 	test("A < B", "A &lt; B")
 	test("A > B", "A &gt; B")
 }
+
+func BenchmarkEscapeMessage(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		EscapeMessage("A & B")
+	}
+}


### PR DESCRIPTION
This change is it performance related....but quite small TBH. Just found if while checking some code. 
The underlaying string.Replacer is optimized to buildup the lookup tables only once (but only if really needed!). 

```
➜  slackutilsx $ go test -bench=. --benchmem               
goos: linux
goarch: amd64
pkg: github.com/slack-go/slack/slackutilsx
cpu: Intel(R) Core(TM) i7-1065G7 CPU @ 1.30GHz
BenchmarkEscapeMessage-8      	  991929	      1230 ns/op	    6792 B/op	       9 allocs/op
BenchmarkEscapeMessageNew-8   	22310755	        58.94 ns/op	      32 B/op	       2 allocs/op
```
-> ~20 times faster, ~200 times less allocated bytes