### PR TITLE
add support for user_profile_changed callback event

### DIFF
--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -536,6 +536,14 @@ type TeamAccessRevokedEvent struct {
 	TeamIDs []string `json:"team_ids"`
 }
 
+// UserProfileChangedEvent is sent if access to teams was revoked for your org-wide app.
+type UserProfileChangedEvent struct {
+	User    *slack.User `json:"user"`
+	CacheTs int         `json:"cache_ts"`
+	Type    string      `json:"type"`
+	EventTs string      `json:"event_ts"`
+}
+
 type EventsAPIType string
 
 const (
@@ -585,9 +593,9 @@ const (
 	LinkShared = EventsAPIType("link_shared")
 	// Message A message was posted to a channel, private channel (group), im, or mim
 	Message = EventsAPIType("message")
-	// Member Joined Channel
+	// MemberJoinedChannel is sent if a member joined a channel.
 	MemberJoinedChannel = EventsAPIType("member_joined_channel")
-	// Member Left Channel
+	// MemberLeftChannel is sent if a member left a channel.
 	MemberLeftChannel = EventsAPIType("member_left_channel")
 	// PinAdded An item was pinned to a channel
 	PinAdded = EventsAPIType("pin_added")
@@ -607,14 +615,16 @@ const (
 	WorkflowStepExecute = EventsAPIType("workflow_step_execute")
 	// MessageMetadataPosted A message with metadata was posted
 	MessageMetadataPosted = EventsAPIType("message_metadata_posted")
-	// MessageMetadataPosted A message with metadata was updated
+	// MessageMetadataUpdated A message with metadata was updated
 	MessageMetadataUpdated = EventsAPIType("message_metadata_updated")
-	// MessageMetadataPosted A message with metadata was deleted
+	// MessageMetadataDeleted A message with metadata was deleted
 	MessageMetadataDeleted = EventsAPIType("message_metadata_deleted")
 	// TeamAccessGranted is sent if access to teams was granted for your org-wide app.
 	TeamAccessGranted = EventsAPIType("team_access_granted")
-	// TeamAccessrevoked is sent if access to teams was revoked for your org-wide app.
-	TeamAccessrevoked = EventsAPIType("team_access_revoked")
+	// TeamAccessRevoked is sent if access to teams was revoked for your org-wide app.
+	TeamAccessRevoked = EventsAPIType("team_access_revoked")
+	// UserProfileChanged is sent if a user's profile information has changed.
+	UserProfileChanged = EventsAPIType("user_profile_changed")
 )
 
 // EventsAPIInnerEventMapping maps INNER Event API events to their corresponding struct
@@ -658,5 +668,6 @@ var EventsAPIInnerEventMapping = map[EventsAPIType]interface{}{
 	MessageMetadataUpdated: MessageMetadataUpdatedEvent{},
 	MessageMetadataDeleted: MessageMetadataDeletedEvent{},
 	TeamAccessGranted:      TeamAccessGrantedEvent{},
-	TeamAccessrevoked:      TeamAccessRevokedEvent{},
+	TeamAccessRevoked:      TeamAccessRevokedEvent{},
+	UserProfileChanged:     UserProfileChangedEvent{},
 }

--- a/slackevents/inner_events_test.go
+++ b/slackevents/inner_events_test.go
@@ -821,3 +821,96 @@ func TestMessageMetadataDeleted(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestUserProfileChanged(t *testing.T) {
+	rawE := []byte(`
+	{
+		"token": "whatever",
+		"team_id": "whatever",
+		"api_app_id": "whatever",
+		"event": {
+			"user": {
+				"id": "whatever",
+				"team_id": "whatever",
+				"name": "whatever",
+				"deleted": true,
+				"profile": {
+					"title": "",
+					"phone": "",
+					"skype": "",
+					"real_name": "whatever",
+					"real_name_normalized": "whatever",
+					"display_name": "",
+					"display_name_normalized": "",
+					"fields": {},
+					"status_text": "",
+					"status_emoji": "",
+					"status_emoji_display_info": [],
+					"status_expiration": 0,
+					"avatar_hash": "whatever",
+					"api_app_id": "whatever",
+					"always_active": true,
+					"bot_id": "whatever",
+					"first_name": "whatever",
+					"last_name": "",
+					"image_24": "https://secure.gravatar.com/avatar/whatever.jpg",
+					"image_32": "https://secure.gravatar.com/avatar/whatever.jpg",
+					"image_48": "https://secure.gravatar.com/avatar/whatever.jpg",
+					"image_72": "https://secure.gravatar.com/avatar/whatever.jpg",
+					"image_192": "https://secure.gravatar.com/avatar/whatever.jpg",
+					"image_512": "https://secure.gravatar.com/avatar/whatever.jpg",
+					"status_text_canonical": "",
+					"team": "whatever"
+				},
+				"is_bot": true,
+				"is_app_user": false,
+				"updated": 1678984254
+			},
+			"cache_ts": 1678984254,
+			"type": "user_profile_changed",
+			"event_ts": "1678984255.006500"
+		},
+		"type": "event_callback",
+		"event_id": "whatever",
+		"event_time": 1678984255,
+		"authorizations": [
+			{
+				"enterprise_id": null,
+				"team_id": "whatever",
+				"user_id": "whatever",
+				"is_bot": false,
+				"is_enterprise_install": false
+			}
+		],
+		"is_ext_shared_channel": false
+	}
+	`)
+
+	evt := &EventsAPICallbackEvent{}
+	err := json.Unmarshal(rawE, &evt)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if evt.Type != "event_callback" {
+		t.Fail()
+	}
+
+	parsedEvent, err := parseInnerEvent(evt)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if parsedEvent.InnerEvent.Type != "user_profile_changed" {
+		t.Fail()
+	}
+
+	actual, ok := parsedEvent.InnerEvent.Data.(*UserProfileChangedEvent)
+	if !ok {
+		t.Fail()
+	}
+
+	if actual.User.Name != "whatever" {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
##### PR preparation
- [x] Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes
n/a

This change allows for the Slack library to parse incoming callback events of the `user_profile_changed` type. Previously, `parseInnerEvent` threw an error because it didn't have record of this event type.