### PR TITLE
Handle null value in JSONTime

### DIFF
--- a/info.go
+++ b/info.go
@@ -409,6 +409,11 @@ func (t JSONTime) Time() time.Time {
 func (t *JSONTime) UnmarshalJSON(buf []byte) error {
 	s := bytes.Trim(buf, `"`)
 
+	if bytes.EqualFold(s, []byte("null")) {
+		*t = JSONTime(0)
+		return nil
+	}
+
 	v, err := strconv.Atoi(string(s))
 	if err != nil {
 		return err

--- a/info_test.go
+++ b/info_test.go
@@ -1,0 +1,44 @@
+package slack
+
+import (
+	"testing"
+)
+
+func TestJSONTime_UnmarshalJSON(t *testing.T) {
+	type args struct {
+		buf []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantTr  JSONTime
+		wantErr bool
+	}{
+		{
+			"acceptable int64 timestamp",
+			args{[]byte(`1643435556`)},
+			JSONTime(1643435556),
+			false,
+		},
+		{
+			"acceptable string timestamp",
+			args{[]byte(`"1643435556"`)},
+			JSONTime(1643435556),
+			false,
+		},
+		{
+			"null",
+			args{[]byte(`null`)},
+			JSONTime(0),
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tr JSONTime
+			if err := tr.UnmarshalJSON(tt.args.buf); (err != nil) != tt.wantErr {
+				t.Errorf("JSONTime.UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Handle the NULL value, when API returns "timestamp": null

It returns JSONTime(0) in this case.

##### Pull Request Guidelines

These are recommendations for pull requests.
They are strictly guidelines to help manage expectations.

##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### Examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.
