### PR TITLE
Fix the block ContextElements field marshaling

### DIFF
--- a/block_conv.go
+++ b/block_conv.go
@@ -361,7 +361,7 @@ func toBlockElement(element *Accessory) BlockElement {
 
 // MarshalJSON implements the Marshaller interface for ContextElements so that any JSON
 // marshalling is delegated and proper type determination can be made before marshal
-func (e *ContextElements) MarshalJSON() ([]byte, error) {
+func (e ContextElements) MarshalJSON() ([]byte, error) {
 	bytes, err := json.Marshal(e.Elements)
 	if err != nil {
 		return nil, err

--- a/block_conv.go
+++ b/block_conv.go
@@ -136,7 +136,7 @@ func (b *InputBlock) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the Marshaller interface for BlockElements so that any JSON
 // marshalling is delegated and proper type determination can be made before marshal
-func (b *BlockElements) MarshalJSON() ([]byte, error) {
+func (b BlockElements) MarshalJSON() ([]byte, error) {
 	bytes, err := json.Marshal(b.ElementSet)
 	if err != nil {
 		return nil, err
@@ -210,8 +210,8 @@ func (b *BlockElements) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the Marshaller interface for Accessory so that any JSON
 // marshalling is delegated and proper type determination can be made before marshal
-func (a *Accessory) MarshalJSON() ([]byte, error) {
-	bytes, err := json.Marshal(toBlockElement(a))
+func (a Accessory) MarshalJSON() ([]byte, error) {
+	bytes, err := json.Marshal(toBlockElement(&a))
 	if err != nil {
 		return nil, err
 	}

--- a/block_conv_test.go
+++ b/block_conv_test.go
@@ -1,0 +1,74 @@
+package slack
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBlocksJSONMarshalAndUnmarshal(t *testing.T) {
+	input := Blocks{
+		BlockSet: []Block{
+			TextBlockObject{
+				Text: "test",
+			},
+		},
+	}
+
+	actualFromValue, err := json.Marshal(input)
+	assert.NoError(t, err)
+	actualFromPtr, err := json.Marshal(&input)
+	assert.NoError(t, err)
+
+	assert.Equal(t, actualFromValue, actualFromPtr)
+}
+
+func TestBlockElementsElementsJSONMarshalAndUnmarshal(t *testing.T) {
+	input := BlockElements{
+		ElementSet: []BlockElement{
+			ImageBlockElement{
+				ImageURL: "test",
+			},
+		},
+	}
+
+	actualFromValue, err := json.Marshal(input)
+	assert.NoError(t, err)
+	actualFromPtr, err := json.Marshal(&input)
+	assert.NoError(t, err)
+
+	assert.Equal(t, actualFromValue, actualFromPtr)
+}
+
+func TestAccessoryJSONMarshalAndUnmarshal(t *testing.T) {
+	input := Accessory{
+		ImageElement: &ImageBlockElement{
+			ImageURL: "test",
+		},
+	}
+
+	actualFromValue, err := json.Marshal(input)
+	assert.NoError(t, err)
+	actualFromPtr, err := json.Marshal(&input)
+	assert.NoError(t, err)
+
+	assert.Equal(t, actualFromValue, actualFromPtr)
+}
+
+func TestContextElementsJSONMarshalAndUnmarshal(t *testing.T) {
+	input := ContextElements{
+		Elements: []MixedElement{
+			ImageBlockElement{
+				ImageURL: "test",
+			},
+		},
+	}
+
+	actualFromValue, err := json.Marshal(input)
+	assert.NoError(t, err)
+	actualFromPtr, err := json.Marshal(&input)
+	assert.NoError(t, err)
+
+	assert.Equal(t, actualFromValue, actualFromPtr)
+}

--- a/interactions.go
+++ b/interactions.go
@@ -74,9 +74,9 @@ type BlockActionStates struct {
 	Values map[string]map[string]BlockAction `json:"values"`
 }
 
-func (ic *InteractionCallback) MarshalJSON() ([]byte, error) {
+func (ic InteractionCallback) MarshalJSON() ([]byte, error) {
 	type alias InteractionCallback
-	tmp := alias(*ic)
+	tmp := alias(ic)
 	if tmp.Type == InteractionTypeBlockActions {
 		if tmp.BlockActionState == nil {
 			tmp.RawState = []byte(`{}`)


### PR DESCRIPTION
The [ContextElements](https://github.com/slack-go/slack/blob/93035c946040f00b2eb69dc9a954f83a9803e931/block_context.go#L10) field is incorrectly marshalled to JSON - it adds an extra nested `"Elements"` field to the resulting `"elements"` field in the object. The issue seems to be caused by the https://github.com/slack-go/slack/blob/93035c946040f00b2eb69dc9a954f83a9803e931/block_conv.go#L364 function signature. The receiver shouldn't be a pointer.

Relevant issue describing the same problem: https://github.com/golang/go/issues/6468

Here's a code snippet to reproduce:

```go
package main

import (
	"encoding/json"
	"fmt"

	"github.com/slack-go/slack"
)

func main() {
	fmt.Println("1. Start with valid JSON")
	inputJSON := `{"type":"context","elements":[{"type":"image","image_url":"https://github.githubassets.com/favicons/favicon.svg","alt_text":"github logo"},{"type":"mrkdwn","text":"issue"}]} `
	fmt.Printf("\tInput: %+v\n", inputJSON)
	parsed := slack.ContextBlock{}
	fmt.Println("2. Unmarshal")
	err := json.Unmarshal([]byte(inputJSON), &parsed)
	if err != nil {
		panic(err)
	}

	fmt.Printf("\tParsed: %+v\n", parsed)

	fmt.Println("3. Marshal")
	mashaled, err := json.Marshal(parsed)
	if err != nil {
		panic(err)
	}

	fmt.Printf("\tMarshaled: %s\n", mashaled)

	parsedAgain := slack.ContextBlock{}
	fmt.Println("4. Unmarshal again")
	err = json.Unmarshal(mashaled, &parsedAgain)
	if err != nil {
		panic(err)
	}

	fmt.Printf("\tParsed again: %+v\n", parsedAgain)
}

```

## Output of running the program before and after the fix

## Before

```shell
$ go run main.go

1. Start with valid JSON
        Input: {"type":"context","elements":[{"type":"image","image_url":"https://github.githubassets.com/favicons/favicon.svg","alt_text":"github logo"},{"type":"mrkdwn","text":"issue"}]}
2. Unmarshal
        Parsed: {Type:context BlockID: ContextElements:{Elements:[0xc0000a30e0 0xc0000a3230]}}
3. Marshal
        Marshaled: {"type":"context","elements":{"Elements":[{"type":"image","image_url":"https://github.githubassets.com/favicons/favicon.svg","alt_text":"github logo"},{"type":"mrkdwn","text":"issue"}]}}
4. Unmarshal again
panic: json: cannot unmarshal object into Go struct field ContextBlock.elements of type []json.RawMessage

goroutine 1 [running]:
main.main()
        /repos/gopg/main.go:34 +0x425
exit status 2

```

## After

```shell
$ go run main.go

1. Start with valid JSON
        Input: {"type":"context","elements":[{"type":"image","image_url":"https://github.githubassets.com/favicons/favicon.svg","alt_text":"github logo"},{"type":"mrkdwn","text":"issue"}]}
2. Unmarshal
        Parsed: {Type:context BlockID: ContextElements:{Elements:[0xc0000a2ff0 0xc0000a3140]}}
3. Marshal
        Marshaled: {"type":"context","elements":[{"type":"image","image_url":"https://github.githubassets.com/favicons/favicon.svg","alt_text":"github logo"},{"type":"mrkdwn","text":"issue"}]}
4. Unmarshal again
        Parsed again: {Type:context BlockID: ContextElements:{Elements:[0xc0000a3470 0xc0000a3500]}}
```
