### PR TITLE
Add support for Rich Text Lists

### DIFF
--- a/block_rich_text.go
+++ b/block_rich_text.go
@@ -106,14 +106,16 @@ type RichTextList struct {
 	Type     RichTextElementType     `json:"type"`
 	Elements []RichTextElement       `json:"elements"`
 	Style    RichTextListElementType `json:"style"`
+	Indent   int                     `json:"indent"`
 }
 
 // NewRichTextList returns a new rich text list element.
-func NewRichTextList(style RichTextListElementType, elements ...RichTextElement) *RichTextList {
+func NewRichTextList(style RichTextListElementType, indent int, elements ...RichTextElement) *RichTextList {
 	return &RichTextList{
 		Type:     RTEList,
 		Elements: elements,
 		Style:    style,
+		Indent:   indent,
 	}
 }
 
@@ -126,6 +128,7 @@ func (e *RichTextList) UnmarshalJSON(b []byte) error {
 	var raw struct {
 		RawElements []json.RawMessage       `json:"elements"`
 		Style       RichTextListElementType `json:"style"`
+		Indent      int                     `json:"indent"`
 	}
 	if string(b) == "{}" {
 		return nil
@@ -163,6 +166,7 @@ func (e *RichTextList) UnmarshalJSON(b []byte) error {
 		Type:     RTEList,
 		Elements: elems,
 		Style:    raw.Style,
+		Indent:   raw.Indent,
 	}
 	return nil
 }

--- a/block_rich_text_test.go
+++ b/block_rich_text_test.go
@@ -172,6 +172,15 @@ func TestRichTextList_UnmarshalJSON(t *testing.T) {
 			},
 			nil,
 		},
+		{
+			[]byte(`{"type": "rich_text_list","elements":[],"indent":2}`),
+			RichTextList{
+				Type:     RTEList,
+				Indent:	  2,
+				Elements: []RichTextElement{},
+			},
+			nil,
+		},
 	}
 	for _, tc := range cases {
 		var actual RichTextList

--- a/block_rich_text_test.go
+++ b/block_rich_text_test.go
@@ -36,11 +36,12 @@ func TestRichTextBlock_UnmarshalJSON(t *testing.T) {
 		err      error
 	}{
 		{
-			[]byte(`{"elements":[{"type":"rich_text_unknown"},{"type":"rich_text_section"}]}`),
+			[]byte(`{"elements":[{"type":"rich_text_unknown"},{"type":"rich_text_section"},{"type":"rich_text_list"}]}`),
 			RichTextBlock{
 				Elements: []RichTextElement{
 					&RichTextUnknown{Type: RTEUnknown, Raw: `{"type":"rich_text_unknown"}`},
 					&RichTextSection{Type: RTESection, Elements: []RichTextSectionElement{}},
+					&RichTextList{Type: RTEList, Elements: []RichTextElement{}},
 				},
 			},
 			nil,
@@ -102,6 +103,78 @@ func TestRichTextSection_UnmarshalJSON(t *testing.T) {
 	}
 	for _, tc := range cases {
 		var actual RichTextSection
+		err := json.Unmarshal(tc.raw, &actual)
+		if err != nil {
+			if tc.err == nil {
+				t.Errorf("unexpected error: %s", err)
+			}
+			t.Errorf("expected error is %s, but got %s", tc.err, err)
+		}
+		if tc.err != nil {
+			t.Errorf("expected to raise an error %s", tc.err)
+		}
+		if diff := deep.Equal(actual, tc.expected); diff != nil {
+			t.Errorf("actual value does not match expected one\n%s", diff)
+		}
+	}
+}
+
+func TestRichTextList_UnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		raw      []byte
+		expected RichTextList
+		err      error
+	}{
+		{
+			[]byte(`{"style":"ordered","elements":[{"type":"rich_text_unknown","value":10},{"type":"rich_text_section","elements":[{"type":"text","text":"hi"}]}]}`),
+			RichTextList{
+				Type:  RTEList,
+				Style: RTEListOrdered,
+				Elements: []RichTextElement{
+					&RichTextUnknown{Type: RTEUnknown, Raw: `{"type":"rich_text_unknown","value":10}`},
+					&RichTextSection{
+						Type: RTESection,
+						Elements: []RichTextSectionElement{
+							&RichTextSectionTextElement{Type: RTSEText, Text: "hi"},
+						},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			[]byte(`{"style":"ordered","elements":[{"type":"rich_text_list","style":"bullet","elements":[{"type":"rich_text_section","elements":[{"type":"text","text":"hi"}]}]}]}`),
+			RichTextList{
+				Type:  RTEList,
+				Style: RTEListOrdered,
+				Elements: []RichTextElement{
+					&RichTextList{
+						Type:  RTEList,
+						Style: RTEListBullet,
+						Elements: []RichTextElement{
+							&RichTextSection{
+								Type: RTESection,
+								Elements: []RichTextSectionElement{
+									&RichTextSectionTextElement{Type: RTSEText, Text: "hi"},
+								},
+							},
+						},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			[]byte(`{"type": "rich_text_list","elements":[]}`),
+			RichTextList{
+				Type:     RTEList,
+				Elements: []RichTextElement{},
+			},
+			nil,
+		},
+	}
+	for _, tc := range cases {
+		var actual RichTextList
 		err := json.Unmarshal(tc.raw, &actual)
 		if err != nil {
 			if tc.err == nil {

--- a/block_rich_text_test.go
+++ b/block_rich_text_test.go
@@ -176,7 +176,7 @@ func TestRichTextList_UnmarshalJSON(t *testing.T) {
 			[]byte(`{"type": "rich_text_list","elements":[],"indent":2}`),
 			RichTextList{
 				Type:     RTEList,
-				Indent:	  2,
+				Indent:   2,
 				Elements: []RichTextElement{},
 			},
 			nil,


### PR DESCRIPTION
This PR adds support for rich text lists.
For example:
```json
{
    "token": "...",
    "team_id": "...",
    "api_app_id": "...",
    "event": {
        "client_msg_id": "...",
        "type": "message",
        "text": "test message with list\n1. first point\n2. second point\n• first bullet\n• second bullet\n",
        "user": "...",
        "ts": "1672827783.092039",
        "blocks": [
            {
                "type": "rich_text",
                "block_id": "...",
                "elements": [
                    {
                        "type": "rich_text_section",
                        "elements": [
                            {
                                "type": "text",
                                "text": "test message with list\n"
                            }
                        ]
                    },
                    {
                        "type": "rich_text_list",
                        "elements": [
                            {
                                "type": "rich_text_section",
                                "elements": [
                                    {
                                        "type": "text",
                                        "text": "first point"
                                    }
                                ]
                            },
                            {
                                "type": "rich_text_section",
                                "elements": [
                                    {
                                        "type": "text",
                                        "text": "second point"
                                    }
                                ]
                            }
                        ],
                        "style": "ordered",
                        "indent": 0,
                        "border": 0
                    },
                    {
                        "type": "rich_text_list",
                        "elements": [
                            {
                                "type": "rich_text_section",
                                "elements": [
                                    {
                                        "type": "text",
                                        "text": "first bullet"
                                    }
                                ]
                            },
                            {
                                "type": "rich_text_section",
                                "elements": [
                                    {
                                        "type": "text",
                                        "text": "second bullet"
                                    }
                                ]
                            }
                        ],
                        "style": "bullet",
                        "indent": 0,
                        "border": 0
                    },
                    {
                        "type": "rich_text_section",
                        "elements": []
                    }
                ]
            }
        ],
        "team": "...",
        "channel": "...",
        "event_ts": "1672827783.092039",
        "channel_type": "im"
    },
    "type": "event_callback",
    "event_id": "...",
    "event_time": 1672827783,
    "authorizations": [
        {
            "enterprise_id": null,
            "team_id": "...",
            "user_id": "...",
            "is_bot": true,
            "is_enterprise_install": false
        }
    ],
    "is_ext_shared_channel": false,
    "event_context": "..."
}
```

Reference: https://api.slack.com/changelog/2019-09-what-they-see-is-what-you-get-and-more-and-less