### PR TITLE
Add support for status_emoji_display_info

### DIFF
--- a/users.go
+++ b/users.go
@@ -17,30 +17,38 @@ const (
 
 // UserProfile contains all the information details of a given user
 type UserProfile struct {
-	FirstName             string                  `json:"first_name"`
-	LastName              string                  `json:"last_name"`
-	RealName              string                  `json:"real_name"`
-	RealNameNormalized    string                  `json:"real_name_normalized"`
-	DisplayName           string                  `json:"display_name"`
-	DisplayNameNormalized string                  `json:"display_name_normalized"`
-	Email                 string                  `json:"email"`
-	Skype                 string                  `json:"skype"`
-	Phone                 string                  `json:"phone"`
-	Image24               string                  `json:"image_24"`
-	Image32               string                  `json:"image_32"`
-	Image48               string                  `json:"image_48"`
-	Image72               string                  `json:"image_72"`
-	Image192              string                  `json:"image_192"`
-	Image512              string                  `json:"image_512"`
-	ImageOriginal         string                  `json:"image_original"`
-	Title                 string                  `json:"title"`
-	BotID                 string                  `json:"bot_id,omitempty"`
-	ApiAppID              string                  `json:"api_app_id,omitempty"`
-	StatusText            string                  `json:"status_text,omitempty"`
-	StatusEmoji           string                  `json:"status_emoji,omitempty"`
-	StatusExpiration      int                     `json:"status_expiration"`
-	Team                  string                  `json:"team"`
-	Fields                UserProfileCustomFields `json:"fields"`
+	FirstName              string                              `json:"first_name"`
+	LastName               string                              `json:"last_name"`
+	RealName               string                              `json:"real_name"`
+	RealNameNormalized     string                              `json:"real_name_normalized"`
+	DisplayName            string                              `json:"display_name"`
+	DisplayNameNormalized  string                              `json:"display_name_normalized"`
+	Email                  string                              `json:"email"`
+	Skype                  string                              `json:"skype"`
+	Phone                  string                              `json:"phone"`
+	Image24                string                              `json:"image_24"`
+	Image32                string                              `json:"image_32"`
+	Image48                string                              `json:"image_48"`
+	Image72                string                              `json:"image_72"`
+	Image192               string                              `json:"image_192"`
+	Image512               string                              `json:"image_512"`
+	ImageOriginal          string                              `json:"image_original"`
+	Title                  string                              `json:"title"`
+	BotID                  string                              `json:"bot_id,omitempty"`
+	ApiAppID               string                              `json:"api_app_id,omitempty"`
+	StatusText             string                              `json:"status_text,omitempty"`
+	StatusEmoji            string                              `json:"status_emoji,omitempty"`
+	StatusEmojiDisplayInfo []UserProfileStatusEmojiDisplayInfo `json:"status_emoji_display_info,omitempty"`
+	StatusExpiration       int                                 `json:"status_expiration"`
+	Team                   string                              `json:"team"`
+	Fields                 UserProfileCustomFields             `json:"fields"`
+}
+
+type UserProfileStatusEmojiDisplayInfo struct {
+	EmojiName    string `json:"emoji_name"`
+	DisplayAlias string `json:"display_alias,omitempty"`
+	DisplayURL   string `json:"display_url,omitempty"`
+	Unicode      string `json:"unicode,omitempty"`
 }
 
 // UserProfileCustomFields represents user profile's custom fields.

--- a/users_test.go
+++ b/users_test.go
@@ -33,22 +33,31 @@ func getTestUserProfileCustomFields() UserProfileCustomFields {
 		}}
 }
 
+func getTestUserProfileStatusEmojiDisplayInfo() []UserProfileStatusEmojiDisplayInfo {
+	return []UserProfileStatusEmojiDisplayInfo{{
+		EmojiName:  "construction",
+		Unicode:    "1f6a7",
+		DisplayURL: "https://a.slack-edge.com/production-standard-emoji-assets/14.0/apple-large/1f6a7.png",
+	}}
+}
+
 func getTestUserProfile() UserProfile {
 	return UserProfile{
-		StatusText:            "testStatus",
-		StatusEmoji:           ":construction:",
-		RealName:              "Test Real Name",
-		RealNameNormalized:    "Test Real Name Normalized",
-		DisplayName:           "Test Display Name",
-		DisplayNameNormalized: "Test Display Name Normalized",
-		Email:                 "test@test.com",
-		Image24:               "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2016-10-18/92962080834_ef14c1469fc0741caea1_24.jpg",
-		Image32:               "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2016-10-18/92962080834_ef14c1469fc0741caea1_32.jpg",
-		Image48:               "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2016-10-18/92962080834_ef14c1469fc0741caea1_48.jpg",
-		Image72:               "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2016-10-18/92962080834_ef14c1469fc0741caea1_72.jpg",
-		Image192:              "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2016-10-18/92962080834_ef14c1469fc0741caea1_192.jpg",
-		Image512:              "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2016-10-18/92962080834_ef14c1469fc0741caea1_512.jpg",
-		Fields:                getTestUserProfileCustomFields(),
+		StatusText:             "testStatus",
+		StatusEmoji:            ":construction:",
+		StatusEmojiDisplayInfo: getTestUserProfileStatusEmojiDisplayInfo(),
+		RealName:               "Test Real Name",
+		RealNameNormalized:     "Test Real Name Normalized",
+		DisplayName:            "Test Display Name",
+		DisplayNameNormalized:  "Test Display Name Normalized",
+		Email:                  "test@test.com",
+		Image24:                "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2016-10-18/92962080834_ef14c1469fc0741caea1_24.jpg",
+		Image32:                "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2016-10-18/92962080834_ef14c1469fc0741caea1_32.jpg",
+		Image48:                "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2016-10-18/92962080834_ef14c1469fc0741caea1_48.jpg",
+		Image72:                "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2016-10-18/92962080834_ef14c1469fc0741caea1_72.jpg",
+		Image192:               "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2016-10-18/92962080834_ef14c1469fc0741caea1_192.jpg",
+		Image512:               "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2016-10-18/92962080834_ef14c1469fc0741caea1_512.jpg",
+		Fields:                 getTestUserProfileCustomFields(),
 	}
 }
 
@@ -607,6 +616,9 @@ func TestGetUserProfile(t *testing.T) {
 	exp := getTestUserProfile()
 	if profile.DisplayName != exp.DisplayName {
 		t.Fatalf(`profile.DisplayName = "%s", wanted "%s"`, profile.DisplayName, exp.DisplayName)
+	}
+	if len(profile.StatusEmojiDisplayInfo) != 1 {
+		t.Fatalf(`expected 1 emoji, got %d`, len(profile.StatusEmojiDisplayInfo))
 	}
 }
 


### PR DESCRIPTION
Add missing field to `users.profile.get`, `status_emoji_display_info` which is a list of all the emoji's present in the status emoji or status text and details about them.

Here is an example response:

```
{
    "ok": true,
    "profile": {
        ...
        "status_text": "Construction!",
        "status_emoji": ":construction:",
        "status_emoji_display_info": [
            {
                "emoji_name": "construction",
                "unicode": "1f6a7",
                "display_url": "https://a.slack-edge.com/production-standard-emoji-assets/14.0/apple-large/1f6a7.png"
            }
        ],
        "status_expiration": 0,
        ...
       }
}
```