### PR TITLE
Update workflow for testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,13 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         go:
-          - '1.16'
           - '1.17'
           - '1.18'
+          - '1.19'
     name: test go-${{ matrix.go }}
     steps:
       - uses: actions/checkout@v3
@@ -26,11 +26,11 @@ jobs:
         env:
           GO111MODULE: on
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: lint
     steps:
       - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc # v3.2.0
         with:
-          version: latest
+          version: v1.48.0


### PR DESCRIPTION
### Description

* Support Go 1.19 (Remove Go1.16)
* Fix golangci-lint version to 1.48.0(this is latest now)
