### PR TITLE
Add fluent `WithConfirm` for `ButtonBlockElement`s

### DIFF
--- a/block_element.go
+++ b/block_element.go
@@ -167,6 +167,12 @@ func (s *ButtonBlockElement) WithStyle(style Style) *ButtonBlockElement {
 	return s
 }
 
+// WithConfirm adds a confirmation dialogue to the button object and returns the modified ButtonBlockElement
+func (s *ButtonBlockElement) WithConfirm(confirm *ConfirmationBlockObject) *ButtonBlockElement {
+	s.Confirm = confirm
+	return s
+}
+
 // NewButtonBlockElement returns an instance of a new button element to be used within a block
 func NewButtonBlockElement(actionID, value string, text *TextBlockObject) *ButtonBlockElement {
 	return &ButtonBlockElement{


### PR DESCRIPTION
This PR adds a `WithConfirm` fluent method helper that behaves much the same way as `WithStyle` does. This allows buttons to be fully constructed as expressions more often.