### PR TITLE
feat: add 'EventsAPIInnerEventData' interface

### DIFF
--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -12,6 +12,11 @@ type EventsAPIInnerEvent struct {
 	Data interface{}
 }
 
+// EventsAPIInnerEventData is the common data for inner events
+type EventsAPIInnerEventData interface {
+	EventType() EventsAPIType
+}
+
 // AppMentionEvent is an (inner) EventsAPI subscribable event.
 type AppMentionEvent struct {
 	Type            string `json:"type"`
@@ -30,6 +35,11 @@ type AppMentionEvent struct {
 	BotID string `json:"bot_id,omitempty"`
 }
 
+// EventType implements EventAPIInnerEventData interface
+func (e AppMentionEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
+}
+
 // AppHomeOpenedEvent Your Slack app home was opened.
 type AppHomeOpenedEvent struct {
 	Type           string     `json:"type"`
@@ -40,9 +50,19 @@ type AppHomeOpenedEvent struct {
 	View           slack.View `json:"view"`
 }
 
+// EventType implements EventAPIInnerEventData interface
+func (e AppHomeOpenedEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
+}
+
 // AppUninstalledEvent Your Slack app was uninstalled.
 type AppUninstalledEvent struct {
 	Type string `json:"type"`
+}
+
+// EventType implements EventAPIInnerEventData interface
+func (e AppUninstalledEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
 }
 
 // ChannelCreatedEvent represents the Channel created event
@@ -52,11 +72,21 @@ type ChannelCreatedEvent struct {
 	EventTimestamp string             `json:"event_ts"`
 }
 
+// EventType implements EventAPIInnerEventData interface
+func (e ChannelCreatedEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
+}
+
 // ChannelDeletedEvent represents the Channel deleted event
 type ChannelDeletedEvent struct {
 	Type           string `json:"type"`
 	Channel        string `json:"channel"`
 	EventTimestamp string `json:"event_ts"`
+}
+
+// EventType implements EventAPIInnerEventData interface
+func (e ChannelDeletedEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
 }
 
 // ChannelArchiveEvent represents the Channel archive event
@@ -67,12 +97,22 @@ type ChannelArchiveEvent struct {
 	EventTimestamp string `json:"event_ts"`
 }
 
+// EventType implements EventAPIInnerEventData interface
+func (e ChannelArchiveEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
+}
+
 // ChannelUnarchiveEvent represents the Channel unarchive event
 type ChannelUnarchiveEvent struct {
 	Type           string `json:"type"`
 	Channel        string `json:"channel"`
 	User           string `json:"user"`
 	EventTimestamp string `json:"event_ts"`
+}
+
+// EventType implements EventAPIInnerEventData interface
+func (e ChannelUnarchiveEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
 }
 
 // ChannelLeftEvent represents the Channel left event
@@ -82,11 +122,21 @@ type ChannelLeftEvent struct {
 	EventTimestamp string `json:"event_ts"`
 }
 
+// EventType implements EventAPIInnerEventData interface
+func (e ChannelLeftEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
+}
+
 // ChannelRenameEvent represents the Channel rename event
 type ChannelRenameEvent struct {
 	Type           string            `json:"type"`
 	Channel        ChannelRenameInfo `json:"channel"`
 	EventTimestamp string            `json:"event_ts"`
+}
+
+// EventType implements EventAPIInnerEventData interface
+func (e ChannelRenameEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
 }
 
 // ChannelIDChangedEvent represents the Channel identifier changed event
@@ -95,6 +145,11 @@ type ChannelIDChangedEvent struct {
 	OldChannelID   string `json:"old_channel_id"`
 	NewChannelID   string `json:"new_channel_id"`
 	EventTimestamp string `json:"event_ts"`
+}
+
+// EventType implements EventAPIInnerEventData interface
+func (e ChannelIDChangedEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
 }
 
 // ChannelCreatedInfo represents the information associated with the Channel created event
@@ -120,11 +175,21 @@ type GroupDeletedEvent struct {
 	EventTimestamp string `json:"event_ts"`
 }
 
+// EventType implements EventAPIInnerEventData interface
+func (e GroupDeletedEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
+}
+
 // GroupArchiveEvent represents the Group archive event
 type GroupArchiveEvent struct {
 	Type           string `json:"type"`
 	Channel        string `json:"channel"`
 	EventTimestamp string `json:"event_ts"`
+}
+
+// EventType implements EventAPIInnerEventData interface
+func (e GroupArchiveEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
 }
 
 // GroupUnarchiveEvent represents the Group unarchive event
@@ -134,6 +199,11 @@ type GroupUnarchiveEvent struct {
 	EventTimestamp string `json:"event_ts"`
 }
 
+// EventType implements EventAPIInnerEventData interface
+func (e GroupUnarchiveEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
+}
+
 // GroupLeftEvent represents the Group left event
 type GroupLeftEvent struct {
 	Type           string `json:"type"`
@@ -141,11 +211,21 @@ type GroupLeftEvent struct {
 	EventTimestamp string `json:"event_ts"`
 }
 
+// EventType implements EventAPIInnerEventData interface
+func (e GroupLeftEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
+}
+
 // GroupRenameEvent represents the Group rename event
 type GroupRenameEvent struct {
 	Type           string          `json:"type"`
 	Channel        GroupRenameInfo `json:"channel"`
 	EventTimestamp string          `json:"event_ts"`
+}
+
+// EventType implements EventAPIInnerEventData interface
+func (e GroupRenameEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
 }
 
 // GroupRenameInfo represents the information associated with the Group rename event
@@ -163,12 +243,22 @@ type FileChangeEvent struct {
 	File   FileEventFile `json:"file"`
 }
 
+// EventType implements EventAPIInnerEventData interface
+func (e FileChangeEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
+}
+
 // FileDeletedEvent represents the information associated with the File deleted
 // event.
 type FileDeletedEvent struct {
 	Type           string `json:"type"`
 	FileID         string `json:"file_id"`
 	EventTimestamp string `json:"event_ts"`
+}
+
+// EventType implements EventAPIInnerEventData interface
+func (e FileDeletedEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
 }
 
 // FileSharedEvent represents the information associated with the File shared
@@ -182,12 +272,22 @@ type FileSharedEvent struct {
 	EventTimestamp string        `json:"event_ts"`
 }
 
+// EventType implements EventAPIInnerEventData interface
+func (e FileSharedEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
+}
+
 // FileUnsharedEvent represents the information associated with the File
 // unshared event.
 type FileUnsharedEvent struct {
 	Type   string        `json:"type"`
 	FileID string        `json:"file_id"`
 	File   FileEventFile `json:"file"`
+}
+
+// EventType implements EventAPIInnerEventData interface
+func (e FileUnsharedEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
 }
 
 // FileEventFile represents information on the specific file being shared in a
@@ -202,10 +302,20 @@ type GridMigrationFinishedEvent struct {
 	EnterpriseID string `json:"enterprise_id"`
 }
 
+// EventType implements EventAPIInnerEventData interface
+func (e GridMigrationFinishedEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
+}
+
 // GridMigrationStartedEvent An enterprise grid migration has started on this workspace.
 type GridMigrationStartedEvent struct {
 	Type         string `json:"type"`
 	EnterpriseID string `json:"enterprise_id"`
+}
+
+// EventType implements EventAPIInnerEventData interface
+func (e GridMigrationStartedEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
 }
 
 // LinkSharedEvent A message was posted containing one or more links relevant to your application
@@ -221,6 +331,11 @@ type LinkSharedEvent struct {
 	ThreadTimeStamp  string        `json:"thread_ts"`
 	Links            []SharedLinks `json:"links"`
 	EventTimestamp   string        `json:"event_ts"`
+}
+
+// EventType implements EventAPIInnerEventData interface
+func (e LinkSharedEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
 }
 
 type SharedLinks struct {
@@ -275,6 +390,11 @@ type MessageEvent struct {
 	Root *MessageEvent `json:"root"`
 }
 
+// EventType implements EventAPIInnerEventData interface
+func (e MessageEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
+}
+
 // MemberJoinedChannelEvent A member joined a public or private channel
 type MemberJoinedChannelEvent struct {
 	Type           string `json:"type"`
@@ -284,6 +404,11 @@ type MemberJoinedChannelEvent struct {
 	Team           string `json:"team"`
 	Inviter        string `json:"inviter"`
 	EventTimestamp string `json:"event_ts"`
+}
+
+// EventType implements EventAPIInnerEventData interface
+func (e MemberJoinedChannelEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
 }
 
 // MemberLeftChannelEvent A member left a public or private channel
@@ -296,6 +421,11 @@ type MemberLeftChannelEvent struct {
 	EventTimestamp string `json:"event_ts"`
 }
 
+// EventType implements EventAPIInnerEventData interface
+func (e MemberLeftChannelEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
+}
+
 type pinEvent struct {
 	Type           string `json:"type"`
 	User           string `json:"user"`
@@ -303,6 +433,11 @@ type pinEvent struct {
 	Channel        string `json:"channel_id"`
 	EventTimestamp string `json:"event_ts"`
 	HasPins        bool   `json:"has_pins,omitempty"`
+}
+
+// EventType implements EventAPIInnerEventData interface
+func (e pinEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
 }
 
 type reactionEvent struct {
@@ -314,17 +449,30 @@ type reactionEvent struct {
 	EventTimestamp string `json:"event_ts"`
 }
 
+// EventType implements EventAPIInnerEventData interface
+func (e reactionEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
+}
+
 // ReactionAddedEvent An reaction was added to a message - https://api.slack.com/events/reaction_added
-type ReactionAddedEvent reactionEvent
+type ReactionAddedEvent struct {
+	reactionEvent
+}
 
 // ReactionRemovedEvent An reaction was removed from a message - https://api.slack.com/events/reaction_removed
-type ReactionRemovedEvent reactionEvent
+type ReactionRemovedEvent struct {
+	reactionEvent
+}
 
 // PinAddedEvent An item was pinned to a channel - https://api.slack.com/events/pin_added
-type PinAddedEvent pinEvent
+type PinAddedEvent struct {
+	pinEvent
+}
 
 // PinRemovedEvent An item was unpinned from a channel - https://api.slack.com/events/pin_removed
-type PinRemovedEvent pinEvent
+type PinRemovedEvent struct {
+	pinEvent
+}
 
 type tokens struct {
 	Oauth []string `json:"oauth"`
@@ -338,11 +486,21 @@ type TeamJoinEvent struct {
 	EventTimestamp string      `json:"event_ts"`
 }
 
+// EventType implements EventAPIInnerEventData interface
+func (e TeamJoinEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
+}
+
 // TokensRevokedEvent APP's API tokens are revoked - https://api.slack.com/events/tokens_revoked
 type TokensRevokedEvent struct {
 	Type           string `json:"type"`
 	Tokens         tokens `json:"tokens"`
 	EventTimestamp string `json:"event_ts"`
+}
+
+// EventType implements EventAPIInnerEventData interface
+func (e TokensRevokedEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
 }
 
 // EmojiChangedEvent is the event of custom emoji has been added or changed
@@ -365,12 +523,22 @@ type EmojiChangedEvent struct {
 	Value string `json:"value,omitempty"`
 }
 
+// EventType implements EventAPIInnerEventData interface
+func (e EmojiChangedEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
+}
+
 // WorkflowStepExecuteEvent is fired, if a workflow step of your app is invoked
 type WorkflowStepExecuteEvent struct {
 	Type           string            `json:"type"`
 	CallbackID     string            `json:"callback_id"`
 	WorkflowStep   EventWorkflowStep `json:"workflow_step"`
 	EventTimestamp string            `json:"event_ts"`
+}
+
+// EventType implements EventAPIInnerEventData interface
+func (e WorkflowStepExecuteEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
 }
 
 // MessageMetadataPostedEvent is sent, if a message with metadata is posted
@@ -384,6 +552,11 @@ type MessageMetadataPostedEvent struct {
 	Metadata         *slack.SlackMetadata `json:"metadata"`
 	MessageTimestamp string               `json:"message_ts"`
 	EventTimestamp   string               `json:"event_ts"`
+}
+
+// EventType implements EventAPIInnerEventData interface
+func (e MessageMetadataPostedEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
 }
 
 // MessageMetadataUpdatedEvent is sent, if a message with metadata is deleted
@@ -400,6 +573,11 @@ type MessageMetadataUpdatedEvent struct {
 	Metadata         *slack.SlackMetadata `json:"metadata"`
 }
 
+// EventType implements EventAPIInnerEventData interface
+func (e MessageMetadataUpdatedEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
+}
+
 // MessageMetadataDeletedEvent is sent, if a message with metadata is deleted
 type MessageMetadataDeletedEvent struct {
 	Type             string               `json:"type"`
@@ -412,6 +590,11 @@ type MessageMetadataDeletedEvent struct {
 	TeamId           string               `json:"team_id"`
 	MessageTimestamp string               `json:"message_ts"`
 	DeletedTimestamp string               `json:"deleted_ts"`
+}
+
+// EventType implements EventAPIInnerEventData interface
+func (e MessageMetadataDeletedEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
 }
 
 type EventWorkflowStep struct {
@@ -530,10 +713,20 @@ type TeamAccessGrantedEvent struct {
 	TeamIDs []string `json:"team_ids"`
 }
 
+// EventType implements EventAPIInnerEventData interface
+func (e TeamAccessGrantedEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
+}
+
 // TeamAccessRevokedEvent is sent if access to teams was revoked for your org-wide app.
 type TeamAccessRevokedEvent struct {
 	Type    string   `json:"type"`
 	TeamIDs []string `json:"team_ids"`
+}
+
+// EventType implements EventAPIInnerEventData interface
+func (e TeamAccessRevokedEvent) EventType() EventsAPIType {
+	return EventsAPIType(e.Type)
 }
 
 type EventsAPIType string

--- a/slackevents/inner_events_test.go
+++ b/slackevents/inner_events_test.go
@@ -20,9 +20,14 @@ func TestAppMention(t *testing.T) {
 				"blah": "test"
 		}
 	`)
-	err := json.Unmarshal(rawE, &AppMentionEvent{})
+
+	var e AppMentionEvent
+	err := json.Unmarshal(rawE, &e)
 	if err != nil {
 		t.Error(err)
+	}
+	if string(e.EventType()) != e.Type {
+		t.Errorf("EventType() method return value should be %q, was %q", e.Type, e.EventType())
 	}
 }
 
@@ -32,9 +37,14 @@ func TestAppUninstalled(t *testing.T) {
 			"type": "app_uninstalled"
 		}
 	`)
-	err := json.Unmarshal(rawE, &AppUninstalledEvent{})
+
+	var e AppUninstalledEvent
+	err := json.Unmarshal(rawE, &e)
 	if err != nil {
 		t.Error(err)
+	}
+	if string(e.EventType()) != e.Type {
+		t.Errorf("EventType() method return value should be %q, was %q", e.Type, e.EventType())
 	}
 }
 
@@ -62,6 +72,9 @@ func TestFileChangeEvent(t *testing.T) {
 	if e.File.ID != "F1234567890" {
 		t.Errorf("file.id should be F1234567890, was %s", e.File.ID)
 	}
+	if string(e.EventType()) != e.Type {
+		t.Errorf("EventType() method return value should be %q, was %q", e.Type, e.EventType())
+	}
 }
 
 func TestFileDeletedEvent(t *testing.T) {
@@ -85,6 +98,9 @@ func TestFileDeletedEvent(t *testing.T) {
 	}
 	if e.EventTimestamp != "1234567890.123456" {
 		t.Errorf("event timestamp should be 1234567890.123456, was %s", e.EventTimestamp)
+	}
+	if string(e.EventType()) != e.Type {
+		t.Errorf("EventType() method return value should be %q, was %q", e.Type, e.EventType())
 	}
 }
 
@@ -124,6 +140,9 @@ func TestFileSharedEvent(t *testing.T) {
 	if e.EventTimestamp != "1234567890.123456" {
 		t.Errorf("event timestamp should be 1234567890.123456, was %s", e.EventTimestamp)
 	}
+	if string(e.EventType()) != e.Type {
+		t.Errorf("EventType() method return value should be %q, was %q", e.Type, e.EventType())
+	}
 }
 
 func TestFileUnsharedEvent(t *testing.T) {
@@ -150,6 +169,9 @@ func TestFileUnsharedEvent(t *testing.T) {
 	if e.File.ID != "F1234567890" {
 		t.Errorf("file.id should be F1234567890, was %s", e.File.ID)
 	}
+	if string(e.EventType()) != e.Type {
+		t.Errorf("EventType() method return value should be %q, was %q", e.Type, e.EventType())
+	}
 }
 
 func TestGridMigrationFinishedEvent(t *testing.T) {
@@ -159,9 +181,14 @@ func TestGridMigrationFinishedEvent(t *testing.T) {
 				"enterprise_id": "EXXXXXXXX"
 			}
 	`)
-	err := json.Unmarshal(rawE, &GridMigrationFinishedEvent{})
+
+	var e GridMigrationFinishedEvent
+	err := json.Unmarshal(rawE, &e)
 	if err != nil {
 		t.Error(err)
+	}
+	if string(e.EventType()) != e.Type {
+		t.Errorf("EventType() method return value should be %q, was %q", e.Type, e.EventType())
 	}
 }
 
@@ -180,9 +207,13 @@ func TestGridMigrationStartedEvent(t *testing.T) {
 				"event_time": 1234567890
 		}
 	`)
-	err := json.Unmarshal(rawE, &GridMigrationStartedEvent{})
+	var e GridMigrationStartedEvent
+	err := json.Unmarshal(rawE, &e)
 	if err != nil {
 		t.Error(err)
+	}
+	if string(e.EventType()) != e.Type {
+		t.Errorf("EventType() method return value should be %q, was %q", e.Type, e.EventType())
 	}
 }
 
@@ -211,9 +242,13 @@ func TestLinkSharedEvent(t *testing.T) {
 						]
 		}
 	`)
-	err := json.Unmarshal(rawE, &LinkSharedEvent{})
+	var e LinkSharedEvent
+	err := json.Unmarshal(rawE, &e)
 	if err != nil {
 		t.Error(err)
+	}
+	if string(e.EventType()) != e.Type {
+		t.Errorf("EventType() method return value should be %q, was %q", e.Type, e.EventType())
 	}
 }
 
@@ -243,6 +278,9 @@ func TestLinkSharedEvent_struct(t *testing.T) {
 	if string(rawE) != expected {
 		t.Errorf("expected %s, but got %s", expected, string(rawE))
 	}
+	if string(e.EventType()) != e.Type {
+		t.Errorf("EventType() method return value should be %q, was %q", e.Type, e.EventType())
+	}
 }
 
 func TestLinkSharedComposerEvent(t *testing.T) {
@@ -271,9 +309,13 @@ func TestLinkSharedComposerEvent(t *testing.T) {
 				]
 			}
 	`)
-	err := json.Unmarshal(rawE, &LinkSharedEvent{})
+	var e LinkSharedEvent
+	err := json.Unmarshal(rawE, &e)
 	if err != nil {
 		t.Error(err)
+	}
+	if string(e.EventType()) != e.Type {
+		t.Errorf("EventType() method return value should be %q, was %q", e.Type, e.EventType())
 	}
 }
 
@@ -302,9 +344,13 @@ func TestMessageEvent(t *testing.T) {
 				}
 		}
 	`)
-	err := json.Unmarshal(rawE, &MessageEvent{})
+	var e MessageEvent
+	err := json.Unmarshal(rawE, &e)
 	if err != nil {
 		t.Error(err)
+	}
+	if string(e.EventType()) != e.Type {
+		t.Errorf("EventType() method return value should be %q, was %q", e.Type, e.EventType())
 	}
 }
 
@@ -320,9 +366,13 @@ func TestBotMessageEvent(t *testing.T) {
 				"icons": {}
 		}
 	`)
-	err := json.Unmarshal(rawE, &MessageEvent{})
+	var e MessageEvent
+	err := json.Unmarshal(rawE, &e)
 	if err != nil {
 		t.Error(err)
+	}
+	if string(e.EventType()) != e.Type {
+		t.Errorf("EventType() method return value should be %q, was %q", e.Type, e.EventType())
 	}
 }
 
@@ -372,6 +422,10 @@ func TestThreadBroadcastEvent(t *testing.T) {
 	if me.Message.Root.TimeStamp != "1355517523.000005" {
 		t.Errorf("me.Message.Root.TimeStamp = %q, want %q", me.Root.TimeStamp, "1355517523.000005")
 	}
+
+	if string(me.EventType()) != me.Type {
+		t.Errorf("EventType() method return value should be %q, was %q", me.Type, me.EventType())
+	}
 }
 
 func TestMemberJoinedChannelEvent(t *testing.T) {
@@ -385,9 +439,13 @@ func TestMemberJoinedChannelEvent(t *testing.T) {
 				"inviter": "U123456789"
 		}
 	`)
-	err := json.Unmarshal(rawE, &MemberJoinedChannelEvent{})
+	var e MemberJoinedChannelEvent
+	err := json.Unmarshal(rawE, &e)
 	if err != nil {
 		t.Error(err)
+	}
+	if string(e.EventType()) != e.Type {
+		t.Errorf("EventType() method return value should be %q, was %q", e.Type, e.EventType())
 	}
 }
 
@@ -401,9 +459,13 @@ func TestMemberLeftChannelEvent(t *testing.T) {
 				"team": "T024BE7LD"
 		}
 	`)
-	err := json.Unmarshal(rawE, &MemberLeftChannelEvent{})
+	var e MemberLeftChannelEvent
+	err := json.Unmarshal(rawE, &e)
 	if err != nil {
 		t.Error(err)
+	}
+	if string(e.EventType()) != e.Type {
+		t.Errorf("EventType() method return value should be %q, was %q", e.Type, e.EventType())
 	}
 }
 
@@ -429,9 +491,13 @@ func TestPinAdded(t *testing.T) {
 				"event_ts": "1515449522000016"
 		}
 	`)
-	err := json.Unmarshal(rawE, &PinAddedEvent{})
+	var e PinAddedEvent
+	err := json.Unmarshal(rawE, &e)
 	if err != nil {
 		t.Error(err)
+	}
+	if string(e.EventType()) != e.Type {
+		t.Errorf("EventType() method return value should be %q, was %q", e.Type, e.EventType())
 	}
 }
 
@@ -457,9 +523,13 @@ func TestPinRemoved(t *testing.T) {
 				"event_ts": "1515449522000016"
 		}
 	`)
