### PR TITLE
Uniformize event_ts support on inner events

### DIFF
--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -3,8 +3,6 @@
 package slackevents
 
 import (
-	"encoding/json"
-
 	"github.com/slack-go/slack"
 )
 
@@ -16,13 +14,13 @@ type EventsAPIInnerEvent struct {
 
 // AppMentionEvent is an (inner) EventsAPI subscribable event.
 type AppMentionEvent struct {
-	Type            string      `json:"type"`
-	User            string      `json:"user"`
-	Text            string      `json:"text"`
-	TimeStamp       string      `json:"ts"`
-	ThreadTimeStamp string      `json:"thread_ts"`
-	Channel         string      `json:"channel"`
-	EventTimeStamp  json.Number `json:"event_ts"`
+	Type            string `json:"type"`
+	User            string `json:"user"`
+	Text            string `json:"text"`
+	TimeStamp       string `json:"ts"`
+	ThreadTimeStamp string `json:"thread_ts"`
+	Channel         string `json:"channel"`
+	EventTimeStamp  string `json:"event_ts"`
 
 	// When Message comes from a channel that is shared between workspaces
 	UserTeam   string `json:"user_team,omitempty"`
@@ -34,12 +32,12 @@ type AppMentionEvent struct {
 
 // AppHomeOpenedEvent Your Slack app home was opened.
 type AppHomeOpenedEvent struct {
-	Type           string      `json:"type"`
-	User           string      `json:"user"`
-	Channel        string      `json:"channel"`
-	EventTimeStamp json.Number `json:"event_ts"`
-	Tab            string      `json:"tab"`
-	View           slack.View  `json:"view"`
+	Type           string     `json:"type"`
+	User           string     `json:"user"`
+	Channel        string     `json:"channel"`
+	EventTimeStamp string     `json:"event_ts"`
+	Tab            string     `json:"tab"`
+	View           slack.View `json:"view"`
 }
 
 // AppUninstalledEvent Your Slack app was uninstalled.
@@ -198,15 +196,15 @@ type sharedLinks struct {
 // TODO: Improve this so that it is not required to manually parse ChannelType
 type MessageEvent struct {
 	// Basic Message Event - https://api.slack.com/events/message
-	ClientMsgID     string      `json:"client_msg_id"`
-	Type            string      `json:"type"`
-	User            string      `json:"user"`
-	Text            string      `json:"text"`
-	ThreadTimeStamp string      `json:"thread_ts"`
-	TimeStamp       string      `json:"ts"`
-	Channel         string      `json:"channel"`
-	ChannelType     string      `json:"channel_type"`
-	EventTimeStamp  json.Number `json:"event_ts"`
+	ClientMsgID     string `json:"client_msg_id"`
+	Type            string `json:"type"`
+	User            string `json:"user"`
+	Text            string `json:"text"`
+	ThreadTimeStamp string `json:"thread_ts"`
+	TimeStamp       string `json:"ts"`
+	Channel         string `json:"channel"`
+	ChannelType     string `json:"channel_type"`
+	EventTimeStamp  string `json:"event_ts"`
 
 	// When Message comes from a channel that is shared between workspaces
 	UserTeam   string `json:"user_team,omitempty"`
@@ -308,9 +306,9 @@ type TokensRevokedEvent struct {
 
 // EmojiChangedEvent is the event of custom emoji has been added or changed
 type EmojiChangedEvent struct {
-	Type           string      `json:"type"`
-	Subtype        string      `json:"subtype"`
-	EventTimeStamp json.Number `json:"event_ts"`
+	Type           string `json:"type"`
+	Subtype        string `json:"subtype"`
+	EventTimeStamp string `json:"event_ts"`
 
 	// filled out when custom emoji added
 	Name string `json:"name,omitempty"`

--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -56,34 +56,39 @@ type ChannelCreatedEvent struct {
 
 // ChannelDeletedEvent represents the Channel deleted event
 type ChannelDeletedEvent struct {
-	Type    string `json:"type"`
-	Channel string `json:"channel"`
+	Type           string `json:"type"`
+	Channel        string `json:"channel"`
+	EventTimestamp string `json:"event_ts"`
 }
 
 // ChannelArchiveEvent represents the Channel archive event
 type ChannelArchiveEvent struct {
-	Type    string `json:"type"`
-	Channel string `json:"channel"`
-	User    string `json:"user"`
+	Type           string `json:"type"`
+	Channel        string `json:"channel"`
+	User           string `json:"user"`
+	EventTimestamp string `json:"event_ts"`
 }
 
 // ChannelUnarchiveEvent represents the Channel unarchive event
 type ChannelUnarchiveEvent struct {
-	Type    string `json:"type"`
-	Channel string `json:"channel"`
-	User    string `json:"user"`
+	Type           string `json:"type"`
+	Channel        string `json:"channel"`
+	User           string `json:"user"`
+	EventTimestamp string `json:"event_ts"`
 }
 
 // ChannelLeftEvent represents the Channel left event
 type ChannelLeftEvent struct {
-	Type    string `json:"type"`
-	Channel string `json:"channel"`
+	Type           string `json:"type"`
+	Channel        string `json:"channel"`
+	EventTimestamp string `json:"event_ts"`
 }
 
 // ChannelRenameEvent represents the Channel rename event
 type ChannelRenameEvent struct {
-	Type    string            `json:"type"`
-	Channel ChannelRenameInfo `json:"channel"`
+	Type           string            `json:"type"`
+	Channel        ChannelRenameInfo `json:"channel"`
+	EventTimestamp string            `json:"event_ts"`
 }
 
 // ChannelIDChangedEvent represents the Channel identifier changed event
@@ -112,32 +117,37 @@ type ChannelRenameInfo struct {
 
 // GroupDeletedEvent represents the Group deleted event
 type GroupDeletedEvent struct {
-	Type    string `json:"type"`
-	Channel string `json:"channel"`
+	Type           string `json:"type"`
+	Channel        string `json:"channel"`
+	EventTimestamp string `json:"event_ts"`
 }
 
 // GroupArchiveEvent represents the Group archive event
 type GroupArchiveEvent struct {
-	Type    string `json:"type"`
-	Channel string `json:"channel"`
+	Type           string `json:"type"`
+	Channel        string `json:"channel"`
+	EventTimestamp string `json:"event_ts"`
 }
 
 // GroupUnarchiveEvent represents the Group unarchive event
 type GroupUnarchiveEvent struct {
-	Type    string `json:"type"`
-	Channel string `json:"channel"`
+	Type           string `json:"type"`
+	Channel        string `json:"channel"`
+	EventTimestamp string `json:"event_ts"`
 }
 
 // GroupLeftEvent represents the Group left event
 type GroupLeftEvent struct {
-	Type    string `json:"type"`
-	Channel string `json:"channel"`
+	Type           string `json:"type"`
+	Channel        string `json:"channel"`
+	EventTimestamp string `json:"event_ts"`
 }
 
 // GroupRenameEvent represents the Group rename event
 type GroupRenameEvent struct {
-	Type    string          `json:"type"`
-	Channel GroupRenameInfo `json:"channel"`
+	Type           string          `json:"type"`
+	Channel        GroupRenameInfo `json:"channel"`
+	EventTimestamp string          `json:"event_ts"`
 }
 
 // GroupRenameInfo represents the information associated with the Group rename event
@@ -171,6 +181,7 @@ type LinkSharedEvent struct {
 	MessageTimeStamp string        `json:"message_ts"`
 	ThreadTimeStamp  string        `json:"thread_ts"`
 	Links            []sharedLinks `json:"links"`
+	EventTimestamp   string        `json:"event_ts"`
 }
 
 type sharedLinks struct {
@@ -227,21 +238,23 @@ type MessageEvent struct {
 
 // MemberJoinedChannelEvent A member joined a public or private channel
 type MemberJoinedChannelEvent struct {
-	Type        string `json:"type"`
-	User        string `json:"user"`
-	Channel     string `json:"channel"`
-	ChannelType string `json:"channel_type"`
-	Team        string `json:"team"`
-	Inviter     string `json:"inviter"`
+	Type           string `json:"type"`
+	User           string `json:"user"`
+	Channel        string `json:"channel"`
+	ChannelType    string `json:"channel_type"`
+	Team           string `json:"team"`
+	Inviter        string `json:"inviter"`
+	EventTimestamp string `json:"event_ts"`
 }
 
 // MemberLeftChannelEvent A member left a public or private channel
 type MemberLeftChannelEvent struct {
-	Type        string `json:"type"`
-	User        string `json:"user"`
-	Channel     string `json:"channel"`
-	ChannelType string `json:"channel_type"`
-	Team        string `json:"team"`
+	Type           string `json:"type"`
+	User           string `json:"user"`
+	Channel        string `json:"channel"`
+	ChannelType    string `json:"channel_type"`
+	Team           string `json:"team"`
+	EventTimestamp string `json:"event_ts"`
 }
 
 type pinEvent struct {
@@ -281,14 +294,16 @@ type tokens struct {
 
 // TeamJoinEvent A new member joined a workspace -  https://api.slack.com/events/team_join
 type TeamJoinEvent struct {
-	Type string      `json:"type"`
-	User *slack.User `json:"user"`
+	Type           string      `json:"type"`
+	User           *slack.User `json:"user"`
+	EventTimestamp string      `json:"event_ts"`
 }
 
-// TokensRevokedEvent APP's API tokes are revoked - https://api.slack.com/events/tokens_revoked
+// TokensRevokedEvent APP's API tokens are revoked - https://api.slack.com/events/tokens_revoked
 type TokensRevokedEvent struct {
-	Type   string `json:"type"`
-	Tokens tokens `json:"tokens"`
+	Type           string `json:"type"`
+	Tokens         tokens `json:"tokens"`
+	EventTimestamp string `json:"event_ts"`
 }
 
 // EmojiChangedEvent is the event of custom emoji has been added or changed

--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -328,10 +328,10 @@ type EmojiChangedEvent struct {
 
 // WorkflowStepExecuteEvent is fired, if a workflow step of your app is invoked
 type WorkflowStepExecuteEvent struct {
-	Type         string            `json:"type"`
-	CallbackID   string            `json:"callback_id"`
-	WorkflowStep EventWorkflowStep `json:"workflow_step"`
-	EventTS      string            `json:"event_ts"`
+	Type           string            `json:"type"`
+	CallbackID     string            `json:"callback_id"`
+	WorkflowStep   EventWorkflowStep `json:"workflow_step"`
+	EventTimestamp string            `json:"event_ts"`
 }
 
 type EventWorkflowStep struct {

--- a/socketmode/socketmode_test.go
+++ b/socketmode/socketmode_test.go
@@ -236,7 +236,7 @@ func TestEventParsing(t *testing.T) {
 						TimeStamp:       "1610927831.000200",
 						ThreadTimeStamp: "",
 						Channel:         "redacted",
-						EventTimeStamp:  json.Number("1610927831.000200"),
+						EventTimeStamp:  "1610927831.000200",
 					},
 				},
 			},


### PR DESCRIPTION
This PR adds uniform support for the `event_ts` field on all inner events, fixing #1051 . It includes two breaking changes, but I consider those optional and would be happy with only merging the first commit.

The two breaking changes are the following
1. Rename `WorkflowStepExecuteEvent.EventTS` to `EventTimestamp`. I did a "brutal" rename, but if backwards compatibility is an issue we could also investigate keeping both fields and have custom `MarshalJSON`/`UnmarshalJSON` functions, though this also opens weird questions like "what do we do when serializing if both are set?".
2. Change all `EventTimestamp` fields to be strings, and not `json.Number`. We're not worried about losing precision here since `json.Number` is actually a string, but it seems (cf. #998) that this field had to be switched to a string for couple of events already, and having an inconsistent type here feels a bit weird.