### PR TITLE
feat: Add Properties.Canvas to Channel

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -19,10 +19,11 @@ type channelResponseFull struct {
 // Channel contains information about the channel
 type Channel struct {
 	GroupConversation
-	IsChannel bool   `json:"is_channel"`
-	IsGeneral bool   `json:"is_general"`
-	IsMember  bool   `json:"is_member"`
-	Locale    string `json:"locale"`
+	IsChannel  bool        `json:"is_channel"`
+	IsGeneral  bool        `json:"is_general"`
+	IsMember   bool        `json:"is_member"`
+	Locale     string      `json:"locale"`
+	Properties *Properties `json:"properties"`
 }
 
 func (api *Client) channelRequest(ctx context.Context, path string, values url.Values) (*channelResponseFull, error) {

--- a/conversation.go
+++ b/conversation.go
@@ -60,6 +60,17 @@ type Purpose struct {
 	LastSet JSONTime `json:"last_set"`
 }
 
+// Properties contains the Canvas associated to the channel.
+type Properties struct {
+	Canvas Canvas `json:"canvas"`
+}
+
+type Canvas struct {
+	FileId       string `json:"file_id"`
+	IsEmpty      bool   `json:"is_empty"`
+	QuipThreadId string `json:"quip_thread_id"`
+}
+
 type GetUsersInConversationParameters struct {
 	ChannelID string
 	Cursor    string

--- a/conversation_test.go
+++ b/conversation_test.go
@@ -149,6 +149,85 @@ func TestCreateSimpleGroup(t *testing.T) {
 	assertSimpleGroup(t, group)
 }
 
+// Channel with Canvas
+var channelWithCanvas = `{
+    "id": "C024BE91L",
+    "name": "fun",
+    "is_channel": true,
+    "created": 1360782804,
+    "creator": "U024BE7LH",
+    "is_archived": false,
+    "is_general": false,
+    "members": [
+        "U024BE7LH"
+    ],
+    "topic": {
+        "value": "Fun times",
+        "creator": "U024BE7LV",
+        "last_set": 1369677212
+    },
+    "purpose": {
+        "value": "This channel is for fun",
+        "creator": "U024BE7LH",
+        "last_set": 1360782804
+    },
+    "is_member": true,
+    "last_read": "1401383885.000061",
+    "unread_count": 0,
+    "unread_count_display": 0,
+	"properties": {
+        "canvas": {
+            "file_id": "F05RQ01LJU0",
+            "is_empty": true,
+            "quip_thread_id": "XFB9AAlvIyJ"
+        }
+    }
+}`
+
+func unmarshalChannelWithCanvas(j string) (*Channel, error) {
+	channel := &Channel{}
+	if err := json.Unmarshal([]byte(j), &channel); err != nil {
+		return nil, err
+	}
+	return channel, nil
+}
+
+func TestChannelWithCanvas(t *testing.T) {
+	channel, err := unmarshalChannelWithCanvas(channelWithCanvas)
+	assert.Nil(t, err)
+	assertChannelWithCanvas(t, channel)
+}
+
+func assertChannelWithCanvas(t *testing.T, channel *Channel) {
+	assertSimpleChannel(t, channel)
+	assert.Equal(t, "F05RQ01LJU0", channel.Properties.Canvas.FileId)
+	assert.Equal(t, true, channel.Properties.Canvas.IsEmpty)
+	assert.Equal(t, "XFB9AAlvIyJ", channel.Properties.Canvas.QuipThreadId)
+}
+
+func TestCreateChannelWithCanvas(t *testing.T) {
+	channel := &Channel{}
+	channel.ID = "C024BE91L"
+	channel.Name = "fun"
+	channel.IsChannel = true
+	channel.Created = JSONTime(1360782804)
+	channel.Creator = "U024BE7LH"
+	channel.IsArchived = false
+	channel.IsGeneral = false
+	channel.IsMember = true
+	channel.LastRead = "1401383885.000061"
+	channel.UnreadCount = 0
+	channel.UnreadCountDisplay = 0
+	channel.Properties = &Properties{
+		Canvas: Canvas{
+			FileId:       "F05RQ01LJU0",
+			IsEmpty:      true,
+			QuipThreadId: "XFB9AAlvIyJ",
+		},
+	}
+	assertChannelWithCanvas(t, channel)
+}
+
 // IM
 var simpleIM = `{
     "id": "D024BFF1M",


### PR DESCRIPTION
Not documented in [the reference of conversations.info](https://api.slack.com/methods/conversations.info/test) but now the response of `conversations.info` contains [Canvas](https://slack.com/features/canvas) related data when the channel has a canvas for the channel. ( `properties` key itself is not contained if no canvas is associated to the channel)

```json
{
    "ok": true,
    "channel": {
      .....
        "properties": {
            "canvas": {
                "file_id": "F05T9HXD8DQ",
                "is_empty": true,
                "quip_thread_id": "MCE9AA8oXgH"
            }
        }
    }
}
```

A Canvas dedicated to the channel can be created by the button placed in top right of the window.
<img width="613" alt="Screenshot 2023-09-21 at 13 54 07" src="https://github.com/slack-go/slack/assets/9550/6d10459c-8400-470a-b560-03a0b19b1d16">