-	err := json.Unmarshal(rawE, &PinRemovedEvent{})
+	var e PinRemovedEvent
+	err := json.Unmarshal(rawE, &e)
 	if err != nil {
 		t.Error(err)
+	}
+	if string(e.EventType()) != e.Type {
+		t.Errorf("EventType() method return value should be %q, was %q", e.Type, e.EventType())
 	}
 }
 
@@ -493,6 +563,10 @@ func TestTokensRevoked(t *testing.T) {
 
 	if len(tre.Tokens.Oauth) != 1 || tre.Tokens.Oauth[0] != "OUXXXXXXXX" {
 		t.Fail()
+	}
+
+	if string(tre.EventType()) != tre.Type {
+		t.Errorf("EventType() method return value should be %q, was %q", tre.Type, tre.EventType())
 	}
 }
 
@@ -573,6 +647,9 @@ func TestEmojiChanged(t *testing.T) {
 	if ece.NewName != "cheese-grin" {
 		t.Fail()
 	}
+	if string(ece.EventType()) != ece.Type {
+		t.Errorf("EventType() method return value should be %q, was %q", ece.Type, ece.EventType())
+	}
 }
 
 func TestWorkflowStepExecute(t *testing.T) {
@@ -634,6 +711,9 @@ func TestWorkflowStepExecute(t *testing.T) {
 			t.Fail()
 		}
 	}
