### PR TITLE
add GetOtherTeam method

### DIFF
--- a/team.go
+++ b/team.go
@@ -100,6 +100,22 @@ func (api *Client) GetTeamInfo() (*TeamInfo, error) {
 	return api.GetTeamInfoContext(context.Background())
 }
 
+// GetOtherTeamInfo gets Team information for any team
+func (api *Client) GetOtherTeamInfo(team string) (*TeamInfo, error) {
+	if team == "" {
+		return api.GetTeamInfo()
+	}
+	values := url.Values{
+		"token": {api.token},
+	}
+	values.Add("team", team)
+	response, err := api.teamRequest(context.Background(), "team.info", values)
+	if err != nil {
+		return nil, err
+	}
+	return &response.Team, nil
+}
+
 // GetTeamInfoContext gets the Team Information of the user with a custom context
 func (api *Client) GetTeamInfoContext(ctx context.Context) (*TeamInfo, error) {
 	values := url.Values{


### PR DESCRIPTION
I'm creating a chatbot that needs to be able to get information about users' teams to decide if/how to respond to them. 

As has been noted in #980, the `GetTeamInfo` method doesn't expose the optional `team` argument that the Slack API accepts, meaning my bot can only get info about its own team.

#981 attempted to fix this, but lacked backwards compatibility. This is an attempt to implement the functionality in a backwards-compatible way by creating a new `GetOtherTeamInfo` method, as had been suggested by @kanata2 in the discussion of #981 

I'm frankly a little unsure how to implement a meaningful test for this unfortunately, but I can confirm that `make pr-prep` reported no issues.