### PR TITLE
fix: UploadFileContext not calling api.AuthTestContext

### DIFF
--- a/files.go
+++ b/files.go
@@ -299,7 +299,7 @@ func (api *Client) UploadFile(params FileUploadParameters) (file *File, err erro
 func (api *Client) UploadFileContext(ctx context.Context, params FileUploadParameters) (file *File, err error) {
 	// Test if user token is valid. This helps because client.Do doesn't like this for some reason. XXX: More
 	// investigation needed, but for now this will do.
-	_, err = api.AuthTest()
+	_, err = api.AuthTestContext(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`UploadFileContext` was calling `api.AuthTest` instead of `api.AuthTestContext`