### PR TITLE
add endpoint to socketmode Clinet and OptionAPIURL function

### DIFF
--- a/socketmode/client.go
+++ b/socketmode/client.go
@@ -58,6 +58,7 @@ type Client struct {
 	// Dialer.
 	dialer *websocket.Dialer
 
-	debug bool
-	log   ilogger
+	endpoint string
+	debug    bool
+	log      ilogger
 }

--- a/socketmode/socket_mode_managed_conn.go
+++ b/socketmode/socket_mode_managed_conn.go
@@ -266,7 +266,7 @@ func (smc *Client) openAndDial(ctx context.Context, additionalPingHandler func(s
 	smc.Debugf("Dialing to websocket on url %s", url)
 	// Only use HTTPS for connections to prevent MITM attacks on the connection.
 	upgradeHeader := http.Header{}
-	upgradeHeader.Add("Origin", "https://api.slack.com")
+	upgradeHeader.Add("Origin", smc.endpoint)
 	dialer := websocket.DefaultDialer
 	if smc.dialer != nil {
 		dialer = smc.dialer

--- a/socketmode/socketmode.go
+++ b/socketmode/socketmode.go
@@ -102,6 +102,11 @@ func OptionLog(l logger) func(*Client) {
 	}
 }
 
+// OptionAPIURL set the url for the client. only useful for testing.
+func OptionAPIURL(u string) func(*Client) {
+	return func(c *Client) { c.endpoint = u }
+}
+
 // New returns a Socket Mode client which provides a fully managed connection to
 // Slack's Websocket-based Socket Mode.
 func New(api *slack.Client, options ...Option) *Client {
@@ -110,6 +115,7 @@ func New(api *slack.Client, options ...Option) *Client {
 		Events:              make(chan Event, 50),
 		socketModeResponses: make(chan *Response, 20),
 		maxPingInterval:     defaultMaxPingInterval,
+		endpoint:            "https://api.slack.com",
 		log:                 log.New(os.Stderr, "slack-go/slack/socketmode", log.LstdFlags|log.Lshortfile),
 	}
 


### PR DESCRIPTION
##### Pull Request Guidelines

These are recommendations for pull requests.
They are strictly guidelines to help manage expectations.

##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### Examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.

---
### Change points

- Added an `endpoint` member to SocketMode Client
- Added an `socketmode.OptionAPIURL` function

### Motivation

I'm creating an application that acts as a server for a Slack App.
To do that, we need to point the Endpoint accessed from slack-go/slack away from `https://api.slack.com`.

The slack client provided a way to change the Endpoint URL, while the socketmode client did not. I also found the URL hardcoded in the `openAndDial` function.
This PR prepares the same `OptionAPIURL` for socketmode client as for slack client.

I would like opinions on whether this change should go into slack-go/slack.