### PR TITLE
Add Video Block

### DIFF
--- a/block.go
+++ b/block.go
@@ -18,6 +18,7 @@ const (
 	MBTInput    MessageBlockType = "input"
 	MBTHeader   MessageBlockType = "header"
 	MBTRichText MessageBlockType = "rich_text"
+	MBTVideo    MessageBlockType = "video"
 )
 
 // Block defines an interface all block types should implement

--- a/block_conv.go
+++ b/block_conv.go
@@ -68,6 +68,8 @@ func (b *Blocks) UnmarshalJSON(data []byte) error {
 			block = &RichTextBlock{}
 		case "section":
 			block = &SectionBlock{}
+		case "video":
+			block = &VideoBlock{}
 		default:
 			block = &UnknownBlock{}
 		}

--- a/block_video.go
+++ b/block_video.go
@@ -1,0 +1,35 @@
+package slack
+
+// VideoBlock defines data required to display a video as a block element
+//
+// More Information: https://api.slack.com/reference/block-kit/blocks#video
+type VideoBlock struct {
+	Type            MessageBlockType `json:"type"`
+	VideoURL        string           `json:"video_url"`
+	ThumbnailURL    string           `json:"thumbnail_url"`
+	AltText         string           `json:"alt_text"`
+	Title           *TextBlockObject `json:"title"`
+	BlockID         string           `json:"block_id,omitempty"`
+	TitleURL        string           `json:"title_url,omitempty"`
+	AuthorName      string           `json:"author_name,omitempty"`
+	ProviderName    string           `json:"provider_name,omitempty"`
+	ProviderIconURL string           `json:"provider_icon_url,omitempty"`
+	Description     *TextBlockObject `json:"description,omitempty"`
+}
+
+// BlockType returns the type of the block
+func (s VideoBlock) BlockType() MessageBlockType {
+	return s.Type
+}
+
+// NewVideoBlock returns an instance of a new Video Block type
+func NewVideoBlock(videoURL, thumbnailURL, altText, blockID string, title *TextBlockObject) *VideoBlock {
+	return &VideoBlock{
+		Type:         MBTVideo,
+		VideoURL:     videoURL,
+		ThumbnailURL: thumbnailURL,
+		AltText:      altText,
+		BlockID:      blockID,
+		Title:        title,
+	}
+}

--- a/block_video.go
+++ b/block_video.go
@@ -33,3 +33,33 @@ func NewVideoBlock(videoURL, thumbnailURL, altText, blockID string, title *TextB
 		Title:        title,
 	}
 }
+
+// WithAuthorName sets the author name for the VideoBlock
+func (s *VideoBlock) WithAuthorName(authorName string) *VideoBlock {
+	s.AuthorName = authorName
+	return s
+}
+
+// WithTitleURL sets the title URL for the VideoBlock
+func (s *VideoBlock) WithTitleURL(titleURL string) *VideoBlock {
+	s.TitleURL = titleURL
+	return s
+}
+
+// WithDescription sets the description for the VideoBlock
+func (s *VideoBlock) WithDescription(description *slack.TextBlockObject) *VideoBlock {
+	s.Description = description
+	return s
+}
+
+// WithProviderIconURL sets the provider icon URL for the VideoBlock
+func (s *VideoBlock) WithProviderIconURL(providerIconURL string) *VideoBlock {
+	s.ProviderIconURL = providerIconURL
+	return s
+}
+
+// WithProviderName sets the provider name for the VideoBlock
+func (s *VideoBlock) WithProviderName(providerName string) *VideoBlock {
+	s.ProviderName = providerName
+	return s
+}

--- a/block_video.go
+++ b/block_video.go
@@ -47,7 +47,7 @@ func (s *VideoBlock) WithTitleURL(titleURL string) *VideoBlock {
 }
 
 // WithDescription sets the description for the VideoBlock
-func (s *VideoBlock) WithDescription(description *slack.TextBlockObject) *VideoBlock {
+func (s *VideoBlock) WithDescription(description *TextBlockObject) *VideoBlock {
 	s.Description = description
 	return s
 }

--- a/block_video_test.go
+++ b/block_video_test.go
@@ -1,0 +1,23 @@
+package slack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewVideoBlock(t *testing.T) {
+
+	videoTitle := NewTextBlockObject("plain_text", "VideoTitle", false, false)
+	videoBlock := NewVideoBlock(
+		"https://example.com/example.mp4",
+		"https://example.com/thumbnail.png",
+		"alternative text", "blockID", videoTitle)
+
+	assert.Equal(t, string(videoBlock.Type), "video")
+	assert.Equal(t, videoBlock.Title.Type, "plain_text")
+	assert.Equal(t, videoBlock.BlockID, "blockID")
+	assert.Contains(t, videoBlock.Title.Text, "VideoTitle")
+	assert.Contains(t, videoBlock.VideoURL, "example.mp4")
+
+}


### PR DESCRIPTION
Add the support for Video Block.

Ref. https://api.slack.com/reference/block-kit/blocks#video

cf. https://github.com/slack-go/slack/discussions/1205