### PR TITLE
Metadata Support

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -669,7 +669,7 @@ func MsgOptionIconEmoji(iconEmoji string) MsgOption {
 	}
 }
 
-// MsgOptionIconEmoji sets an icon emoji
+// MsgOptionMetadata sets message metadata
 func MsgOptionMetadata(metadata SlackMetadata) MsgOption {
 	return func(config *sendConfig) error {
 		config.metadata = metadata

--- a/chat.go
+++ b/chat.go
@@ -64,6 +64,9 @@ type PostMessageParameters struct {
 	// chat.postEphemeral support
 	Channel string `json:"channel"`
 	User    string `json:"user"`
+
+	// chat metadata support
+	MetaData SlackMetadata `json:"metadata"`
 }
 
 // NewPostMessageParameters provides an instance of PostMessageParameters with all the sane default values set
@@ -285,6 +288,7 @@ type sendConfig struct {
 	endpoint        string
 	values          url.Values
 	attachments     []Attachment
+	metadata        SlackMetadata
 	blocks          Blocks
 	responseType    string
 	replaceOriginal bool
@@ -306,6 +310,7 @@ func (t sendConfig) BuildRequestContext(ctx context.Context, token, channelID st
 			endpoint:        t.endpoint,
 			values:          t.values,
 			attachments:     t.attachments,
+			metadata:        t.metadata,
 			blocks:          t.blocks,
 			responseType:    t.responseType,
 			replaceOriginal: t.replaceOriginal,
@@ -336,6 +341,7 @@ type responseURLSender struct {
 	endpoint        string
 	values          url.Values
 	attachments     []Attachment
+	metadata        SlackMetadata
 	blocks          Blocks
 	responseType    string
 	replaceOriginal bool
@@ -352,6 +358,7 @@ func (t responseURLSender) BuildRequestContext(ctx context.Context) (*http.Reque
 		Timestamp:       t.values.Get("ts"),
 		Attachments:     t.attachments,
 		Blocks:          t.blocks,
+		Metadata:        t.metadata,
 		ResponseType:    t.responseType,
 		ReplaceOriginal: t.replaceOriginal,
 		DeleteOriginal:  t.deleteOriginal,
@@ -659,6 +666,18 @@ func MsgOptionIconEmoji(iconEmoji string) MsgOption {
 	return func(config *sendConfig) error {
 		config.values.Set("icon_emoji", iconEmoji)
 		return nil
+	}
+}
+
+// MsgOptionIconEmoji sets an icon emoji
+func MsgOptionMetadata(metadata SlackMetadata) MsgOption {
+	return func(config *sendConfig) error {
+		config.metadata = metadata
+		meta, err := json.Marshal(metadata)
+		if err == nil {
+			config.values.Set("metadata", string(meta))
+		}
+		return err
 	}
 }
 

--- a/chat_test.go
+++ b/chat_test.go
@@ -109,6 +109,24 @@ func TestPostMessage(t *testing.T) {
 				"token":       []string{"testing-token"},
 			},
 		},
+		"Metadata": {
+			endpoint: "/chat.postMessage",
+			opt: []MsgOption{
+				MsgOptionMetadata(
+					SlackMetadata{
+						EventType: "testing-event",
+						EventPayload: map[string]interface{}{
+							"id":   13,
+							"name": "testing-name",
+						},
+					}),
+			},
+			expected: url.Values{
+				"metadata": []string{`{"event_type":"testing-event","event_payload":{"id":13,"name":"testing-name"}}`},
+				"channel":  []string{"CXXX"},
+				"token":    []string{"testing-token"},
+			},
+		},
 		"Unfurl": {
 			endpoint: "/chat.unfurl",
 			opt: []MsgOption{

--- a/chat_test.go
+++ b/chat_test.go
@@ -82,6 +82,14 @@ func TestPostMessage(t *testing.T) {
 	blockStr := `[{"type":"context","block_id":"context","elements":[{"type":"plain_text","text":"hello"}]}]`
 
 	tests := map[string]messageTest{
+		"OnlyBasicProperties": {
+			endpoint: "/chat.postMessage",
+			opt:      []MsgOption{},
+			expected: url.Values{
+				"channel": []string{"CXXX"},
+				"token":   []string{"testing-token"},
+			},
+		},
 		"Blocks": {
 			endpoint: "/chat.postMessage",
 			opt: []MsgOption{

--- a/conversation.go
+++ b/conversation.go
@@ -571,12 +571,13 @@ func (api *Client) JoinConversationContext(ctx context.Context, channelID string
 }
 
 type GetConversationHistoryParameters struct {
-	ChannelID string
-	Cursor    string
-	Inclusive bool
-	Latest    string
-	Limit     int
-	Oldest    string
+	ChannelID          string
+	Cursor             string
+	Inclusive          bool
+	Latest             string
+	Limit              int
+	Oldest             string
+	IncludeAllMetadata bool
 }
 
 type GetConversationHistoryResponse struct {
@@ -614,6 +615,11 @@ func (api *Client) GetConversationHistoryContext(ctx context.Context, params *Ge
 	}
 	if params.Oldest != "" {
 		values.Add("oldest", params.Oldest)
+	}
+	if params.IncludeAllMetadata {
+		values.Add("include_all_metadata", "1")
+	} else {
+		values.Add("include_all_metadata", "0")
 	}
 
 	response := GetConversationHistoryResponse{}

--- a/messages.go
+++ b/messages.go
@@ -129,7 +129,7 @@ type Msg struct {
 	ReplaceOriginal bool   `json:"replace_original"`
 	DeleteOriginal  bool   `json:"delete_original"`
 
-	// Block type Message
+	// metadata
 	Metadata SlackMetadata `json:"metadata,omitempty"`
 
 	// Block type Message

--- a/messages.go
+++ b/messages.go
@@ -130,6 +130,9 @@ type Msg struct {
 	DeleteOriginal  bool   `json:"delete_original"`
 
 	// Block type Message
+	Metadata SlackMetadata `json:"metadata,omitempty"`
+
+	// Block type Message
 	Blocks Blocks `json:"blocks,omitempty"`
 	// permalink
 	Permalink string `json:"permalink,omitempty"`

--- a/metadata.go
+++ b/metadata.go
@@ -2,6 +2,6 @@ package slack
 
 // SlackMetadata https://api.slack.com/reference/metadata
 type SlackMetadata struct {
-	EventType    string      `json:"event_type"`
-	EventPayload interface{} `json:"event_payload"`
+	EventType    string                 `json:"event_type"`
+	EventPayload map[string]interface{} `json:"event_payload"`
 }

--- a/metadata.go
+++ b/metadata.go
@@ -1,0 +1,7 @@
+package slack
+
+// SlackMetadata https://api.slack.com/reference/metadata
+type SlackMetadata struct {
+	EventType    string      `json:"event_type"`
+	EventPayload interface{} `json:"event_payload"`
+}

--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -234,6 +234,12 @@ type MessageEvent struct {
 	Root *MessageEvent `json:"root"`
 }
 
+type MessageMetadataEvent struct {
+	// TODO: not sure about the actual fields we get here!
+	Type           string `json:"type"`
+	EventTimestamp string `json:"event_ts"`
+}
+
 // MemberJoinedChannelEvent A member joined a public or private channel
 type MemberJoinedChannelEvent struct {
 	Type           string `json:"type"`
@@ -487,6 +493,12 @@ const (
 	MemberJoinedChannel = EventsAPIType("member_joined_channel")
 	// Member Left Channel
 	MemberLeftChannel = EventsAPIType("member_left_channel")
+	// Message metadata was deleted
+	MessageMetadataDeleted = EventsAPIType("message_metadata_deleted")
+	// Message metadata was posted
+	MessageMetadataPosted = EventsAPIType("message_metadata_posted")
+	// Message metadata was updated
+	MessageMetadataUpdated = EventsAPIType("message_metadata_updated")
 	// PinAdded An item was pinned to a channel
 	PinAdded = EventsAPIType("pin_added")
 	// PinRemoved An item was unpinned from a channel
@@ -509,33 +521,36 @@ const (
 // implementations. The structs should be instances of the unmarshalling
 // target for the matching event type.
 var EventsAPIInnerEventMapping = map[EventsAPIType]interface{}{
-	AppMention:            AppMentionEvent{},
-	AppHomeOpened:         AppHomeOpenedEvent{},
-	AppUninstalled:        AppUninstalledEvent{},
-	ChannelCreated:        ChannelCreatedEvent{},
-	ChannelDeleted:        ChannelDeletedEvent{},
-	ChannelArchive:        ChannelArchiveEvent{},
-	ChannelUnarchive:      ChannelUnarchiveEvent{},
-	ChannelLeft:           ChannelLeftEvent{},
-	ChannelRename:         ChannelRenameEvent{},
-	ChannelIDChanged:      ChannelIDChangedEvent{},
-	GroupDeleted:          GroupDeletedEvent{},
-	GroupArchive:          GroupArchiveEvent{},
-	GroupUnarchive:        GroupUnarchiveEvent{},
-	GroupLeft:             GroupLeftEvent{},
-	GroupRename:           GroupRenameEvent{},
-	GridMigrationFinished: GridMigrationFinishedEvent{},
-	GridMigrationStarted:  GridMigrationStartedEvent{},
-	LinkShared:            LinkSharedEvent{},
-	Message:               MessageEvent{},
-	MemberJoinedChannel:   MemberJoinedChannelEvent{},
-	MemberLeftChannel:     MemberLeftChannelEvent{},
-	PinAdded:              PinAddedEvent{},
-	PinRemoved:            PinRemovedEvent{},
-	ReactionAdded:         ReactionAddedEvent{},
-	ReactionRemoved:       ReactionRemovedEvent{},
-	TeamJoin:              TeamJoinEvent{},
-	TokensRevoked:         TokensRevokedEvent{},
-	EmojiChanged:          EmojiChangedEvent{},
-	WorkflowStepExecute:   WorkflowStepExecuteEvent{},
+	AppMention:             AppMentionEvent{},
+	AppHomeOpened:          AppHomeOpenedEvent{},
+	AppUninstalled:         AppUninstalledEvent{},
+	ChannelCreated:         ChannelCreatedEvent{},
+	ChannelDeleted:         ChannelDeletedEvent{},
+	ChannelArchive:         ChannelArchiveEvent{},
+	ChannelUnarchive:       ChannelUnarchiveEvent{},
+	ChannelLeft:            ChannelLeftEvent{},
+	ChannelRename:          ChannelRenameEvent{},
+	ChannelIDChanged:       ChannelIDChangedEvent{},
+	GroupDeleted:           GroupDeletedEvent{},
+	GroupArchive:           GroupArchiveEvent{},
+	GroupUnarchive:         GroupUnarchiveEvent{},
+	GroupLeft:              GroupLeftEvent{},
+	GroupRename:            GroupRenameEvent{},
+	GridMigrationFinished:  GridMigrationFinishedEvent{},
+	GridMigrationStarted:   GridMigrationStartedEvent{},
+	LinkShared:             LinkSharedEvent{},
+	Message:                MessageEvent{},
+	MessageMetadataDeleted: MessageMetadataEvent{},
+	MessageMetadataPosted:  MessageMetadataEvent{},
+	MessageMetadataUpdated: MessageMetadataEvent{},
+	MemberJoinedChannel:    MemberJoinedChannelEvent{},
+	MemberLeftChannel:      MemberLeftChannelEvent{},
+	PinAdded:               PinAddedEvent{},
+	PinRemoved:             PinRemovedEvent{},
+	ReactionAdded:          ReactionAddedEvent{},
+	ReactionRemoved:        ReactionRemovedEvent{},
+	TeamJoin:               TeamJoinEvent{},
+	TokensRevoked:          TokensRevokedEvent{},
+	EmojiChanged:           EmojiChangedEvent{},
+	WorkflowStepExecute:    WorkflowStepExecuteEvent{},
 }

--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -234,12 +234,6 @@ type MessageEvent struct {
 	Root *MessageEvent `json:"root"`
 }
 
-type MessageMetadataEvent struct {
-	// TODO: not sure about the actual fields we get here!
-	Type           string `json:"type"`
-	EventTimestamp string `json:"event_ts"`
-}
-
 // MemberJoinedChannelEvent A member joined a public or private channel
 type MemberJoinedChannelEvent struct {
 	Type           string `json:"type"`
@@ -493,12 +487,6 @@ const (
 	MemberJoinedChannel = EventsAPIType("member_joined_channel")
 	// Member Left Channel
 	MemberLeftChannel = EventsAPIType("member_left_channel")
-	// Message metadata was deleted
-	MessageMetadataDeleted = EventsAPIType("message_metadata_deleted")
-	// Message metadata was posted
-	MessageMetadataPosted = EventsAPIType("message_metadata_posted")
-	// Message metadata was updated
-	MessageMetadataUpdated = EventsAPIType("message_metadata_updated")
 	// PinAdded An item was pinned to a channel
 	PinAdded = EventsAPIType("pin_added")
 	// PinRemoved An item was unpinned from a channel
@@ -521,36 +509,33 @@ const (
 // implementations. The structs should be instances of the unmarshalling
 // target for the matching event type.
 var EventsAPIInnerEventMapping = map[EventsAPIType]interface{}{
-	AppMention:             AppMentionEvent{},
-	AppHomeOpened:          AppHomeOpenedEvent{},
-	AppUninstalled:         AppUninstalledEvent{},
-	ChannelCreated:         ChannelCreatedEvent{},
-	ChannelDeleted:         ChannelDeletedEvent{},
-	ChannelArchive:         ChannelArchiveEvent{},
-	ChannelUnarchive:       ChannelUnarchiveEvent{},
-	ChannelLeft:            ChannelLeftEvent{},
-	ChannelRename:          ChannelRenameEvent{},
-	ChannelIDChanged:       ChannelIDChangedEvent{},
-	GroupDeleted:           GroupDeletedEvent{},
-	GroupArchive:           GroupArchiveEvent{},
-	GroupUnarchive:         GroupUnarchiveEvent{},
-	GroupLeft:              GroupLeftEvent{},
-	GroupRename:            GroupRenameEvent{},
-	GridMigrationFinished:  GridMigrationFinishedEvent{},
-	GridMigrationStarted:   GridMigrationStartedEvent{},
-	LinkShared:             LinkSharedEvent{},
-	Message:                MessageEvent{},
-	MessageMetadataDeleted: MessageMetadataEvent{},
-	MessageMetadataPosted:  MessageMetadataEvent{},
-	MessageMetadataUpdated: MessageMetadataEvent{},
-	MemberJoinedChannel:    MemberJoinedChannelEvent{},
-	MemberLeftChannel:      MemberLeftChannelEvent{},
-	PinAdded:               PinAddedEvent{},
-	PinRemoved:             PinRemovedEvent{},
-	ReactionAdded:          ReactionAddedEvent{},
-	ReactionRemoved:        ReactionRemovedEvent{},
-	TeamJoin:               TeamJoinEvent{},
-	TokensRevoked:          TokensRevokedEvent{},
-	EmojiChanged:           EmojiChangedEvent{},
-	WorkflowStepExecute:    WorkflowStepExecuteEvent{},
+	AppMention:            AppMentionEvent{},
+	AppHomeOpened:         AppHomeOpenedEvent{},
+	AppUninstalled:        AppUninstalledEvent{},
+	ChannelCreated:        ChannelCreatedEvent{},
+	ChannelDeleted:        ChannelDeletedEvent{},
+	ChannelArchive:        ChannelArchiveEvent{},
+	ChannelUnarchive:      ChannelUnarchiveEvent{},
+	ChannelLeft:           ChannelLeftEvent{},
+	ChannelRename:         ChannelRenameEvent{},
+	ChannelIDChanged:      ChannelIDChangedEvent{},
+	GroupDeleted:          GroupDeletedEvent{},
+	GroupArchive:          GroupArchiveEvent{},
+	GroupUnarchive:        GroupUnarchiveEvent{},
+	GroupLeft:             GroupLeftEvent{},
+	GroupRename:           GroupRenameEvent{},
+	GridMigrationFinished: GridMigrationFinishedEvent{},
+	GridMigrationStarted:  GridMigrationStartedEvent{},
+	LinkShared:            LinkSharedEvent{},
+	Message:               MessageEvent{},
+	MemberJoinedChannel:   MemberJoinedChannelEvent{},
+	MemberLeftChannel:     MemberLeftChannelEvent{},
+	PinAdded:              PinAddedEvent{},
+	PinRemoved:            PinRemovedEvent{},
+	ReactionAdded:         ReactionAddedEvent{},
+	ReactionRemoved:       ReactionRemovedEvent{},
+	TeamJoin:              TeamJoinEvent{},
+	TokensRevoked:         TokensRevokedEvent{},
+	EmojiChanged:          EmojiChangedEvent{},
+	WorkflowStepExecute:   WorkflowStepExecuteEvent{},
 }


### PR DESCRIPTION
## Disclaimer

I am somewhat new to this library AND to writing Go Code, feel free to correct me or suggest changes I am happily learning!

## Should this be an issue instead [NO]

## API changes

Add support for Metadata, as requested by: 
https://github.com/slack-go/slack/issues/1057

https://api.slack.com/metadata/publishing

Changes:
* added `MsgOptionMetadata` in `chat.go`, so we can add metadata to postMessage
* added `includeAllMetadata` to conversationHistory to retrieve existing metadata.

