### PR TITLE
Add missing panic in socket mode handler example

### DIFF
--- a/examples/socketmode_handler/socketmode_handler.go
+++ b/examples/socketmode_handler/socketmode_handler.go
@@ -15,7 +15,7 @@ import (
 func main() {
 	appToken := os.Getenv("SLACK_APP_TOKEN")
 	if appToken == "" {
-
+		panic("SLACK_APP_TOKEN must be set.\n")
 	}
 
 	if !strings.HasPrefix(appToken, "xapp-") {


### PR DESCRIPTION
Adds a missing panic statement when the app token environment variable is empty inside an empty if block.