### PR TITLE
add 2FA type to slack user

### DIFF
--- a/users.go
+++ b/users.go
@@ -130,7 +130,7 @@ type User struct {
 	IsAppUser         bool           `json:"is_app_user"`
 	IsInvitedUser     bool           `json:"is_invited_user"`
 	Has2FA            bool           `json:"has_2fa"`
-	TwoFactorType     *string        `json:"two_factor_type,omitempty"`
+	TwoFactorType     *string        `json:"two_factor_type"`
 	HasFiles          bool           `json:"has_files"`
 	Presence          string         `json:"presence"`
 	Locale            string         `json:"locale"`

--- a/users.go
+++ b/users.go
@@ -130,6 +130,7 @@ type User struct {
 	IsAppUser         bool           `json:"is_app_user"`
 	IsInvitedUser     bool           `json:"is_invited_user"`
 	Has2FA            bool           `json:"has_2fa"`
+	TwoFactorType     *string        `json:"two_factor_type,omitempty"`
 	HasFiles          bool           `json:"has_files"`
 	Presence          string         `json:"presence"`
 	Locale            string         `json:"locale"`


### PR DESCRIPTION
Added a missing property to Slack user. Since it is optional (as documented [here](https://api.slack.com/types/user#fields)), I made it optional in the struct too
