### PR TITLE
Add team_id as a parameter to the users.conversations API method

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -71,6 +71,7 @@ type GetConversationsForUserParameters struct {
 	Types           []string
 	Limit           int
 	ExcludeArchived bool
+	TeamID          string
 }
 
 type responseMetaData struct {
@@ -137,6 +138,10 @@ func (api *Client) GetConversationsForUserContext(ctx context.Context, params *G
 	if params.ExcludeArchived {
 		values.Add("exclude_archived", "true")
 	}
+	if params.TeamID != "" {
+		values.Add("team_id", params.TeamID)
+	}
+
 	response := struct {
 		Channels         []Channel        `json:"channels"`
 		ResponseMetaData responseMetaData `json:"response_metadata"`


### PR DESCRIPTION
This API method takes an optional team_id parameter, which is required if you're using an app/bot with organization access. This just exposes this in golang. There's no existing test for this method, so nothing for me to add on to here.