### PR TITLE
fix: remove omitempty from replace_original and delete_orginal

### DIFF
--- a/webhooks.go
+++ b/webhooks.go
@@ -21,8 +21,8 @@ type WebhookMessage struct {
 	Parse           string       `json:"parse,omitempty"`
 	Blocks          *Blocks      `json:"blocks,omitempty"`
 	ResponseType    string       `json:"response_type,omitempty"`
-	ReplaceOriginal bool         `json:"replace_original,omitempty"`
-	DeleteOriginal  bool         `json:"delete_original,omitempty"`
+	ReplaceOriginal bool         `json:"replace_original"`
+	DeleteOriginal  bool         `json:"delete_original"`
 	ReplyBroadcast  bool         `json:"reply_broadcast,omitempty"`
 }
 

--- a/webhooks_test.go
+++ b/webhooks_test.go
@@ -77,15 +77,15 @@ func TestWebhookMessage_WithBlocks(t *testing.T) {
 	assert.Equal(t, 1, len(msgSingleBlock.Blocks.BlockSet))
 
 	msgJsonSingleBlock, _ := json.Marshal(msgSingleBlock)
-	assert.Equal(t, `{"blocks":[{"type":"section","text":{"type":"plain_text","text":"text"}}]}`, string(msgJsonSingleBlock))
+	assert.Equal(t, `{"blocks":[{"type":"section","text":{"type":"plain_text","text":"text"}}],"replace_original":false,"delete_original":false}`, string(msgJsonSingleBlock))
 
 	msgTwoBlocks := WebhookMessage{Blocks: twoBlocks}
 	assert.Equal(t, 2, len(msgTwoBlocks.Blocks.BlockSet))
 
 	msgJsonTwoBlocks, _ := json.Marshal(msgTwoBlocks)
-	assert.Equal(t, `{"blocks":[{"type":"section","text":{"type":"plain_text","text":"text"}},{"type":"section","text":{"type":"plain_text","text":"text"}}]}`, string(msgJsonTwoBlocks))
+	assert.Equal(t, `{"blocks":[{"type":"section","text":{"type":"plain_text","text":"text"}},{"type":"section","text":{"type":"plain_text","text":"text"}}],"replace_original":false,"delete_original":false}`, string(msgJsonTwoBlocks))
 
 	msgNoBlocks := WebhookMessage{Text: "foo"}
 	msgJsonNoBlocks, _ := json.Marshal(msgNoBlocks)
-	assert.Equal(t, `{"text":"foo"}`, string(msgJsonNoBlocks))
+	assert.Equal(t, `{"text":"foo","replace_original":false,"delete_original":false}`, string(msgJsonNoBlocks))
 }


### PR DESCRIPTION
## why
I saw the issue on https://github.com/slack-go/slack/issues/1063 and fixed it.

## what
- I removed omitempty in replaceOriginal and deleteOriginal in webhookmessage.
- I made a few changes to the webhookmessage test.

