### PR TITLE
fix: change type of timestamp

### DIFF
--- a/block_rich_text.go
+++ b/block_rich_text.go
@@ -327,17 +327,17 @@ func NewRichTextSectionUserGroupElement(usergroupID string) *RichTextSectionUser
 
 type RichTextSectionDateElement struct {
 	Type      RichTextSectionElementType `json:"type"`
-	Timestamp string                     `json:"timestamp"`
+	Timestamp JSONTime                   `json:"timestamp"`
 }
 
 func (r RichTextSectionDateElement) RichTextSectionElementType() RichTextSectionElementType {
 	return r.Type
 }
 
-func NewRichTextSectionDateElement(timestamp string) *RichTextSectionDateElement {
+func NewRichTextSectionDateElement(timestamp int64) *RichTextSectionDateElement {
 	return &RichTextSectionDateElement{
 		Type:      RTSEDate,
-		Timestamp: timestamp,
+		Timestamp: JSONTime(timestamp),
 	}
 }
 

--- a/block_rich_text_test.go
+++ b/block_rich_text_test.go
@@ -80,12 +80,13 @@ func TestRichTextSection_UnmarshalJSON(t *testing.T) {
 		err      error
 	}{
 		{
-			[]byte(`{"elements":[{"type":"unknown","value":10},{"type":"text","text":"hi"}]}`),
+			[]byte(`{"elements":[{"type":"unknown","value":10},{"type":"text","text":"hi"},{"type":"date","timestamp":1636961629}]}`),
 			RichTextSection{
 				Type: RTESection,
 				Elements: []RichTextSectionElement{
 					&RichTextSectionUnknownElement{Type: RTSEUnknown, Raw: `{"type":"unknown","value":10}`},
 					&RichTextSectionTextElement{Type: RTSEText, Text: "hi"},
+					&RichTextSectionDateElement{Type: RTSEDate, Timestamp: JSONTime(1636961629)},
 				},
 			},
 			nil,


### PR DESCRIPTION
## why
I saw the issues on https://github.com/slack-go/slack/issues/1123 and https://github.com/slack-go/slack/issues/1104.
I fixed them.

## what
I changed the Timestamp defined in RichTextSectionDateElement to a JSONTime type.
I also added the case of RichTextSectionDateElement to the test.