### PR TITLE
add: workflows.stepCompleted and workflwows.stepFailed support

### DIFF
--- a/workflow_step_execute.go
+++ b/workflow_step_execute.go
@@ -19,14 +19,25 @@ type (
 	}
 )
 
+type WorkflowStepCompletedRequestOption func(opt WorkflowStepCompletedRequest) error
+
+func WorkflowStepCompletedRequestOptionOutput(outputs map[string]string) WorkflowStepCompletedRequestOption {
+	return func(opt WorkflowStepCompletedRequest) error {
+		if len(outputs) > 0 {
+			opt.Outputs = &outputs
+		}
+		return nil
+	}
+}
+
 // WorkflowStepCompleted indicates step is completed
-func (api *Client) WorkflowStepCompleted(workflowStepExecuteID string, outputs *map[string]string) error {
+func (api *Client) WorkflowStepCompleted(workflowStepExecuteID string, options ...WorkflowStepCompletedRequestOption) error {
 	// More information: https://api.slack.com/methods/workflows.stepCompleted
 	r := WorkflowStepCompletedRequest{
 		WorkflowStepExecuteID: workflowStepExecuteID,
 	}
-	if outputs != nil {
-		r.Outputs = outputs
+	for _, option := range options {
+		option(r)
 	}
 
 	endpoint := api.endpoint + "workflows.stepCompleted"

--- a/workflow_step_execute.go
+++ b/workflow_step_execute.go
@@ -1,0 +1,74 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+)
+
+type (
+	WorkflowStepCompletedRequest struct {
+		WorkflowStepExecuteID string             `json:"workflow_step_execute_id"`
+		Outputs               *map[string]string `json:"outputs"`
+	}
+
+	WorkflowStepFailedRequest struct {
+		WorkflowStepExecuteID string `json:"workflow_step_execute_id"`
+		Error                 struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+)
+
+// WorkflowStepCompleted indicates step is completed
+func (api *Client) WorkflowStepCompleted(workflowStepExecuteID string, outputs *map[string]string) error {
+	// More information: https://api.slack.com/methods/workflows.stepCompleted
+	r := WorkflowStepCompletedRequest{
+		WorkflowStepExecuteID: workflowStepExecuteID,
+	}
+	if outputs != nil {
+		r.Outputs = outputs
+	}
+
+	endpoint := api.endpoint + "workflows.stepCompleted"
+	jsonData, err := json.Marshal(r)
+	if err != nil {
+		return err
+	}
+
+	response := &SlackResponse{}
+	if err := postJSON(context.Background(), api.httpclient, endpoint, api.token, jsonData, response, api); err != nil {
+		return err
+	}
+
+	if !response.Ok {
+		return response.Err()
+	}
+
+	return nil
+}
+
+// WorkflowStepFailed indicates step is failed
+func (api *Client) WorkflowStepFailed(workflowStepExecuteID string, errorMessage string) error {
+	// More information: https://api.slack.com/methods/workflows.stepFailed
+	r := WorkflowStepFailedRequest{
+		WorkflowStepExecuteID: workflowStepExecuteID,
+	}
+	r.Error.Message = errorMessage
+
+	endpoint := api.endpoint + "workflows.stepFailed"
+	jsonData, err := json.Marshal(r)
+	if err != nil {
+		return err
+	}
+
+	response := &SlackResponse{}
+	if err := postJSON(context.Background(), api.httpclient, endpoint, api.token, jsonData, response, api); err != nil {
+		return err
+	}
+
+	if !response.Ok {
+		return response.Err()
+	}
+
+	return nil
+}

--- a/workflow_step_execute.go
+++ b/workflow_step_execute.go
@@ -7,8 +7,8 @@ import (
 
 type (
 	WorkflowStepCompletedRequest struct {
-		WorkflowStepExecuteID string             `json:"workflow_step_execute_id"`
-		Outputs               *map[string]string `json:"outputs"`
+		WorkflowStepExecuteID string            `json:"workflow_step_execute_id"`
+		Outputs               map[string]string `json:"outputs"`
 	}
 
 	WorkflowStepFailedRequest struct {
@@ -24,7 +24,7 @@ type WorkflowStepCompletedRequestOption func(opt WorkflowStepCompletedRequest) e
 func WorkflowStepCompletedRequestOptionOutput(outputs map[string]string) WorkflowStepCompletedRequestOption {
 	return func(opt WorkflowStepCompletedRequest) error {
 		if len(outputs) > 0 {
-			opt.Outputs = &outputs
+			opt.Outputs = outputs
 		}
 		return nil
 	}

--- a/workflow_step_execute_test.go
+++ b/workflow_step_execute_test.go
@@ -1,0 +1,35 @@
+package slack
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func workflowStepHandler(rw http.ResponseWriter, r *http.Request) {
+	rw.Header().Set("Content-Type", "application/json")
+	response, _ := json.Marshal(SlackResponse{
+		Ok: true,
+	})
+	rw.Write(response)
+}
+
+func TestWorkflowStepCompleted(t *testing.T) {
+	http.HandleFunc("/workflows.stepCompleted", workflowStepHandler)
+	once.Do(startServer)
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
+
+	if err := api.WorkflowStepCompleted("executeID", nil); err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+}
+
+func TestWorkflowStepFailed(t *testing.T) {
+	http.HandleFunc("/workflows.stepFailed", workflowStepHandler)
+	once.Do(startServer)
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
+
+	if err := api.WorkflowStepFailed("executeID", "error message"); err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+}

--- a/workflow_step_execute_test.go
+++ b/workflow_step_execute_test.go
@@ -19,7 +19,7 @@ func TestWorkflowStepCompleted(t *testing.T) {
 	once.Do(startServer)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
-	if err := api.WorkflowStepCompleted("executeID", nil); err != nil {
+	if err := api.WorkflowStepCompleted("executeID"); err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
 }


### PR DESCRIPTION
add support for the [workflows.stepCompleted](https://api.slack.com/methods/workflows.stepCompleted) and [workflows.stepFailed](https://api.slack.com/methods/workflows.stepFailed) 

using this API to indicate Slack that the workflow step is complete