### PR TITLE
Issue 844: Redact api token in chat message

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -243,6 +243,17 @@ func UnsafeApplyMsgOptions(token, channel, apiurl string, options ...MsgOption) 
 }
 
 func applyMsgOptions(token, channel, apiurl string, options ...MsgOption) (sendConfig, error) {
+	// It maybe be useful to know if the token supplied was empty or a token,
+	// however we do not want tokens printed out in messages. If the token is
+	// empty, change the token to a nil string to make it obvious in the message.
+	// If the token is not empty, change the token to a redacted string.
+	switch token {
+	case "":
+		token = "nil"
+	default:
+		token = "<REDACTED>"
+	}
+
 	config := sendConfig{
 		apiurl:   apiurl,
 		endpoint: apiurl + string(chatPostMessage),

--- a/chat_test.go
+++ b/chat_test.go
@@ -87,7 +87,7 @@ func TestPostMessage(t *testing.T) {
 			opt:      []MsgOption{},
 			expected: url.Values{
 				"channel": []string{"CXXX"},
-				"token":   []string{"testing-token"},
+				"token":   []string{"<REDACTED>"},
 			},
 		},
 		"Blocks": {
@@ -100,7 +100,7 @@ func TestPostMessage(t *testing.T) {
 				"blocks":  []string{blockStr},
 				"channel": []string{"CXXX"},
 				"text":    []string{"text"},
-				"token":   []string{"testing-token"},
+				"token":   []string{"<REDACTED>"},
 			},
 		},
 		"Attachment": {
@@ -114,7 +114,7 @@ func TestPostMessage(t *testing.T) {
 			expected: url.Values{
 				"attachments": []string{`[{"blocks":` + blockStr + `}]`},
 				"channel":     []string{"CXXX"},
-				"token":       []string{"testing-token"},
+				"token":       []string{"<REDACTED>"},
 			},
 		},
 		"Metadata": {
@@ -132,7 +132,7 @@ func TestPostMessage(t *testing.T) {
 			expected: url.Values{
 				"metadata": []string{`{"event_type":"testing-event","event_payload":{"id":13,"name":"testing-name"}}`},
 				"channel":  []string{"CXXX"},
-				"token":    []string{"testing-token"},
+				"token":    []string{"<REDACTED>"},
 			},
 		},
 		"Unfurl": {
@@ -142,7 +142,7 @@ func TestPostMessage(t *testing.T) {
 			},
 			expected: url.Values{
 				"channel": []string{"CXXX"},
-				"token":   []string{"testing-token"},
+				"token":   []string{"<REDACTED>"},
 				"ts":      []string{"123"},
 				"unfurls": []string{`{"something":{"text":"attachment-test","blocks":null}}`},
 			},
@@ -154,7 +154,7 @@ func TestPostMessage(t *testing.T) {
 			},
 			expected: url.Values{
 				"channel":       []string{"CXXX"},
-				"token":         []string{"testing-token"},
+				"token":         []string{"<REDACTED>"},
 				"ts":            []string{"123"},
 				"user_auth_url": []string{"https://auth-url.com"},
 			},
@@ -166,7 +166,7 @@ func TestPostMessage(t *testing.T) {
 			},
 			expected: url.Values{
 				"channel":            []string{"CXXX"},
-				"token":              []string{"testing-token"},
+				"token":              []string{"<REDACTED>"},
 				"ts":                 []string{"123"},
 				"user_auth_required": []string{"true"},
 			},
@@ -178,7 +178,7 @@ func TestPostMessage(t *testing.T) {
 			},
 			expected: url.Values{
 				"channel":           []string{"CXXX"},
-				"token":             []string{"testing-token"},
+				"token":             []string{"<REDACTED>"},
 				"ts":                []string{"123"},
 				"user_auth_message": []string{"Please!"},
 			},


### PR DESCRIPTION
Debug logs are printing api tokens as part of the request message.
Instead of printing the token, the token is transformed into a redacted
string if it is not empty. If the token is empty, which is a useful
piece of information that should be surfaced in the request, the empty
string is transformed into a nil string to make it more obvious.

##### Pull Request Guidelines

These are recommendations for pull requests.
They are strictly guidelines to help manage expectations.

##### PR preparation
[PASSED] Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead - YES IT IS #844 
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [X] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### Examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.
