### PR TITLE
Add UnfurlLinks and UnfurlMedia to WebhookMessage

### DIFF
--- a/webhooks.go
+++ b/webhooks.go
@@ -24,6 +24,8 @@ type WebhookMessage struct {
 	ReplaceOriginal bool         `json:"replace_original"`
 	DeleteOriginal  bool         `json:"delete_original"`
 	ReplyBroadcast  bool         `json:"reply_broadcast,omitempty"`
+	UnfurlLinks     bool         `json:"unfurl_links,omitempty"`
+	UnfurlMedia     bool         `json:"unfurl_media,omitempty"`
 }
 
 func PostWebhook(url string, msg *WebhookMessage) error {


### PR DESCRIPTION
* to support 'classic unfurl' configuration options in webhook messages.
* https://api.slack.com/reference/messaging/link-unfurling#classic_unfurl
* addresses https://github.com/slack-go/slack/issues/1207