### PR TITLE
adds postephemeral handler to slacktest to audit outgoing messages

### DIFF
--- a/slacktest/handlers.go
+++ b/slacktest/handlers.go
@@ -211,6 +211,98 @@ func (sts *Server) postMessageHandler(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
+// handle chat.postEphemeralMessage
+func (sts *Server) postEphemeralHandler(w http.ResponseWriter, r *http.Request) {
+	serverAddr := r.Context().Value(ServerBotHubNameContextKey).(string)
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		msg := fmt.Sprintf("error reading body: %s", err.Error())
+		log.Printf(msg)
+		http.Error(w, msg, http.StatusInternalServerError)
+		return
+	}
+	values, vErr := url.ParseQuery(string(data))
+	if vErr != nil {
+		msg := fmt.Sprintf("Unable to decode query params: %s", vErr.Error())
+		log.Printf(msg)
+		http.Error(w, msg, http.StatusInternalServerError)
+		return
+	}
+
+	ts := time.Now().Unix()
+	resp := &struct {
+		Ok      bool   `json:"ok"`
+		Channel string `json:"channel"`
+		Ts      string `json:"ts"`
+		Text    string `json:"text"`
+	}{
+		Ok:      true,
+		Channel: values.Get("channel"),
+		Ts:      fmt.Sprintf("%d", ts),
+		Text:    values.Get("text"),
+	}
+
+	m := slack.Message{}
+	m.Type = "message"
+	m.Channel = values.Get("channel")
+	m.Timestamp = fmt.Sprintf("%d", ts)
+	m.Text = values.Get("text")
+	m.ThreadTimestamp = values.Get("thread_ts")
+	m.User = values.Get("user")
+	if values.Get("as_user") != "true" {
+		m.Username = defaultNonBotUserName
+	} else {
+		m.Username = BotNameFromContext(r.Context())
+	}
+	attachments := values.Get("attachments")
+	if attachments != "" {
+		decoded, err := url.QueryUnescape(attachments)
+		if err != nil {
+			msg := fmt.Sprintf("Unable to decode attachments: %s", err.Error())
+			log.Printf(msg)
+			http.Error(w, msg, http.StatusInternalServerError)
+			return
+		}
+		var attaches []slack.Attachment
+		aJErr := json.Unmarshal([]byte(decoded), &attaches)
+		if aJErr != nil {
+			msg := fmt.Sprintf("Unable to decode attachments string to json: %s", aJErr.Error())
+			log.Printf(msg)
+			http.Error(w, msg, http.StatusInternalServerError)
+			return
+		}
+		m.Attachments = attaches
+	}
+	blocks := values.Get("blocks")
+	if blocks != "" {
+		decoded, err := url.QueryUnescape(blocks)
+		if err != nil {
+			msg := fmt.Sprintf("Unable to decode blocks: %s", err.Error())
+			log.Printf(msg)
+			http.Error(w, msg, http.StatusInternalServerError)
+			return
+		}
+		var decodedBlocks slack.Blocks
+		dbJErr := json.Unmarshal([]byte(decoded), &decodedBlocks)
+		if dbJErr != nil {
+			msg := fmt.Sprintf("Unable to decode blocks string to json: %s", dbJErr.Error())
+			log.Printf(msg)
+			http.Error(w, msg, http.StatusInternalServerError)
+			return
+		}
+		m.Blocks = decodedBlocks
+	}
+	jsonMessage, jsonErr := json.Marshal(m)
+	if jsonErr != nil {
+		msg := fmt.Sprintf("Unable to marshal message: %s", jsonErr.Error())
+		log.Printf(msg)
+		http.Error(w, msg, http.StatusInternalServerError)
+		return
+	}
+	go sts.queueForWebsocket(string(jsonMessage), serverAddr)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
 // RTMConnectHandler generates a valid connection
 func RTMConnectHandler(w http.ResponseWriter, r *http.Request) {
 	_, err := ioutil.ReadAll(r.Body)

--- a/slacktest/handlers_test.go
+++ b/slacktest/handlers_test.go
@@ -32,6 +32,16 @@ func TestPostMessageHandler(t *testing.T) {
 	assert.NotEmpty(t, tstamp, "timestamp should not be empty")
 }
 
+func TestPostEphemeralHandler(t *testing.T) {
+	s := NewTestServer()
+	go s.Start()
+
+	client := slack.New("ABCDEFG", slack.OptionAPIURL(s.GetAPIURL()))
+	tstamp, err := client.PostEphemeral("fake_channel", "fake_user", slack.MsgOptionText("some ephemeral text", false), slack.MsgOptionPostMessageParameters(slack.PostMessageParameters{}))
+	assert.NoError(t, err, "should not error out")
+	assert.NotEmpty(t, tstamp, "timestamp should not be empty")
+}
+
 func TestServerCreateConversationHandler(t *testing.T) {
 	s := NewTestServer()
 	go s.Start()

--- a/slacktest/server.go
+++ b/slacktest/server.go
@@ -50,6 +50,7 @@ func NewTestServer(custom ...binder) *Server {
 	s.Handle("/rtm.start", rtmStartHandler)
 	s.Handle("/rtm.connect", RTMConnectHandler)
 	s.Handle("/chat.postMessage", s.postMessageHandler)
+	s.Handle("/chat.postEphemeral", s.postEphemeralHandler)
 	s.Handle("/conversations.create", createConversationHandler)
 	s.Handle("/conversations.setTopic", setConversationTopicHandler)
 	s.Handle("/conversations.setPurpose", setConversationPurposeHandler)


### PR DESCRIPTION
##### The Changes
PostEphemeral was not exposing messages in the outgoing messages on slacktest. This is mostly a copy-paste from how postMessage handles that with the [addition](https://github.com/slack-go/slack/compare/master...mtintes:slack:master?expand=1#diff-9b81311406fe82eca68598c5090a2b687e6ab02444abe0ec25cd3bc83c39d2ceR251) that we use the userId that gets handed into the method.
