### PR TITLE
Add Filter Object to Multi Conversation Select Block Element

### DIFF
--- a/block_element.go
+++ b/block_element.go
@@ -279,6 +279,7 @@ type MultiSelectBlockElement struct {
 	InitialChannels      []string                  `json:"initial_channels,omitempty"`
 	MinQueryLength       *int                      `json:"min_query_length,omitempty"`
 	MaxSelectedItems     *int                      `json:"max_selected_items,omitempty"`
+	Filter               *SelectBlockElementFilter `json:"filter,omitempty"`
 	Confirm              *ConfirmationBlockObject  `json:"confirm,omitempty"`
 }
 

--- a/block_element.go
+++ b/block_element.go
@@ -217,15 +217,15 @@ type SelectBlockElement struct {
 	InitialChannel               string                    `json:"initial_channel,omitempty"`
 	DefaultToCurrentConversation bool                      `json:"default_to_current_conversation,omitempty"`
 	ResponseURLEnabled           bool                      `json:"response_url_enabled,omitempty"`
-	Filter                       *SelectBlockElementFilter `json:"filter,omitempty"`
+	Filter                       *ConversationListsFilter  `json:"filter,omitempty"`
 	MinQueryLength               *int                      `json:"min_query_length,omitempty"`
 	Confirm                      *ConfirmationBlockObject  `json:"confirm,omitempty"`
 }
 
-// SelectBlockElementFilter allows to filter select element conversation options by type.
+// ConversationListsFilter allows to filter select element conversation options by type.
 //
 // More Information: https://api.slack.com/reference/block-kit/composition-objects#filter_conversations
-type SelectBlockElementFilter struct {
+type ConversationListsFilter struct {
 	Include                       []string `json:"include,omitempty"`
 	ExcludeExternalSharedChannels bool     `json:"exclude_external_shared_channels,omitempty"`
 	ExcludeBotUsers               bool     `json:"exclude_bot_users,omitempty"`
@@ -279,7 +279,7 @@ type MultiSelectBlockElement struct {
 	InitialChannels      []string                  `json:"initial_channels,omitempty"`
 	MinQueryLength       *int                      `json:"min_query_length,omitempty"`
 	MaxSelectedItems     *int                      `json:"max_selected_items,omitempty"`
-	Filter               *SelectBlockElementFilter `json:"filter,omitempty"`
+	Filter               *ConversationListsFilter  `json:"filter,omitempty"`
 	Confirm              *ConfirmationBlockObject  `json:"confirm,omitempty"`
 }
 


### PR DESCRIPTION
##### PR preparation

- [x]  Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

N/A

This changes is to add the `filter` object in `multi_conversation_select` block element type since the documentation said the `filter` object is also supported in that type. Currently the `filter` object only present in `conversation_select` type.

Reference to the documentation:
- https://api.slack.com/reference/block-kit/composition-objects#filter_conversations
- https://api.slack.com/reference/block-kit/block-elements#conversation_multi_select 
