### PR TITLE
add block elements for email_text_input and url_text_input

### DIFF
--- a/block_conv.go
+++ b/block_conv.go
@@ -112,6 +112,10 @@ func (b *InputBlock) UnmarshalJSON(data []byte) error {
 		e = &TimePickerBlockElement{}
 	case "plain_text_input":
 		e = &PlainTextInputBlockElement{}
+	case "email_text_input":
+		e = &EmailTextInputBlockElement{}
+	case "url_text_input":
+		e = &URLTextInputBlockElement{}
 	case "static_select", "external_select", "users_select", "conversations_select", "channels_select":
 		e = &SelectBlockElement{}
 	case "multi_static_select", "multi_external_select", "multi_users_select", "multi_conversations_select", "multi_channels_select":
@@ -186,6 +190,10 @@ func (b *BlockElements) UnmarshalJSON(data []byte) error {
 			blockElement = &TimePickerBlockElement{}
 		case "plain_text_input":
 			blockElement = &PlainTextInputBlockElement{}
+		case "email_text_input":
+			blockElement = &EmailTextInputBlockElement{}
+		case "url_text_input":
+			blockElement = &URLTextInputBlockElement{}
 		case "checkboxes":
 			blockElement = &CheckboxGroupsBlockElement{}
 		case "radio_buttons":

--- a/block_element.go
+++ b/block_element.go
@@ -402,6 +402,7 @@ type EmailTextInputBlockElement struct {
 	Placeholder          *TextBlockObject      `json:"placeholder,omitempty"`
 	InitialValue         string                `json:"initial_value,omitempty"`
 	DispatchActionConfig *DispatchActionConfig `json:"dispatch_action_config,omitempty"`
+	FocusOnLoad          bool                  `json:"focus_on_load,omitempty"`
 }
 
 // ElementType returns the type of the Element
@@ -430,6 +431,7 @@ type URLTextInputBlockElement struct {
 	Placeholder          *TextBlockObject      `json:"placeholder,omitempty"`
 	InitialValue         string                `json:"initial_value,omitempty"`
 	DispatchActionConfig *DispatchActionConfig `json:"dispatch_action_config,omitempty"`
+	FocusOnLoad          bool                  `json:"focus_on_load,omitempty"`
 }
 
 // ElementType returns the type of the Element

--- a/block_element.go
+++ b/block_element.go
@@ -11,6 +11,8 @@ const (
 	METTimepicker     MessageElementType = "timepicker"
 	METPlainTextInput MessageElementType = "plain_text_input"
 	METRadioButtons   MessageElementType = "radio_buttons"
+	METEmailTextInput MessageElementType = "email_text_input"
+	METURLTextInput   MessageElementType = "url_text_input"
 
 	MixedElementImage MixedElementType = "mixed_image"
 	MixedElementText  MixedElementType = "mixed_text"
@@ -386,6 +388,62 @@ func NewTimePickerBlockElement(actionID string) *TimePickerBlockElement {
 	return &TimePickerBlockElement{
 		Type:     METTimepicker,
 		ActionID: actionID,
+	}
+}
+
+// EmailTextInputBlockElement creates a field where a user can enter email
+// data.
+// email-text-input elements are currently only available in modals.
+//
+// More Information: https://api.slack.com/reference/block-kit/block-elements#email
+type EmailTextInputBlockElement struct {
+	Type                 MessageElementType    `json:"type"`
+	ActionID             string                `json:"action_id,omitempty"`
+	Placeholder          *TextBlockObject      `json:"placeholder,omitempty"`
+	InitialValue         string                `json:"initial_value,omitempty"`
+	DispatchActionConfig *DispatchActionConfig `json:"dispatch_action_config,omitempty"`
+}
+
+// ElementType returns the type of the Element
+func (s EmailTextInputBlockElement) ElementType() MessageElementType {
+	return s.Type
+}
+
+// NewEmailTextInputBlockElement returns an instance of a plain-text input
+// element
+func NewEmailTextInputBlockElement(placeholder *TextBlockObject, actionID string) *EmailTextInputBlockElement {
+	return &EmailTextInputBlockElement{
+		Type:        METEmailTextInput,
+		ActionID:    actionID,
+		Placeholder: placeholder,
+	}
+}
+
+// URLTextInputBlockElement creates a field where a user can enter url data.
+//
+// url-text-input elements are currently only available in modals.
+//
+// More Information: https://api.slack.com/reference/block-kit/block-elements#url
+type URLTextInputBlockElement struct {
+	Type                 MessageElementType    `json:"type"`
+	ActionID             string                `json:"action_id,omitempty"`
+	Placeholder          *TextBlockObject      `json:"placeholder,omitempty"`
+	InitialValue         string                `json:"initial_value,omitempty"`
+	DispatchActionConfig *DispatchActionConfig `json:"dispatch_action_config,omitempty"`
+}
+
+// ElementType returns the type of the Element
+func (s URLTextInputBlockElement) ElementType() MessageElementType {
+	return s.Type
+}
+
+// NewURLTextInputBlockElement returns an instance of a plain-text input
+// element
+func NewURLTextInputBlockElement(placeholder *TextBlockObject, actionID string) *URLTextInputBlockElement {
+	return &URLTextInputBlockElement{
+		Type:        METURLTextInput,
+		ActionID:    actionID,
+		Placeholder: placeholder,
 	}
 }
 

--- a/block_element_test.go
+++ b/block_element_test.go
@@ -143,17 +143,17 @@ func TestNewPlainTextInputBlockElement(t *testing.T) {
 }
 
 func TestNewEmailTextInputBlockElement(t *testing.T) {
-	emailTextInputElement := NewEmailTextInputBlockElement(nil, "test@test.com")
+	emailTextInputElement := NewEmailTextInputBlockElement(nil, "example@example.com")
 
 	assert.Equal(t, string(emailTextInputElement.Type), "email_text_input")
-	assert.Equal(t, emailTextInputElement.ActionID, "test@test.com")
+	assert.Equal(t, emailTextInputElement.ActionID, "example@example.com")
 }
 
 func TestNewURLTextInputBlockElement(t *testing.T) {
-	urlTextInputElement := NewURLTextInputBlockElement(nil, "www.test.com")
+	urlTextInputElement := NewURLTextInputBlockElement(nil, "www.example.com")
 
 	assert.Equal(t, string(urlTextInputElement.Type), "url_text_input")
-	assert.Equal(t, urlTextInputElement.ActionID, "www.test.com")
+	assert.Equal(t, urlTextInputElement.ActionID, "www.example.com")
 }
 
 func TestNewCheckboxGroupsBlockElement(t *testing.T) {

--- a/block_element_test.go
+++ b/block_element_test.go
@@ -142,6 +142,20 @@ func TestNewPlainTextInputBlockElement(t *testing.T) {
 
 }
 
+func TestNewEmailTextInputBlockElement(t *testing.T) {
+	emailTextInputElement := NewEmailTextInputBlockElement(nil, "test@test.com")
+
+	assert.Equal(t, string(emailTextInputElement.Type), "email_text_input")
+	assert.Equal(t, emailTextInputElement.ActionID, "test@test.com")
+}
+
+func TestNewURLTextInputBlockElement(t *testing.T) {
+	urlTextInputElement := NewURLTextInputBlockElement(nil, "www.test.com")
+
+	assert.Equal(t, string(urlTextInputElement.Type), "url_text_input")
+	assert.Equal(t, urlTextInputElement.ActionID, "www.test.com")
+}
+
 func TestNewCheckboxGroupsBlockElement(t *testing.T) {
 	// Build Text Objects associated with each option
 	checkBoxOptionTextOne := NewTextBlockObject("plain_text", "Check One", false, false)


### PR DESCRIPTION
Adds [`email_text_input`](https://api.slack.com/reference/block-kit/block-elements#email) and [`url_text_input`](https://api.slack.com/reference/block-kit/block-elements#url) block elements, which were recently added to BlockKit, to the SDK.

I tested these by using them in a modal:
![Screenshot 2022-11-30 at 9 51 11 AM](https://user-images.githubusercontent.com/7328106/204829488-b68f7601-264d-4d50-9389-7fe729f20d17.png)

And the values in the request from Slack:
![Screenshot 2022-11-30 at 9 52 14 AM](https://user-images.githubusercontent.com/7328106/204829526-74c5cc89-9893-4e79-bfa6-04b1960e793d.png)
