### PR TITLE
interactions: parse AppInstalledTeamID

### DIFF
--- a/interactions_test.go
+++ b/interactions_test.go
@@ -68,7 +68,8 @@ const (
 					"text": "Select a date"
 				  }
 				}
-			}]
+			}],
+			"app_installed_team_id": "T1ABCD2E12"
 		},
 		"api_app_id": "A123ABC",
 		"is_cleared": false
@@ -137,7 +138,8 @@ const (
 						}
 					}
 				}
-			}
+			},
+			"app_installed_team_id": "T1ABCD2E12"
 		},
 		"hash": "156663117.cd33ad1f",
 		"response_urls": [
@@ -221,6 +223,7 @@ func TestViewClosedck(t *testing.T) {
 					),
 				},
 			},
+			AppInstalledTeamID: "T1ABCD2E12",
 		},
 		APIAppID: "A123ABC",
 	}
@@ -297,6 +300,7 @@ func TestViewSubmissionCallback(t *testing.T) {
 					},
 				},
 			},
+			AppInstalledTeamID: "T1ABCD2E12",
 		},
 		ViewSubmissionCallback: ViewSubmissionCallback{
 			Hash: "156663117.cd33ad1f",

--- a/views.go
+++ b/views.go
@@ -18,24 +18,25 @@ type ViewState struct {
 
 type View struct {
 	SlackResponse
-	ID              string           `json:"id"`
-	TeamID          string           `json:"team_id"`
-	Type            ViewType         `json:"type"`
-	Title           *TextBlockObject `json:"title"`
-	Close           *TextBlockObject `json:"close"`
-	Submit          *TextBlockObject `json:"submit"`
-	Blocks          Blocks           `json:"blocks"`
-	PrivateMetadata string           `json:"private_metadata"`
-	CallbackID      string           `json:"callback_id"`
-	State           *ViewState       `json:"state"`
-	Hash            string           `json:"hash"`
-	ClearOnClose    bool             `json:"clear_on_close"`
-	NotifyOnClose   bool             `json:"notify_on_close"`
-	RootViewID      string           `json:"root_view_id"`
-	PreviousViewID  string           `json:"previous_view_id"`
-	AppID           string           `json:"app_id"`
-	ExternalID      string           `json:"external_id"`
-	BotID           string           `json:"bot_id"`
+	ID                 string           `json:"id"`
+	TeamID             string           `json:"team_id"`
+	Type               ViewType         `json:"type"`
+	Title              *TextBlockObject `json:"title"`
+	Close              *TextBlockObject `json:"close"`
+	Submit             *TextBlockObject `json:"submit"`
+	Blocks             Blocks           `json:"blocks"`
+	PrivateMetadata    string           `json:"private_metadata"`
+	CallbackID         string           `json:"callback_id"`
+	State              *ViewState       `json:"state"`
+	Hash               string           `json:"hash"`
+	ClearOnClose       bool             `json:"clear_on_close"`
+	NotifyOnClose      bool             `json:"notify_on_close"`
+	RootViewID         string           `json:"root_view_id"`
+	PreviousViewID     string           `json:"previous_view_id"`
+	AppID              string           `json:"app_id"`
+	ExternalID         string           `json:"external_id"`
+	BotID              string           `json:"bot_id"`
+	AppInstalledTeamID string           `json:"app_installed_team_id"`
 }
 
 type ViewSubmissionCallbackResponseURL struct {


### PR DESCRIPTION
Slack includes a field called `app_installed_team_id` within the view object when the following interactions are triggered

* `view_submission`
* `view_closed`

This PR aims to expose the data to consumers of this library when unmarshalling into a InteractionCallback struct

This field helps us differentiate between different instances of a Slack App that we are interacting with within a Slack Connect channel.