+	if string(wse.EventType()) != wse.Type {
+		t.Errorf("EventType() method return value should be %q, was %q", wse.Type, wse.EventType())
+	}
 }
 
 func TestMessageMetadataPosted(t *testing.T) {
@@ -690,6 +770,9 @@ func TestMessageMetadataPosted(t *testing.T) {
 	}
 	if mmp.MessageTimestamp != "1660398079.756349" {
 		t.Fail()
+	}
+	if string(mmp.EventType()) != mmp.Type {
+		t.Errorf("EventType() method return value should be %q, was %q", mmp.Type, mmp.EventType())
 	}
 }
 
@@ -759,6 +842,9 @@ func TestMessageMetadataUpdated(t *testing.T) {
 	if len(payload) <= 0 {
 		t.Fail()
 	}
+	if string(mmp.EventType()) != mmp.Type {
+		t.Errorf("EventType() method return value should be %q, was %q", mmp.Type, mmp.EventType())
+	}
 }
 
 func TestMessageMetadataDeleted(t *testing.T) {
@@ -819,5 +905,8 @@ func TestMessageMetadataDeleted(t *testing.T) {
 	}
 	if mmp.DeletedTimestamp != "1660398079.756349" {
 		t.Fail()
+	}
+	if string(mmp.EventType()) != mmp.Type {
+		t.Errorf("EventType() method return value should be %q, was %q", mmp.Type, mmp.EventType())
 	}
 }


