### PR TITLE
Fix GoDoc grammers

### DIFF
--- a/dialog_text.go
+++ b/dialog_text.go
@@ -18,7 +18,7 @@ const (
 )
 
 // TextInputElement subtype of DialogInput
-//	https://api.slack.com/dialogs#option_element_attributes#text_element_attributes
+// https://api.slack.com/dialogs#option_element_attributes#text_element_attributes
 type TextInputElement struct {
 	DialogInput
 	MaxLength int              `json:"max_length,omitempty"`

--- a/internal/backoff/backoff.go
+++ b/internal/backoff/backoff.go
@@ -51,7 +51,7 @@ func (b *Backoff) Duration() (dur time.Duration) {
 	return dur
 }
 
-//Resets the current value of the counter back to Min
+// Resets the current value of the counter back to Min
 func (b *Backoff) Reset() {
 	b.attempts = 0
 }

--- a/socketmode/request.go
+++ b/socketmode/request.go
@@ -6,7 +6,7 @@ import "encoding/json"
 //
 // We call this a "request" rather than e.g. a WebSocket message or an Socket Mode "event" following python-slack-sdk:
 //
-//   https://github.com/slackapi/python-slack-sdk/blob/3f1c4c6e27bf7ee8af57699b2543e6eb7848bcf9/slack_sdk/socket_mode/request.py#L6
+// https://github.com/slackapi/python-slack-sdk/blob/3f1c4c6e27bf7ee8af57699b2543e6eb7848bcf9/slack_sdk/socket_mode/request.py#L6
 //
 // We know that node-slack-sdk calls it an "event", that makes it hard for us to distinguish our client's own event
 // that wraps both internal events and Socket Mode "events", vs node-slack-sdk's is for the latter only.

--- a/stars.go
+++ b/stars.go
@@ -130,17 +130,18 @@ func (api *Client) ListStarsContext(ctx context.Context, params StarsParameters)
 // GetStarred returns a list of StarredItem items.
 //
 // The user then has to iterate over them and figure out what they should
-// be looking at according to what is in the Type.
-//    for _, item := range items {
-//        switch c.Type {
-//        case "file_comment":
-//            log.Println(c.Comment)
-//        case "file":
-//             ...
+// be looking at according to what is in the Type:
 //
-//    }
+//	for _, item := range items {
+//	    switch c.Type {
+//	    case "file_comment":
+//	        log.Println(c.Comment)
+//	    case "file":
+//	        ...
+//	}
+//
 // This function still exists to maintain backwards compatibility.
-// I exposed it as returning []StarredItem, so it shall stay as StarredItem
+// I exposed it as returning []StarredItem, so it shall stay as StarredItem.
 func (api *Client) GetStarred(params StarsParameters) ([]StarredItem, *Paging, error) {
 	return api.GetStarredContext(context.Background(), params)
 }


### PR DESCRIPTION
### Description
I just fixed GoDocs that Linter has newly pointed out. (Probably Go 1.19 is related.)
