### PR TITLE
webhooks: discarding body after http requests in order to allow reusi…

### DIFF
--- a/webhooks.go
+++ b/webhooks.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 )
 
@@ -51,7 +53,10 @@ func PostWebhookCustomHTTPContext(ctx context.Context, url string, httpClient *h
 	if err != nil {
 		return fmt.Errorf("failed to post webhook: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		io.Copy(ioutil.Discard, resp.Body)
+		resp.Body.Close()
+	}()
 
 	return checkStatusCode(resp, discard{})
 }


### PR DESCRIPTION
when you do more than 1 call using the provided http client,  the connection won't be reused and a new potentially expensive TCP connection will be established. 

In order for the connection to be reused by the Transport you need to read the response body in full and close the response.

this is from the go source code comment [https://pkg.go.dev/net/http]:

```
// The http Client and Transport guarantee that Body is always
// non-nil, even on responses without a body or responses with
// a zero-length body. It is the caller's responsibility to
// close Body. The default HTTP client's Transport may not
// reuse HTTP/1.x "keep-alive" TCP connections if the Body is
// not read to completion and closed.
```

Note:
ioutil.Discard is used but if the lib supports golang >= 1.16 then it should become io.Discard. 
Additionally, ioutil.Discard is used in other places that's why I picked that.

Best