### PR DESCRIPTION
### Description
This PR adds a new interface `EventsAPIInnerEventData` that all inner events will fulfill. At this time, with only one method (`EventType()`) but open to grow according to https://api.slack.com/apis/connections/events-api#event_type_structure.

A very useful use case for this is reacting to those events from event handlers. I.e. :

```go
type EventHandler func(slackevents.EventsAPIInnerEventData) error
```

### Alternatives
There is no good alternatives for this. I tried using generics but the immaturity of it made me drop the idea since you cannot use interface with constraints as types (See the [type parameters proposal](https://go.googlesource.com/proposal/+/refs/heads/master/design/43651-type-parameters.md#permitting-constraints-as-ordinary-interface-types)). E.g. the following is not allowed:

```go
type MessageEvent interface {
	slackevents.AppMentionEvent | slackevents.AppHomeOpenedEvent | slackevents.AppUninstalledEvent |
		slackevents.ChannelCreatedEvent | slackevents.ChannelDeletedEvent | slackevents.ChannelArchiveEvent |
		slackevents.ChannelUnarchiveEvent | slackevents.ChannelLeftEvent | slackevents.ChannelRenameEvent |
		slackevents.ChannelIDChangedEvent | slackevents.GroupDeletedEvent | slackevents.GroupArchiveEvent |
		slackevents.GroupUnarchiveEvent | slackevents.GroupLeftEvent | slackevents.GroupRenameEvent |
		slackevents.GridMigrationFinishedEvent | slackevents.GridMigrationStartedEvent | slackevents.LinkSharedEvent |
		slackevents.MessageEvent | slackevents.MemberJoinedChannelEvent | slackevents.MemberLeftChannelEvent |
		slackevents.PinAddedEvent | slackevents.PinRemovedEvent | slackevents.ReactionAddedEvent |
		slackevents.ReactionRemovedEvent | slackevents.TeamJoinEvent | slackevents.TokensRevokedEvent |
		slackevents.EmojiChangedEvent
}

type EventHandler func(MessageEvent) error // This is not possible with the current version of Go.
```