### PR TITLE
add debug logging for rate limited errors

### DIFF
--- a/socketmode/socket_mode_managed_conn.go
+++ b/socketmode/socket_mode_managed_conn.go
@@ -219,6 +219,7 @@ func (smc *Client) connect(ctx context.Context, connectionCount int, additionalP
 				return nil, nil, err
 			}
 		case *slack.RateLimitedError:
+			smc.Debugf("socket mode open and dial: %s", err.(*slack.RateLimitedError).Error())
 			backoff = actual.RetryAfter
 		default:
 		}

--- a/stars.go
+++ b/stars.go
@@ -194,6 +194,7 @@ func (api *Client) ListAllStarsContext(ctx context.Context) (results []Item, err
 			case <-ctx.Done():
 				err = ctx.Err()
 			case <-time.After(rateLimitedError.RetryAfter):
+				api.Debugf("ListAllStarsContext: %s", rateLimitedError.Error())
 				err = nil
 			}
 		}

--- a/users.go
+++ b/users.go
@@ -389,6 +389,7 @@ func (api *Client) GetUsersContext(ctx context.Context, options ...GetUsersOptio
 			case <-ctx.Done():
 				err = ctx.Err()
 			case <-time.After(rateLimitedError.RetryAfter):
+				api.Debugf("GetUsersContext: %s", rateLimitedError.Error())
 				err = nil
 			}
 		}

--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -133,6 +133,7 @@ func (rtm *RTM) connect(connectionCount int, useRTMStart bool) (*Info, *websocke
 				return nil, nil, err
 			}
 		case *RateLimitedError:
+			rtm.Debugf("websocket start connection: %s", err.(*RateLimitedError).Error())
 			backoff = actual.RetryAfter
 		default:
 		}


### PR DESCRIPTION
In order to have some visibility into continued rate limit errors, adding call for debug logging.
