### PR TITLE
socketmode example: use embedded api client in socketmode client

### DIFF
--- a/examples/socketmode/socketmode.go
+++ b/examples/socketmode/socketmode.go
@@ -72,7 +72,7 @@ func main() {
 					innerEvent := eventsAPIEvent.InnerEvent
 					switch ev := innerEvent.Data.(type) {
 					case *slackevents.AppMentionEvent:
-						_, _, err := api.PostMessage(ev.Channel, slack.MsgOptionText("Yes, hello.", false))
+						_, _, err := client.PostMessage(ev.Channel, slack.MsgOptionText("Yes, hello.", false))
 						if err != nil {
 							fmt.Printf("failed posting message: %v", err)
 						}
@@ -137,7 +137,8 @@ func main() {
 								),
 							),
 						),
-					}}
+					},
+				}
 
 				client.Ack(*evt.Request, payload)
 			default:


### PR DESCRIPTION
The socketmode example in its current version is confusing for new users. Although a new socketmode client embeds the provided api client into itself, thus inheriting all methods, the example uses the earlier defined api to call said command. This gives the impression that you need to still keep the original client.

One could even go further by creating the api inline with the socketmode client.

To be honest, elaborating a bit more on the socketmode example would be helpful (or at least would've been helpful to me when I first started using it), but that's out of scope for this tiny PR.

Also, accidentally fixed a small formatting error.