### PR TITLE
Added ReplyUsers to the Msg struct

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -100,10 +100,11 @@ type Msg struct {
 	Members []string `json:"members,omitempty"`
 
 	// channels.replies, groups.replies, im.replies, mpim.replies
-	ReplyCount   int     `json:"reply_count,omitempty"`
-	Replies      []Reply `json:"replies,omitempty"`
-	ParentUserId string  `json:"parent_user_id,omitempty"`
-	LatestReply  string  `json:"latest_reply,omitempty"`
+	ReplyCount    int      `json:"reply_count,omitempty"`
+	Replies       []Reply  `json:"replies,omitempty"`
+	ParentUserId  string   `json:"parent_user_id,omitempty"`
+	LatestReply   string   `json:"latest_reply,omitempty"`
+	ReplyUsers   []string  `json:"reply_users,omitempty"`
 
 	// file_share, file_comment, file_mention
 	Files []File `json:"files,omitempty"`


### PR DESCRIPTION
Slack API response returns reply_users that has information about all the participants in a thread. We should be able to access that as well using this package as well.

##### Pull Request Guidelines

These are recommendations for pull requests.
They are strictly guidelines to help manage expectations.

##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### Examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.
