### PR TITLE
Remove full event details from UnmarshallingErrorEvent

### DIFF
--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -475,7 +475,7 @@ func (rtm *RTM) handleEvent(typeStr string, event json.RawMessage) {
 	v, exists := EventMapping[typeStr]
 	if !exists {
 		rtm.Debugf("RTM Error - received unmapped event %q: %s\n", typeStr, string(event))
-		err := fmt.Errorf("RTM Error: Received unmapped event %q: %s", typeStr, string(event))
+		err := fmt.Errorf("RTM Error: Received unmapped event %q", typeStr)
 		rtm.IncomingEvents <- RTMEvent{"unmarshalling_error", &UnmarshallingErrorEvent{err}}
 		return
 	}
@@ -484,7 +484,7 @@ func (rtm *RTM) handleEvent(typeStr string, event json.RawMessage) {
 	err := json.Unmarshal(event, recvEvent)
 	if err != nil {
 		rtm.Debugf("RTM Error, could not unmarshall event %q: %s\n", typeStr, string(event))
-		err := fmt.Errorf("RTM Error: Could not unmarshall event %q: %s", typeStr, string(event))
+		err := fmt.Errorf("RTM Error: Could not unmarshall event %q", typeStr)
 		rtm.IncomingEvents <- RTMEvent{"unmarshalling_error", &UnmarshallingErrorEvent{err}}
 		return
 	}


### PR DESCRIPTION
Hi 👋 

When an unknown Slack event is received (e.g. unsupported Huddle-related events like `user_huddle_changed` or `sh_room_join`), the library sends `UnmarshallingErrorEvent` containing full event details data, including some pieces of personal information about the user.

This is a part of this error message when calling `err.Error()` on such `slack.UnmarshallingErrorEvent`:

```
RTM Error: Received unmapped event "user_huddle_changed": {"type":"user_huddle_changed","user":{"id":"id","team_id":"team_id",name":"name","deleted":false,"color":"9f69e7","real_name":"name","tz":"timezone,"tz_label":"timezone_label","tz_offset":7200,"profile":{"title":"","phone":"","skype":"","real_name":"name","real_name_normalized":"name","display_name":"","display_name_normalized":"","fields":null,"status_text":"","status_emoji":"","status_emoji_display_info":[],"status_expiration":0,"avatar_hash":"g4c69e455b85","email":"email","huddle_state_expiration_ts":1652949419,"first_name":"name,"last_name":"","image_24":"...
```

It is a problem, because such error should be presented to a user in some way. As this is a string, it needs some string manipulation to remove the event details. I think it shouldn't work that way.

While there are different options to solve this, I went with the simplest option: do not concatenate the event details to the error message 🙂 It brings consistency across all errors that are returned as incoming events. Also, there is still debug logging around UnmarshallingErrorEvents, so basically the change doesn't impact anything.

Let me know what you think 🙂 Cheers!