### PR TITLE
feat: add number input block element

### DIFF
--- a/block_conv.go
+++ b/block_conv.go
@@ -122,6 +122,8 @@ func (b *InputBlock) UnmarshalJSON(data []byte) error {
 		e = &OverflowBlockElement{}
 	case "radio_buttons":
 		e = &RadioButtonsBlockElement{}
+	case "number_input":
+		e = &NumberInputBlockElement{}
 	default:
 		return errors.New("unsupported block element type")
 	}
@@ -192,6 +194,8 @@ func (b *BlockElements) UnmarshalJSON(data []byte) error {
 			blockElement = &RadioButtonsBlockElement{}
 		case "static_select", "external_select", "users_select", "conversations_select", "channels_select":
 			blockElement = &SelectBlockElement{}
+		case "number_input":
+			blockElement = &NumberInputBlockElement{}
 		default:
 			return fmt.Errorf("unsupported block element type %v", blockElementType)
 		}

--- a/block_element.go
+++ b/block_element.go
@@ -11,6 +11,7 @@ const (
 	METTimepicker     MessageElementType = "timepicker"
 	METPlainTextInput MessageElementType = "plain_text_input"
 	METRadioButtons   MessageElementType = "radio_buttons"
+	METNumber         MessageElementType = "number_input"
 
 	MixedElementImage MixedElementType = "mixed_image"
 	MixedElementText  MixedElementType = "mixed_text"
@@ -473,5 +474,36 @@ func NewRadioButtonsBlockElement(actionID string, options ...*OptionBlockObject)
 		Type:     METRadioButtons,
 		ActionID: actionID,
 		Options:  options,
+	}
+}
+
+// NumberInputBlockElement creates a field where a user can enter number
+// data.
+// Number input elements are currently only available in modals.
+//
+// More Information: https://api.slack.com/reference/block-kit/block-elements#number
+type NumberInputBlockElement struct {
+	Type                 MessageElementType    `json:"type"`
+	IsDecimalAllowed     bool                  `json:"is_decimal_allowed"`
+	ActionID             string                `json:"action_id,omitempty"`
+	Placeholder          *TextBlockObject      `json:"placeholder,omitempty"`
+	InitialValue         string                `json:"initial_value,omitempty"`
+	MinValue             string                `json:"min_value,omitempty"`
+	MaxValue             string                `json:"max_value,omitempty"`
+	DispatchActionConfig *DispatchActionConfig `json:"dispatch_action_config,omitempty"`
+}
+
+// ElementType returns the type of the Element
+func (s NumberInputBlockElement) ElementType() MessageElementType {
+	return s.Type
+}
+
+// NewNumberInputBlockElement returns an instance of a number input element
+func NewNumberInputBlockElement(placeholder *TextBlockObject, actionID string, isDecimalAllowed bool) *NumberInputBlockElement {
+	return &NumberInputBlockElement{
+		Type:             METNumber,
+		ActionID:         actionID,
+		Placeholder:      placeholder,
+		IsDecimalAllowed: isDecimalAllowed,
 	}
 }

--- a/block_element_test.go
+++ b/block_element_test.go
@@ -185,3 +185,13 @@ func TestNewRadioButtonsBlockElement(t *testing.T) {
 	assert.Equal(t, len(radioButtonsElement.Options), 3)
 
 }
+
+func TestNewNumberInputBlockElement(t *testing.T) {
+
+	numberInputElement := NewNumberInputBlockElement(nil, "test", true)
+
+	assert.Equal(t, string(numberInputElement.Type), "number_input")
+	assert.Equal(t, numberInputElement.ActionID, "test")
+	assert.Equal(t, numberInputElement.IsDecimalAllowed, true)
+
+}


### PR DESCRIPTION
I added `NumberInputBlockElement` type. It's necessary to make input blocks which accepts only numbers.