### PR TITLE
fix: panic when ParseEvent if event data not provide

### DIFF
--- a/slackevents/parsers.go
+++ b/slackevents/parsers.go
@@ -95,6 +95,18 @@ func parseOuterEvent(rawE json.RawMessage) (EventsAPIEvent, error) {
 func parseInnerEvent(e *EventsAPICallbackEvent) (EventsAPIEvent, error) {
 	iE := &slack.Event{}
 	rawInnerJSON := e.InnerEvent
+	if rawInnerJSON == nil {
+		return EventsAPIEvent{
+			e.Token,
+			e.TeamID,
+			"unmarshalling_error",
+			e.APIAppID,
+			"",
+			nil,
+			EventsAPIInnerEvent{},
+		}, errors.New("Inner Event empty!")
+	}
+
 	err := json.Unmarshal(*rawInnerJSON, iE)
 	if err != nil {
 		return EventsAPIEvent{

--- a/slackevents/parsers_test.go
+++ b/slackevents/parsers_test.go
@@ -143,3 +143,11 @@ func TestNoTokenVerification(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestNoInnerEvent(t *testing.T) {
+	noInnerEvent := `{"type":"event_callback"}`
+	_, e := ParseEvent(json.RawMessage(noInnerEvent), OptionNoVerifyToken())
+	if e == nil {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
##### API changes

No API changes

##### Bug fixes

```go
noInnerEvent := `{"type":"event_callback"}`
slackevents.ParseEvent(json.RawMessage(noInnerEvent))
```

When json don't contains `event` field, `ParseEvent` will panic.
