### PR TITLE
Add hidden subtypes to MessageEvent

### DIFF
--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -218,6 +218,11 @@ type MessageEvent struct {
 	// Message Subtypes
 	SubType string `json:"subtype,omitempty"`
 
+	// Hidden Subtypes
+	Hidden           bool   `json:"hidden,omitempty"`     // message_changed, message_deleted, unpinned_item
+	DeletedTimestamp string `json:"deleted_ts,omitempty"` // message_deleted
+	EventTimestamp   string `json:"event_ts,omitempty"`
+
 	// bot_message (https://api.slack.com/events/message/bot_message)
 	BotID    string `json:"bot_id,omitempty"`
 	Username string `json:"username,omitempty"`


### PR DESCRIPTION
When handling events through Socket Mode, we end up getting a `MessageEvent` from the Events API. In order to distinguish hidden subtypes, there are fields that isn't being marshaled into the struct like `Hidden bool` which will be nice to have.