### PR TITLE
Add deserializations for file-related events

### DIFF
--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -63,6 +63,39 @@ type ChannelCreatedInfo struct {
 	Creator   string `json:"creator"`
 }
 
+// FileChangeEvent represents the information associated with the File change
+// event.
+type FileChangeEvent struct {
+	Type   string        `json:"type"`
+	FileID string        `json:"file_id"`
+	File   FileEventFile `json:"file"`
+}
+
+// FileDeletedEvent represents the information associated with the File deleted
+// event.
+type FileDeletedEvent struct {
+	Type           string `json:"type"`
+	FileID         string `json:"file_id"`
+	EventTimestamp string `json:"event_ts"`
+}
+
+// FileSharedEvent represents the information associated with the File shared
+// event.
+type FileSharedEvent struct {
+	Type           string        `json:"type"`
+	ChannelID      string        `json:"channel_id"`
+	FileID         string        `json:"file_id"`
+	UserID         string        `json:"user_id"`
+	File           FileEventFile `json:"file"`
+	EventTimestamp string        `json:"event_ts"`
+}
+
+// FileEventFile represents information on the specific file being shared in a
+// file-related Slack event.
+type FileEventFile struct {
+	ID string `json:"id"`
+}
+
 // GridMigrationFinishedEvent An enterprise grid migration has finished on this workspace.
 type GridMigrationFinishedEvent struct {
 	Type         string `json:"type"`
@@ -328,6 +361,12 @@ const (
 	AppUninstalled = "app_uninstalled"
 	// ChannelCreated is sent when a new channel is created.
 	ChannelCreated = "channel_created"
+	// FileChange is sent when a file is changed.
+	FileChange = "file_change"
+	// FileDeleted is sent when a file is deleted.
+	FileDeleted = "file_deleted"
+	// FileShared is sent when a file is shared.
+	FileShared = "file_shared"
 	// GridMigrationFinished An enterprise grid migration has finished on this workspace.
 	GridMigrationFinished = "grid_migration_finished"
 	// GridMigrationStarted An enterprise grid migration has started on this workspace.
@@ -362,6 +401,9 @@ var EventsAPIInnerEventMapping = map[string]interface{}{
 	AppHomeOpened:         AppHomeOpenedEvent{},
 	AppUninstalled:        AppUninstalledEvent{},
 	ChannelCreated:        ChannelCreatedEvent{},
+	FileChange:            FileChangeEvent{},
+	FileDeleted:           FileDeletedEvent{},
+	FileShared:            FileSharedEvent{},
 	GridMigrationFinished: GridMigrationFinishedEvent{},
 	GridMigrationStarted:  GridMigrationStartedEvent{},
 	LinkShared:            LinkSharedEvent{},

--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -198,6 +198,19 @@ type MemberLeftChannelEvent struct {
 	Team        string `json:"team"`
 }
 
+// ChannelDeletedEvent indicates that a channel was deleted
+type ChannelDeletedEvent struct {
+	Type    string `json:"type"`
+	Channel string `json:"channel"`
+}
+
+// ChannelArchivedEvent indicates that a channel was archived
+type ChannelArchivedEvent struct {
+	Type    string `json:"type"`
+	User    string `json:"user"`
+	Channel string `json:"channel"`
+}
+
 type pinEvent struct {
 	Type           string `json:"type"`
 	User           string `json:"user"`
@@ -369,6 +382,10 @@ const (
 	AppUninstalled = "app_uninstalled"
 	// ChannelCreated is sent when a new channel is created.
 	ChannelCreated = "channel_created"
+	// ChannelDeleted is sent when a new channel is deleted.
+	ChannelDeleted = "channel_deleted"
+	// ChannelArchived is sent when a new channel is archived.
+	ChannelArchived = "channel_archived"
 	// FileChange is sent when a file is changed.
 	FileChange = "file_change"
 	// FileDeleted is sent when a file is deleted.
@@ -410,7 +427,9 @@ var EventsAPIInnerEventMapping = map[string]interface{}{
 	AppMention:            AppMentionEvent{},
 	AppHomeOpened:         AppHomeOpenedEvent{},
 	AppUninstalled:        AppUninstalledEvent{},
+	ChannelArchived:       ChannelArchivedEvent{},
 	ChannelCreated:        ChannelCreatedEvent{},
+	ChannelDeleted:        ChannelDeletedEvent{},
 	FileChange:            FileChangeEvent{},
 	FileDeleted:           FileDeletedEvent{},
 	FileShared:            FileSharedEvent{},

--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -90,6 +90,14 @@ type FileSharedEvent struct {
 	EventTimestamp string        `json:"event_ts"`
 }
 
+// FileUnsharedEvent represents the information associated with the File
+// unshared event.
+type FileUnsharedEvent struct {
+	Type   string        `json:"type"`
+	FileID string        `json:"file_id"`
+	File   FileEventFile `json:"file"`
+}
+
 // FileEventFile represents information on the specific file being shared in a
 // file-related Slack event.
 type FileEventFile struct {
@@ -367,6 +375,8 @@ const (
 	FileDeleted = "file_deleted"
 	// FileShared is sent when a file is shared.
 	FileShared = "file_shared"
+	// FileUnshared is sent when a file is unshared.
+	FileUnshared = "file_unshared"
 	// GridMigrationFinished An enterprise grid migration has finished on this workspace.
 	GridMigrationFinished = "grid_migration_finished"
 	// GridMigrationStarted An enterprise grid migration has started on this workspace.
@@ -404,6 +414,7 @@ var EventsAPIInnerEventMapping = map[string]interface{}{
 	FileChange:            FileChangeEvent{},
 	FileDeleted:           FileDeletedEvent{},
 	FileShared:            FileSharedEvent{},
+	FileUnshared:          FileUnsharedEvent{},
 	GridMigrationFinished: GridMigrationFinishedEvent{},
 	GridMigrationStarted:  GridMigrationStartedEvent{},
 	LinkShared:            LinkSharedEvent{},

--- a/slackevents/inner_events_test.go
+++ b/slackevents/inner_events_test.go
@@ -38,6 +38,94 @@ func TestAppUninstalled(t *testing.T) {
 	}
 }
 
+func TestFileChangeEvent(t *testing.T) {
+	rawE := []byte(`
+		{
+			"type": "file_change",
+			"file_id": "F1234567890",
+			"file": {
+				"id": "F1234567890"
+			}
+		}
+	`)
+
+	var e FileChangeEvent
+	if err := json.Unmarshal(rawE, &e); err != nil {
+		t.Fatal(err)
+	}
+	if e.Type != "file_change" {
+		t.Errorf("type should be file_change, was %s", e.Type)
+	}
+	if e.FileID != "F1234567890" {
+		t.Errorf("file ID should be F1234567890, was %s", e.FileID)
+	}
+	if e.File.ID != "F1234567890" {
+		t.Errorf("file.id should be F1234567890, was %s", e.File.ID)
+	}
+}
+
+func TestFileDeletedEvent(t *testing.T) {
+	rawE := []byte(`
+		{
+			"type": "file_deleted",
+			"file_id": "F1234567890",
+			"event_ts": "1234567890.123456"
+		}
+	`)
+
+	var e FileDeletedEvent
+	if err := json.Unmarshal(rawE, &e); err != nil {
+		t.Fatal(err)
+	}
+	if e.Type != "file_deleted" {
+		t.Errorf("type should be file_deleted, was %s", e.Type)
+	}
+	if e.FileID != "F1234567890" {
+		t.Errorf("file ID should be F1234567890, was %s", e.FileID)
+	}
+	if e.EventTimestamp != "1234567890.123456" {
+		t.Errorf("event timestamp should be 1234567890.123456, was %s", e.EventTimestamp)
+	}
+}
+
+func TestFileSharedEvent(t *testing.T) {
+	rawE := []byte(`
+		{
+			"type": "file_shared",
+			"channel_id": "C1234567890",
+			"file_id": "F1234567890",
+			"user_id": "U11235813",
+			"file": {
+				"id": "F1234567890"
+			},
+			"event_ts": "1234567890.123456"
+		}
+	`)
+
+	var e FileSharedEvent
+	if err := json.Unmarshal(rawE, &e); err != nil {
+		t.Fatal(err)
+	}
+	if e.Type != "file_shared" {
+		t.Errorf("type should be file_shared, was %s", e.Type)
+	}
+	if e.ChannelID != "C1234567890" {
+		t.Errorf("channel ID should be C1234567890, was %s", e.ChannelID)
+	}
+	if e.FileID != "F1234567890" {
+		t.Errorf("file ID should be F1234567890, was %s", e.FileID)
+	}
+	if e.UserID != "U11235813" {
+		t.Errorf("user ID should be U11235813, was %s", e.UserID)
+	}
+	if e.File.ID != "F1234567890" {
+		t.Errorf("file.id should be F1234567890, was %s", e.File.ID)
+	}
+	if e.EventTimestamp != "1234567890.123456" {
+		t.Errorf("event timestamp should be 1234567890.123456, was %s", e.EventTimestamp)
+	}
+}
+
 func TestGridMigrationFinishedEvent(t *testing.T) {
 	rawE := []byte(`
 			{

--- a/slackevents/inner_events_test.go
+++ b/slackevents/inner_events_test.go
@@ -152,6 +152,50 @@ func TestFileUnsharedEvent(t *testing.T) {
 	}
 }
 
+func TestChannelDeletedEvent(t *testing.T) {
+	rawE := []byte(`
+		{
+			"type": "channel_deleted",
+			"channel": "C1234567890"
+		}
+	`)
+
+	var e ChannelDeletedEvent
+	if err := json.Unmarshal(rawE, &e); err != nil {
+		t.Fatal(err)
+	}
+	if e.Type != "channel_deleted" {
+		t.Errorf("type should be channel_deleted, was %s", e.Type)
+	}
+	if e.Channel != "C1234567890" {
+		t.Errorf("channel ID should be C1234567890, was %s", e.Channel)
+	}
+}
+
+func TestChannelArchivedEvent(t *testing.T) {
+	rawE := []byte(`
+		{
+			"type": "channel_deleted",
+			"channel": "C1234567890",
+			"user": "U1234567890"
+		}
+	`)
+
+	var e ChannelArchivedEvent
+	if err := json.Unmarshal(rawE, &e); err != nil {
+		t.Fatal(err)
+	}
+	if e.Type != "channel_deleted" {
+		t.Errorf("type should be channel_deleted, was %s", e.Type)
+	}
+	if e.Channel != "C1234567890" {
+		t.Errorf("channel ID should be C1234567890, was %s", e.Channel)
+	}
+	if e.User != "U1234567890" {
+		t.Errorf("user ID should be U1234567890, was %s", e.Channel)
+	}
+}
+
 func TestGridMigrationFinishedEvent(t *testing.T) {
 	rawE := []byte(`
 			{

--- a/slackevents/inner_events_test.go
+++ b/slackevents/inner_events_test.go
@@ -126,6 +126,32 @@ func TestFileSharedEvent(t *testing.T) {
 	}
 }
 
+func TestFileUnsharedEvent(t *testing.T) {
+	rawE := []byte(`
+		{
+			"type": "file_unshared",
+			"file_id": "F1234567890",
+			"file": {
+				"id": "F1234567890"
+			}
+		}
+	`)
+
+	var e FileUnsharedEvent
+	if err := json.Unmarshal(rawE, &e); err != nil {
+		t.Fatal(err)
+	}
+	if e.Type != "file_unshared" {
+		t.Errorf("type should be file_shared, was %s", e.Type)
+	}
+	if e.FileID != "F1234567890" {
+		t.Errorf("file ID should be F1234567890, was %s", e.FileID)
+	}
+	if e.File.ID != "F1234567890" {
+		t.Errorf("file.id should be F1234567890, was %s", e.File.ID)
+	}
+}
+
 func TestGridMigrationFinishedEvent(t *testing.T) {
 	rawE := []byte(`
 			{


### PR DESCRIPTION
This PR adds support for deserializing file-related events in the Slack Events API

##### Pull Request Guidelines

These are recommendations for pull requests.
They are strictly guidelines to help manage expectations.

##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### Examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.
