### PR TITLE
socketmode remove duplicate debug logging

### DIFF
--- a/socketmode/socket_mode_managed_conn.go
+++ b/socketmode/socket_mode_managed_conn.go
@@ -1,7 +1,6 @@
 package socketmode
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"

--- a/socketmode/socket_mode_managed_conn.go
+++ b/socketmode/socket_mode_managed_conn.go
@@ -469,18 +469,6 @@ func (smc *Client) receiveMessagesInto(ctx context.Context, conn *websocket.Conn
 	case len(event) == 0:
 		smc.Debugln("Received empty event")
 	default:
-		if smc.debug {
-			buf := &bytes.Buffer{}
-			d := json.NewEncoder(buf)
-			d.SetIndent("", "  ")
-			if err := d.Encode(event); err != nil {
-				smc.Debugln("Failed encoding decoded json:", err)
-			}
-			reencoded := buf.String()
-
-			smc.Debugln("Incoming WebSocket message:", reencoded)
-		}
-
 		select {
 		case sink <- event:
 		case <-ctx.Done():


### PR DESCRIPTION
`smc.runRequestHandler` and `smc.runMessageReceiver` are both run as goroutines. 

Respectively, when debug is enabled, they log the event:
- `smc.Debugf("Received WebSocket message: %s", message)`
- `smc.Debugln("Incoming WebSocket message:", reencoded)` (in receiveMessagesInto)

One of these should be removed. This PR removes the latter as it re-marshalls the json, and pretty prints (and was the offender that made me investigate this in the first place).

I'm open to other ideas too, as long as it means the end result is no pretty-printed log line, and no duplicate logging of the same data in full.