### PR TITLE
Added new FileUploadV2 function to avoid server side file timeouts

### DIFF
--- a/files.go
+++ b/files.go
@@ -524,7 +524,7 @@ func (api *Client) completeUploadExternal(ctx context.Context, fileID string, pa
 	return response, nil
 }
 
-// UploadFileV2 uploads file to a given slack channel using 3 steps - 
+// UploadFileV2 uploads file to a given slack channel using 3 steps -
 // 	1. Get an upload URL using files.getUploadURLExternal API
 //  2. Send the file as a post to the URL provided by slack
 //  3. Complete the upload and share it to the specified channel using files.completeUploadExternal
@@ -532,7 +532,7 @@ func (api *Client) UploadFileV2(params FileUploadV2Parameters) (*FileSummary, er
 	return api.UploadFileV2Context(context.Background(), params)
 }
 
-// UploadFileV2 uploads file to a given slack channel using 3 steps with a custom context - 
+// UploadFileV2 uploads file to a given slack channel using 3 steps with a custom context -
 // 	1. Get an upload URL using files.getUploadURLExternal API
 //  2. Send the file as a post to the URL provided by slack
 //  3. Complete the upload and share it to the specified channel using files.completeUploadExternal
@@ -567,7 +567,7 @@ func (api *Client) UploadFileV2Context(ctx context.Context, params FileUploadV2P
 		return nil, err
 	}
 	if len(c.Files) != 1 {
-		return nil, fmt.Errorf("file.upload.v2: something went wrong; recieved %d files instead of 1", len(c.Files))
+		return nil, fmt.Errorf("file.upload.v2: something went wrong; received %d files instead of 1", len(c.Files))
 	}
 
 	return &c.Files[0], nil

--- a/files.go
+++ b/files.go
@@ -459,10 +459,10 @@ func (api *Client) ShareFilePublicURLContext(ctx context.Context, fileID string)
 // getUploadURLExternal gets a URL and fileID from slack which can later be used to upload a file
 func (api *Client) getUploadURLExternal(ctx context.Context, fileSize int, fileName, altText, snippetText string) (*getUploadURLExternalResponse, error) {
 	values := url.Values{
-		"token": {api.token},
+		"token":    {api.token},
+		"filename": {fileName},
+		"length":   {strconv.Itoa(fileSize)},
 	}
-	values.Add("filename", fileName)
-	values.Add("length", strconv.Itoa(fileSize))
 	if altText != "" {
 		values.Add("initial_comment", altText)
 	}
@@ -495,17 +495,16 @@ func (api *Client) uploadToURL(ctx context.Context, params uploadToExternalParam
 
 // completeUploadExternal once files are uploaded, this completes the upload and shares it to the specified channel
 func (api *Client) completeUploadExternal(ctx context.Context, fileID string, params FileUploadV2Parameters) (file *completeUploadExternalResponse, err error) {
-	values := url.Values{
-		"token": {api.token},
-	}
-
 	request := []FileSummary{{ID: fileID, Title: params.Title}}
 	requestBytes, err := json.Marshal(request)
 	if err != nil {
 		return nil, err
 	}
-	values.Add("files", string(requestBytes))
-	values.Add("channel_id", params.Channel)
+	values := url.Values{
+		"token":      {api.token},
+		"files":      {string(requestBytes)},
+		"channel_id": {params.Channel},
+	}
 
 	if params.InitialComment != "" {
 		values.Add("initial_comment", params.InitialComment)

--- a/files_test.go
+++ b/files_test.go
@@ -211,3 +211,65 @@ func TestUploadFileWithoutFilename(t *testing.T) {
 		t.Errorf("Error message should mention empty FileUploadParameters.Filename")
 	}
 }
+
+func uploadURLHandler(rw http.ResponseWriter, r *http.Request) {
+	rw.Header().Set("Content-Type", "application/json")
+	response, _ := json.Marshal(getUploadURLExternalResponse{
+		FileID:        "RandomID",
+		UploadURL:     "http://" + serverAddr + "/abc",
+		SlackResponse: SlackResponse{Ok: true}})
+	rw.Write(response)
+}
+
+func urlFileUploadHandler(rw http.ResponseWriter, r *http.Request) {
+	rw.Header().Set("Content-Type", "text")
+	rw.Write([]byte("Ok: 200, file uploaded"))
+}
+
+func completeURLUpload(rw http.ResponseWriter, r *http.Request) {
+	rw.Header().Set("Content-Type", "application/json")
+	response, _ := json.Marshal(completeUploadExternalResponse{
+		Files: []FileSummary{
+			{
+				ID:    "RandomID",
+				Title: "",
+			},
+		},
+		SlackResponse: SlackResponse{Ok: true}})
+	rw.Write(response)
+}
+
+func TestUploadFileV2(t *testing.T) {
+	http.HandleFunc("/files.getUploadURLExternal", uploadURLHandler)
+	http.HandleFunc("/abc", urlFileUploadHandler)
+	http.HandleFunc("/files.completeUploadExternal", completeURLUpload)
+	once.Do(startServer)
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
+
+	params := FileUploadV2Parameters{
+		Filename: "test.txt", Content: "test content", FileSize: 10,
+		Channel: "CXXXXXXXX",
+	}
+	if _, err := api.UploadFileV2(params); err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+
+	reader := bytes.NewBufferString("test reader")
+	params = FileUploadV2Parameters{
+		Filename: "test.txt",
+		Reader:   reader,
+		FileSize: 10,
+		Channel:  "CXXXXXXXX"}
+	if _, err := api.UploadFileV2(params); err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+
+	largeByt := make([]byte, 107374200)
+	reader = bytes.NewBuffer(largeByt)
+	params = FileUploadV2Parameters{
+		Filename: "test.txt", Reader: reader, FileSize: len(largeByt),
+		Channel: "CXXXXXXXX"}
+	if _, err := api.UploadFileV2(params); err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+}

--- a/misc.go
+++ b/misc.go
@@ -307,6 +307,9 @@ type responseParser func(*http.Response) error
 
 func newJSONParser(dst interface{}) responseParser {
 	return func(resp *http.Response) error {
+		if dst == nil {
+			return nil
+		}
 		return json.NewDecoder(resp.Body).Decode(dst)
 	}
 }


### PR DESCRIPTION
### Linking issue 
This PR solves for - https://github.com/slack-go/slack/issues/1108
Implements the methods suggested in - https://github.com/slackapi/python-slack-sdk/releases/tag/v3.19.0

Need to account for nil interface because slack doesn't give `SlackResponse` or any json response for that matter when uploading file via post to [GetUploadURLExternal](https://api.slack.com/methods/files.getUploadURLExternal)'s UploadURL
