### PR TITLE
Fix WorkflowStepCompletedRequest options handling

### DIFF
--- a/workflow_step_execute.go
+++ b/workflow_step_execute.go
@@ -19,10 +19,10 @@ type (
 	}
 )
 
-type WorkflowStepCompletedRequestOption func(opt WorkflowStepCompletedRequest) error
+type WorkflowStepCompletedRequestOption func(opt *WorkflowStepCompletedRequest) error
 
 func WorkflowStepCompletedRequestOptionOutput(outputs map[string]string) WorkflowStepCompletedRequestOption {
-	return func(opt WorkflowStepCompletedRequest) error {
+	return func(opt *WorkflowStepCompletedRequest) error {
 		if len(outputs) > 0 {
 			opt.Outputs = outputs
 		}
@@ -33,7 +33,7 @@ func WorkflowStepCompletedRequestOptionOutput(outputs map[string]string) Workflo
 // WorkflowStepCompleted indicates step is completed
 func (api *Client) WorkflowStepCompleted(workflowStepExecuteID string, options ...WorkflowStepCompletedRequestOption) error {
 	// More information: https://api.slack.com/methods/workflows.stepCompleted
-	r := WorkflowStepCompletedRequest{
+	r := &WorkflowStepCompletedRequest{
 		WorkflowStepExecuteID: workflowStepExecuteID,
 	}
 	for _, option := range options {


### PR DESCRIPTION
This PR fixes handling for options of `WorkflowStepCompletedRequest`. (description added by @kanata2)

---

##### Pull Request Guidelines

These are recommendations for pull requests.
They are strictly guidelines to help manage expectations.

##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### Examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.
