### PR TITLE
Increase operations-per-run

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -22,3 +22,4 @@ jobs:
           stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 10 days with no activity.'
           close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
+          operations-per-run: 120


### PR DESCRIPTION
## Description
Increase `operations-per-run` to 120 (default is 30).
We plan to reduce this value as the number of issues/pr accumulated decreases.
