### PR TITLE
Honor deadman timer, fixes #1093

### DIFF
--- a/socketmode/socket_mode_managed_conn.go
+++ b/socketmode/socket_mode_managed_conn.go
@@ -146,7 +146,7 @@ func (smc *Client) run(ctx context.Context, connectionCount int) error {
 		return firstErr
 	}
 
-	// wg.Wait() finishes only after any of the above go routines finishes.
+	// select unblocks on first cancel or timeout.
 	// Also, we can expect firstErr to be not nil, as goroutines can finish only on error.
 	smc.Debugf("Reconnecting due to %v", firstErr)
 


### PR DESCRIPTION
NOTE: The original description of this PR is outdated, but left here for reference. See the discussion for how the PR was updated.

- [X] Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

This patch modifies the main run loop for the socket mode connection. Based on reading the comments, it appears the intention was for run() to return `context.Cancelled` in the event of a cancelled context, or `nil` in the event of a different error. This based on the comment:
```
// wg.Wait() finishes only after any of the above go routines finishes.
```
... but based on the use of the wait group, it appears that ALL of the goroutines would have to finish, causing the the deadman time to be ignored. This patch removes the wait group (and wg.Wait()) and instead selects on either 1) context cancelled, or 2) timer expired.

I believe this preserves the original intent of the code - but I could be wrong! In any case, this patch fixes #1093 for me, and my robot still runs correctly AFAICS. Ping to @xNok (the original PR author) to have a look.