### PR TITLE
Support slack events about file

### DIFF
--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -182,6 +182,14 @@ type FileSharedEvent struct {
 	EventTimestamp string        `json:"event_ts"`
 }
 
+// FileUnsharedEvent represents the information associated with the File
+// unshared event.
+type FileUnsharedEvent struct {
+	Type   string        `json:"type"`
+	FileID string        `json:"file_id"`
+	File   FileEventFile `json:"file"`
+}
+
 // FileEventFile represents information on the specific file being shared in a
 // file-related Slack event.
 type FileEventFile struct {
@@ -555,6 +563,8 @@ const (
 	FileDeleted = EventsAPIType("file_deleted")
 	// FileShared is sent when a file is shared.
 	FileShared = EventsAPIType("file_shared")
+	// FileUnshared is sent when a file is unshared.
+	FileUnshared = EventsAPIType("file_unshared")
 	// GridMigrationFinished An enterprise grid migration has finished on this workspace.
 	GridMigrationFinished = EventsAPIType("grid_migration_finished")
 	// GridMigrationStarted An enterprise grid migration has started on this workspace.
@@ -608,6 +618,7 @@ var EventsAPIInnerEventMapping = map[EventsAPIType]interface{}{
 	FileChange:             FileChangeEvent{},
 	FileDeleted:            FileDeletedEvent{},
 	FileShared:             FileSharedEvent{},
+	FileUnshared:           FileUnsharedEvent{},
 	GroupDeleted:           GroupDeletedEvent{},
 	GroupArchive:           GroupArchiveEvent{},
 	GroupUnarchive:         GroupUnarchiveEvent{},

--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -155,6 +155,39 @@ type GroupRenameInfo struct {
 	Created int    `json:"created"`
 }
 
+// FileChangeEvent represents the information associated with the File change
+// event.
+type FileChangeEvent struct {
+	Type   string        `json:"type"`
+	FileID string        `json:"file_id"`
+	File   FileEventFile `json:"file"`
+}
+
+// FileDeletedEvent represents the information associated with the File deleted
+// event.
+type FileDeletedEvent struct {
+	Type           string `json:"type"`
+	FileID         string `json:"file_id"`
+	EventTimestamp string `json:"event_ts"`
+}
+
+// FileSharedEvent represents the information associated with the File shared
+// event.
+type FileSharedEvent struct {
+	Type           string        `json:"type"`
+	ChannelID      string        `json:"channel_id"`
+	FileID         string        `json:"file_id"`
+	UserID         string        `json:"user_id"`
+	File           FileEventFile `json:"file"`
+	EventTimestamp string        `json:"event_ts"`
+}
+
+// FileEventFile represents information on the specific file being shared in a
+// file-related Slack event.
+type FileEventFile struct {
+	ID string `json:"id"`
+}
+
 // GridMigrationFinishedEvent An enterprise grid migration has finished on this workspace.
 type GridMigrationFinishedEvent struct {
 	Type         string `json:"type"`
@@ -516,6 +549,12 @@ const (
 	GroupLeft = EventsAPIType("group_left")
 	// GroupRename is sent when a group is renamed.
 	GroupRename = EventsAPIType("group_rename")
+	// FileChange is sent when a file is changed.
+	FileChange = EventsAPIType("file_change")
+	// FileDeleted is sent when a file is deleted.
+	FileDeleted = EventsAPIType("file_deleted")
+	// FileShared is sent when a file is shared.
+	FileShared = EventsAPIType("file_shared")
 	// GridMigrationFinished An enterprise grid migration has finished on this workspace.
 	GridMigrationFinished = EventsAPIType("grid_migration_finished")
 	// GridMigrationStarted An enterprise grid migration has started on this workspace.
@@ -566,6 +605,9 @@ var EventsAPIInnerEventMapping = map[EventsAPIType]interface{}{
 	ChannelLeft:            ChannelLeftEvent{},
 	ChannelRename:          ChannelRenameEvent{},
 	ChannelIDChanged:       ChannelIDChangedEvent{},
+	FileChange:             FileChangeEvent{},
+	FileDeleted:            FileDeletedEvent{},
+	FileShared:             FileSharedEvent{},
 	GroupDeleted:           GroupDeletedEvent{},
 	GroupArchive:           GroupArchiveEvent{},
 	GroupUnarchive:         GroupUnarchiveEvent{},

--- a/slackevents/inner_events_test.go
+++ b/slackevents/inner_events_test.go
@@ -38,6 +38,94 @@ func TestAppUninstalled(t *testing.T) {
 	}
 }
 
+func TestFileChangeEvent(t *testing.T) {
+	rawE := []byte(`
+		{
+			"type": "file_change",
+			"file_id": "F1234567890",
+			"file": {
+				"id": "F1234567890"
+			}
+		}
+	`)
+
+	var e FileChangeEvent
+	if err := json.Unmarshal(rawE, &e); err != nil {
+		t.Fatal(err)
+	}
+	if e.Type != "file_change" {
+		t.Errorf("type should be file_change, was %s", e.Type)
+	}
+	if e.FileID != "F1234567890" {
+		t.Errorf("file ID should be F1234567890, was %s", e.FileID)
+	}
+	if e.File.ID != "F1234567890" {
+		t.Errorf("file.id should be F1234567890, was %s", e.File.ID)
+	}
+}
+
+func TestFileDeletedEvent(t *testing.T) {
+	rawE := []byte(`
+		{
+			"type": "file_deleted",
+			"file_id": "F1234567890",
+			"event_ts": "1234567890.123456"
+		}
+	`)
+
+	var e FileDeletedEvent
+	if err := json.Unmarshal(rawE, &e); err != nil {
+		t.Fatal(err)
+	}
+	if e.Type != "file_deleted" {
+		t.Errorf("type should be file_deleted, was %s", e.Type)
+	}
+	if e.FileID != "F1234567890" {
+		t.Errorf("file ID should be F1234567890, was %s", e.FileID)
+	}
+	if e.EventTimestamp != "1234567890.123456" {
+		t.Errorf("event timestamp should be 1234567890.123456, was %s", e.EventTimestamp)
+	}
+}
+
+func TestFileSharedEvent(t *testing.T) {
+	rawE := []byte(`
+		{
+			"type": "file_shared",
+			"channel_id": "C1234567890",
+			"file_id": "F1234567890",
+			"user_id": "U11235813",
+			"file": {
+				"id": "F1234567890"
+			},
+			"event_ts": "1234567890.123456"
+		}
+	`)
+
+	var e FileSharedEvent
+	if err := json.Unmarshal(rawE, &e); err != nil {
+		t.Fatal(err)
+	}
+	if e.Type != "file_shared" {
+		t.Errorf("type should be file_shared, was %s", e.Type)
+	}
+	if e.ChannelID != "C1234567890" {
+		t.Errorf("channel ID should be C1234567890, was %s", e.ChannelID)
+	}
+	if e.FileID != "F1234567890" {
+		t.Errorf("file ID should be F1234567890, was %s", e.FileID)
+	}
+	if e.UserID != "U11235813" {
+		t.Errorf("user ID should be U11235813, was %s", e.UserID)
+	}
+	if e.File.ID != "F1234567890" {
+		t.Errorf("file.id should be F1234567890, was %s", e.File.ID)
+	}
+	if e.EventTimestamp != "1234567890.123456" {
+		t.Errorf("event timestamp should be 1234567890.123456, was %s", e.EventTimestamp)
+	}
+}
+
 func TestGridMigrationFinishedEvent(t *testing.T) {
 	rawE := []byte(`
 			{

--- a/slackevents/inner_events_test.go
+++ b/slackevents/inner_events_test.go
@@ -126,6 +126,32 @@ func TestFileSharedEvent(t *testing.T) {
 	}
 }
 
+func TestFileUnsharedEvent(t *testing.T) {
+	rawE := []byte(`
+		{
+			"type": "file_unshared",
+			"file_id": "F1234567890",
+			"file": {
+				"id": "F1234567890"
+			}
+		}
+	`)
+
+	var e FileUnsharedEvent
+	if err := json.Unmarshal(rawE, &e); err != nil {
+		t.Fatal(err)
+	}
+	if e.Type != "file_unshared" {
+		t.Errorf("type should be file_shared, was %s", e.Type)
+	}
+	if e.FileID != "F1234567890" {
+		t.Errorf("file ID should be F1234567890, was %s", e.FileID)
+	}
+	if e.File.ID != "F1234567890" {
+		t.Errorf("file.id should be F1234567890, was %s", e.File.ID)
+	}
+}
+
 func TestGridMigrationFinishedEvent(t *testing.T) {
 	rawE := []byte(`
 			{


### PR DESCRIPTION
This PR adds support for deserializing file_change, file_deleted, file_shared, and file_unshared events from the Slack Events API

##### Pull Request Guidelines

These are recommendations for pull requests.
They are strictly guidelines to help manage expectations.

##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### Examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.
