### PR TITLE
Add is_enterprise_install flag for org wide installation support

### DIFF
--- a/interactions.go
+++ b/interactions.go
@@ -33,29 +33,30 @@ const (
 
 // InteractionCallback is sent from slack when a user interactions with a button or dialog.
 type InteractionCallback struct {
-	Type            InteractionType         `json:"type"`
-	Token           string                  `json:"token"`
-	CallbackID      string                  `json:"callback_id"`
-	ResponseURL     string                  `json:"response_url"`
-	TriggerID       string                  `json:"trigger_id"`
-	ActionTs        string                  `json:"action_ts"`
-	Team            Team                    `json:"team"`
-	Channel         Channel                 `json:"channel"`
-	User            User                    `json:"user"`
-	OriginalMessage Message                 `json:"original_message"`
-	Message         Message                 `json:"message"`
-	Name            string                  `json:"name"`
-	Value           string                  `json:"value"`
-	MessageTs       string                  `json:"message_ts"`
-	AttachmentID    string                  `json:"attachment_id"`
-	ActionCallback  ActionCallbacks         `json:"actions"`
-	View            View                    `json:"view"`
-	ActionID        string                  `json:"action_id"`
-	APIAppID        string                  `json:"api_app_id"`
-	BlockID         string                  `json:"block_id"`
-	Container       Container               `json:"container"`
-	Enterprise      Enterprise              `json:"enterprise"`
-	WorkflowStep    InteractionWorkflowStep `json:"workflow_step"`
+	Type                InteractionType         `json:"type"`
+	Token               string                  `json:"token"`
+	CallbackID          string                  `json:"callback_id"`
+	ResponseURL         string                  `json:"response_url"`
+	TriggerID           string                  `json:"trigger_id"`
+	ActionTs            string                  `json:"action_ts"`
+	Team                Team                    `json:"team"`
+	Channel             Channel                 `json:"channel"`
+	User                User                    `json:"user"`
+	OriginalMessage     Message                 `json:"original_message"`
+	Message             Message                 `json:"message"`
+	Name                string                  `json:"name"`
+	Value               string                  `json:"value"`
+	MessageTs           string                  `json:"message_ts"`
+	AttachmentID        string                  `json:"attachment_id"`
+	ActionCallback      ActionCallbacks         `json:"actions"`
+	View                View                    `json:"view"`
+	ActionID            string                  `json:"action_id"`
+	APIAppID            string                  `json:"api_app_id"`
+	BlockID             string                  `json:"block_id"`
+	Container           Container               `json:"container"`
+	Enterprise          Enterprise              `json:"enterprise"`
+	IsEnterpriseInstall bool                    `json:"is_enterprise_install"`
+	WorkflowStep        InteractionWorkflowStep `json:"workflow_step"`
 	DialogSubmissionCallback
 	ViewSubmissionCallback
 	ViewClosedCallback

--- a/oauth.go
+++ b/oauth.go
@@ -33,17 +33,18 @@ type OAuthResponse struct {
 
 // OAuthV2Response ...
 type OAuthV2Response struct {
-	AccessToken     string                       `json:"access_token"`
-	TokenType       string                       `json:"token_type"`
-	Scope           string                       `json:"scope"`
-	BotUserID       string                       `json:"bot_user_id"`
-	AppID           string                       `json:"app_id"`
-	Team            OAuthV2ResponseTeam          `json:"team"`
-	IncomingWebhook OAuthResponseIncomingWebhook `json:"incoming_webhook"`
-	Enterprise      OAuthV2ResponseEnterprise    `json:"enterprise"`
-	AuthedUser      OAuthV2ResponseAuthedUser    `json:"authed_user"`
-	RefreshToken    string                       `json:"refresh_token"`
-	ExpiresIn       int                          `json:"expires_in"`
+	AccessToken         string                       `json:"access_token"`
+	TokenType           string                       `json:"token_type"`
+	Scope               string                       `json:"scope"`
+	BotUserID           string                       `json:"bot_user_id"`
+	AppID               string                       `json:"app_id"`
+	Team                OAuthV2ResponseTeam          `json:"team"`
+	IncomingWebhook     OAuthResponseIncomingWebhook `json:"incoming_webhook"`
+	Enterprise          OAuthV2ResponseEnterprise    `json:"enterprise"`
+	IsEnterpriseInstall bool                         `json:"is_enterprise_install"`
+	AuthedUser          OAuthV2ResponseAuthedUser    `json:"authed_user"`
+	RefreshToken        string                       `json:"refresh_token"`
+	ExpiresIn           int                          `json:"expires_in"`
 	SlackResponse
 }
 

--- a/slash.go
+++ b/slash.go
@@ -6,20 +6,21 @@ import (
 
 // SlashCommand contains information about a request of the slash command
 type SlashCommand struct {
-	Token          string `json:"token"`
-	TeamID         string `json:"team_id"`
-	TeamDomain     string `json:"team_domain"`
-	EnterpriseID   string `json:"enterprise_id,omitempty"`
-	EnterpriseName string `json:"enterprise_name,omitempty"`
-	ChannelID      string `json:"channel_id"`
-	ChannelName    string `json:"channel_name"`
-	UserID         string `json:"user_id"`
-	UserName       string `json:"user_name"`
-	Command        string `json:"command"`
-	Text           string `json:"text"`
-	ResponseURL    string `json:"response_url"`
-	TriggerID      string `json:"trigger_id"`
-	APIAppID       string `json:"api_app_id"`
+	Token               string `json:"token"`
+	TeamID              string `json:"team_id"`
+	TeamDomain          string `json:"team_domain"`
+	EnterpriseID        string `json:"enterprise_id,omitempty"`
+	EnterpriseName      string `json:"enterprise_name,omitempty"`
+	IsEnterpriseInstall bool   `json:"is_enterprise_install"`
+	ChannelID           string `json:"channel_id"`
+	ChannelName         string `json:"channel_name"`
+	UserID              string `json:"user_id"`
+	UserName            string `json:"user_name"`
+	Command             string `json:"command"`
+	Text                string `json:"text"`
+	ResponseURL         string `json:"response_url"`
+	TriggerID           string `json:"trigger_id"`
+	APIAppID            string `json:"api_app_id"`
 }
 
 // SlashCommandParse will parse the request of the slash command
@@ -32,6 +33,7 @@ func SlashCommandParse(r *http.Request) (s SlashCommand, err error) {
 	s.TeamDomain = r.PostForm.Get("team_domain")
 	s.EnterpriseID = r.PostForm.Get("enterprise_id")
 	s.EnterpriseName = r.PostForm.Get("enterprise_name")
+	s.IsEnterpriseInstall = r.PostForm.Get("is_enterprise_install") == "true"
 	s.ChannelID = r.PostForm.Get("channel_id")
 	s.ChannelName = r.PostForm.Get("channel_name")
 	s.UserID = r.PostForm.Get("user_id")


### PR DESCRIPTION
Introducing the inclusion of the 'is_enterprise_install' parameter in commands, interactions, and oauth2 responses. This flag is essential for facilitating organization-wide installations within the enterprise grid environment. Without this flag, the authentication token mapping process becomes unreliable, as it necessitates attempts with both the enterprise ID and team ID, potentially resulting in unexpected outcomes.

##### Pull Request Guidelines

These are recommendations for pull requests.
They are strictly guidelines to help manage expectations.

##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### Examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.
