### PR TITLE
Export the Binder type in slacktest

### DIFF
--- a/slacktest/server.go
+++ b/slacktest/server.go
@@ -26,10 +26,10 @@ type Customize interface {
 	Handle(pattern string, handler http.HandlerFunc)
 }
 
-type binder func(Customize)
+type Binder func(Customize)
 
 // NewTestServer returns a slacktest.Server ready to be started
-func NewTestServer(custom ...binder) *Server {
+func NewTestServer(custom ...Binder) *Server {
 	serverChans := newMessageChannels()
 
 	channels := &serverChannels{}


### PR DESCRIPTION
Fixes https://github.com/slack-go/slack/issues/1176

The `binder` type is defined as such in `slacktest/server.go`:

```
type binder func(Customize)
```

This PR changes `slacktest.binder` to `slacktest.Binder`. The reason for doing this is to be able to define a slice of custom functions to pass to the constructor. This makes things much easier for table-driven tests. Without this change, each entry in the table has to build its own `*slacktest.Server` which is less than convenient.

As far as I can tell these are the only places in the code where `binder` is used explicitly. There are only a few tests in this entire project that actually do these customizations (three tests in `websocket_managed_conn_test.go`). I've explicitly tested that this change has no effect on those tests.