### PR TITLE
Expose StatusCodeError

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -18,8 +18,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/slack-go/slack/internal/misc"
 )
 
 // SlackResponse handles parsing out errors from the web api.
@@ -299,7 +297,7 @@ func checkStatusCode(resp *http.Response, d Debug) error {
 	// Slack seems to send an HTML body along with 5xx error codes. Don't parse it.
 	if resp.StatusCode != http.StatusOK {
 		logResponse(resp, d)
-		return misc.StatusCodeError{Code: resp.StatusCode, Status: resp.Status}
+		return StatusCodeError{Code: resp.StatusCode, Status: resp.Status}
 	}
 
 	return nil

--- a/misc_test.go
+++ b/misc_test.go
@@ -8,8 +8,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/slack-go/slack/internal/misc"
-
 	"github.com/slack-go/slack/slackutilsx"
 )
 
@@ -94,8 +92,8 @@ func TestParseResponseInvalidToken(t *testing.T) {
 func TestRetryable(t *testing.T) {
 	for _, e := range []error{
 		&RateLimitedError{},
-		misc.StatusCodeError{Code: http.StatusInternalServerError},
-		misc.StatusCodeError{Code: http.StatusTooManyRequests},
+		StatusCodeError{Code: http.StatusInternalServerError},
+		StatusCodeError{Code: http.StatusTooManyRequests},
 	} {
 		r, ok := e.(slackutilsx.Retryable)
 		if !ok {

--- a/socketmode/socket_mode_managed_conn.go
+++ b/socketmode/socket_mode_managed_conn.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/internal/backoff"
-	"github.com/slack-go/slack/internal/misc"
 	"github.com/slack-go/slack/internal/timex"
 	"github.com/slack-go/slack/slackevents"
 )
@@ -213,7 +212,7 @@ func (smc *Client) connect(ctx context.Context, connectionCount int, additionalP
 		}
 
 		switch actual := err.(type) {
-		case misc.StatusCodeError:
+		case StatusCodeError:
 			if actual.Code == http.StatusNotFound {
 				smc.Debugf("invalid auth when connecting with Socket Mode: %s", err)
 				smc.Events <- newEvent(EventTypeInvalidAuth, &slack.InvalidAuthEvent{})

--- a/socketmode/socket_mode_managed_conn.go
+++ b/socketmode/socket_mode_managed_conn.go
@@ -212,7 +212,7 @@ func (smc *Client) connect(ctx context.Context, connectionCount int, additionalP
 		}
 
 		switch actual := err.(type) {
-		case StatusCodeError:
+		case slack.StatusCodeError:
 			if actual.Code == http.StatusNotFound {
 				smc.Debugf("invalid auth when connecting with Socket Mode: %s", err)
 				smc.Events <- newEvent(EventTypeInvalidAuth, &slack.InvalidAuthEvent{})

--- a/status_code_error.go
+++ b/status_code_error.go
@@ -1,4 +1,4 @@
-package misc
+package slack
 
 import (
 	"fmt"

--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/slack-go/slack/internal/backoff"
 	"github.com/slack-go/slack/internal/errorsx"
-	"github.com/slack-go/slack/internal/misc"
 	"github.com/slack-go/slack/internal/timex"
 )
 
@@ -127,7 +126,7 @@ func (rtm *RTM) connect(connectionCount int, useRTMStart bool) (*Info, *websocke
 		}
 
 		switch actual := err.(type) {
-		case misc.StatusCodeError:
+		case StatusCodeError:
 			if actual.Code == http.StatusNotFound {
 				rtm.Debugf("invalid auth when connecting with RTM: %s", err)
 				rtm.IncomingEvents <- RTMEvent{"invalid_auth", &InvalidAuthEvent{}}


### PR DESCRIPTION
This change addresses issue #878

This allows library clients to perform checks on the HTTP status code.

##### Pull Request Guidelines

These are recommendations for pull requests.
They are strictly guidelines to help manage expectations.

##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [X] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### Examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.

Resolve: #878