### PR TITLE
fix: change period to comma

### DIFF
--- a/block_rich_text.go
+++ b/block_rich_text.go
@@ -294,7 +294,7 @@ func NewRichTextSectionLinkElement(url, text string, style *RichTextSectionTextS
 type RichTextSectionTeamElement struct {
 	Type   RichTextSectionElementType `json:"type"`
 	TeamID string                     `json:"team_id"`
-	Style  *RichTextSectionTextStyle  `json:"style.omitempty"`
+	Style  *RichTextSectionTextStyle  `json:"style,omitempty"`
 }
 
 func (r RichTextSectionTeamElement) RichTextSectionElementType() RichTextSectionElementType {
@@ -312,64 +312,76 @@ func NewRichTextSectionTeamElement(teamID string, style *RichTextSectionTextStyl
 type RichTextSectionUserGroupElement struct {
 	Type        RichTextSectionElementType `json:"type"`
 	UsergroupID string                     `json:"usergroup_id"`
+	Style       *RichTextSectionTextStyle  `json:"style,omitempty"`
 }
 
 func (r RichTextSectionUserGroupElement) RichTextSectionElementType() RichTextSectionElementType {
 	return r.Type
 }
 
-func NewRichTextSectionUserGroupElement(usergroupID string) *RichTextSectionUserGroupElement {
+func NewRichTextSectionUserGroupElement(usergroupID string, style *RichTextSectionTextStyle) *RichTextSectionUserGroupElement {
 	return &RichTextSectionUserGroupElement{
 		Type:        RTSEUserGroup,
 		UsergroupID: usergroupID,
+		Style:       style,
 	}
 }
 
 type RichTextSectionDateElement struct {
 	Type      RichTextSectionElementType `json:"type"`
 	Timestamp JSONTime                   `json:"timestamp"`
+	Format    string                     `json:"format"`
+	Fallback  string                     `json:"fallback,omitempty"`
+	Style     *RichTextSectionTextStyle  `json:"style,omitempty"`
 }
 
 func (r RichTextSectionDateElement) RichTextSectionElementType() RichTextSectionElementType {
 	return r.Type
 }
 
-func NewRichTextSectionDateElement(timestamp int64) *RichTextSectionDateElement {
+func NewRichTextSectionDateElement(timestamp int64, format, fallback string, style *RichTextSectionTextStyle) *RichTextSectionDateElement {
 	return &RichTextSectionDateElement{
 		Type:      RTSEDate,
 		Timestamp: JSONTime(timestamp),
+		Format:    format,
+		Fallback:  fallback,
+		Style:     style,
 	}
 }
 
 type RichTextSectionBroadcastElement struct {
 	Type  RichTextSectionElementType `json:"type"`
 	Range string                     `json:"range"`
+	Style *RichTextSectionTextStyle  `json:"style,omitempty"`
 }
 
 func (r RichTextSectionBroadcastElement) RichTextSectionElementType() RichTextSectionElementType {
 	return r.Type
 }
 
-func NewRichTextSectionBroadcastElement(rangeStr string) *RichTextSectionBroadcastElement {
+func NewRichTextSectionBroadcastElement(rangeStr string, style *RichTextSectionTextStyle) *RichTextSectionBroadcastElement {
 	return &RichTextSectionBroadcastElement{
 		Type:  RTSEBroadcast,
 		Range: rangeStr,
+		Style: style,
 	}
 }
 
 type RichTextSectionColorElement struct {
 	Type  RichTextSectionElementType `json:"type"`
 	Value string                     `json:"value"`
+	Style *RichTextSectionTextStyle  `json:"style,omitempty"`
 }
 
 func (r RichTextSectionColorElement) RichTextSectionElementType() RichTextSectionElementType {
 	return r.Type
 }
 
-func NewRichTextSectionColorElement(value string) *RichTextSectionColorElement {
+func NewRichTextSectionColorElement(value string, style *RichTextSectionTextStyle) *RichTextSectionColorElement {
 	return &RichTextSectionColorElement{
 		Type:  RTSEColor,
 		Value: value,
+		Style: style,
 	}
 }
 

--- a/block_rich_text.go
+++ b/block_rich_text.go
@@ -312,76 +312,64 @@ func NewRichTextSectionTeamElement(teamID string, style *RichTextSectionTextStyl
 type RichTextSectionUserGroupElement struct {
 	Type        RichTextSectionElementType `json:"type"`
 	UsergroupID string                     `json:"usergroup_id"`
-	Style       *RichTextSectionTextStyle  `json:"style,omitempty"`
 }
 
 func (r RichTextSectionUserGroupElement) RichTextSectionElementType() RichTextSectionElementType {
 	return r.Type
 }
 
-func NewRichTextSectionUserGroupElement(usergroupID string, style *RichTextSectionTextStyle) *RichTextSectionUserGroupElement {
+func NewRichTextSectionUserGroupElement(usergroupID string) *RichTextSectionUserGroupElement {
 	return &RichTextSectionUserGroupElement{
 		Type:        RTSEUserGroup,
 		UsergroupID: usergroupID,
-		Style:       style,
 	}
 }
 
 type RichTextSectionDateElement struct {
 	Type      RichTextSectionElementType `json:"type"`
 	Timestamp JSONTime                   `json:"timestamp"`
-	Format    string                     `json:"format"`
-	Fallback  string                     `json:"fallback,omitempty"`
-	Style     *RichTextSectionTextStyle  `json:"style,omitempty"`
 }
 
 func (r RichTextSectionDateElement) RichTextSectionElementType() RichTextSectionElementType {
 	return r.Type
 }
 
-func NewRichTextSectionDateElement(timestamp int64, format, fallback string, style *RichTextSectionTextStyle) *RichTextSectionDateElement {
+func NewRichTextSectionDateElement(timestamp int64) *RichTextSectionDateElement {
 	return &RichTextSectionDateElement{
 		Type:      RTSEDate,
 		Timestamp: JSONTime(timestamp),
-		Format:    format,
-		Fallback:  fallback,
-		Style:     style,
 	}
 }
 
 type RichTextSectionBroadcastElement struct {
 	Type  RichTextSectionElementType `json:"type"`
 	Range string                     `json:"range"`
-	Style *RichTextSectionTextStyle  `json:"style,omitempty"`
 }
 
 func (r RichTextSectionBroadcastElement) RichTextSectionElementType() RichTextSectionElementType {
 	return r.Type
 }
 
-func NewRichTextSectionBroadcastElement(rangeStr string, style *RichTextSectionTextStyle) *RichTextSectionBroadcastElement {
+func NewRichTextSectionBroadcastElement(rangeStr string) *RichTextSectionBroadcastElement {
 	return &RichTextSectionBroadcastElement{
 		Type:  RTSEBroadcast,
 		Range: rangeStr,
-		Style: style,
 	}
 }
 
 type RichTextSectionColorElement struct {
 	Type  RichTextSectionElementType `json:"type"`
 	Value string                     `json:"value"`
-	Style *RichTextSectionTextStyle  `json:"style,omitempty"`
 }
 
 func (r RichTextSectionColorElement) RichTextSectionElementType() RichTextSectionElementType {
 	return r.Type
 }
 
-func NewRichTextSectionColorElement(value string, style *RichTextSectionTextStyle) *RichTextSectionColorElement {
+func NewRichTextSectionColorElement(value string) *RichTextSectionColorElement {
 	return &RichTextSectionColorElement{
 		Type:  RTSEColor,
 		Value: value,
-		Style: style,
 	}
 }
 

--- a/block_rich_text_test.go
+++ b/block_rich_text_test.go
@@ -80,14 +80,13 @@ func TestRichTextSection_UnmarshalJSON(t *testing.T) {
 		err      error
 	}{
 		{
-			[]byte(`{"elements":[{"type":"unknown","value":10},{"type":"text","text":"hi"},{"type":"date","timestamp":1636961629},{"type":"date","timestamp":1636961629,"format":"{date} at {time}","fallback":"not available"}]}`),
+			[]byte(`{"elements":[{"type":"unknown","value":10},{"type":"text","text":"hi"},{"type":"date","timestamp":1636961629}]}`),
 			RichTextSection{
 				Type: RTESection,
 				Elements: []RichTextSectionElement{
 					&RichTextSectionUnknownElement{Type: RTSEUnknown, Raw: `{"type":"unknown","value":10}`},
 					&RichTextSectionTextElement{Type: RTSEText, Text: "hi"},
 					&RichTextSectionDateElement{Type: RTSEDate, Timestamp: JSONTime(1636961629)},
-					&RichTextSectionDateElement{Type: RTSEDate, Timestamp: JSONTime(1636961629), Format: "{date} at {time}", Fallback: "not available"},
 				},
 			},
 			nil,

--- a/block_rich_text_test.go
+++ b/block_rich_text_test.go
@@ -80,13 +80,14 @@ func TestRichTextSection_UnmarshalJSON(t *testing.T) {
 		err      error
 	}{
 		{
-			[]byte(`{"elements":[{"type":"unknown","value":10},{"type":"text","text":"hi"},{"type":"date","timestamp":1636961629}]}`),
+			[]byte(`{"elements":[{"type":"unknown","value":10},{"type":"text","text":"hi"},{"type":"date","timestamp":1636961629},{"type":"date","timestamp":1636961629,"format":"{date} at {time}","fallback":"not available"}]}`),
 			RichTextSection{
 				Type: RTESection,
 				Elements: []RichTextSectionElement{
 					&RichTextSectionUnknownElement{Type: RTSEUnknown, Raw: `{"type":"unknown","value":10}`},
 					&RichTextSectionTextElement{Type: RTSEText, Text: "hi"},
 					&RichTextSectionDateElement{Type: RTSEDate, Timestamp: JSONTime(1636961629)},
+					&RichTextSectionDateElement{Type: RTSEDate, Timestamp: JSONTime(1636961629), Format: "{date} at {time}", Fallback: "not available"},
 				},
 			},
 			nil,


### PR DESCRIPTION
### Why
The character before omitempty in the RichTextSectionElement struct tag was period.

### What
I changed to comma.

