### PR TITLE
Add connected_team_ids optional field to Conversation 

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -22,6 +22,7 @@ type Conversation struct {
 	IsIM               bool     `json:"is_im"`
 	IsExtShared        bool     `json:"is_ext_shared"`
 	IsOrgShared        bool     `json:"is_org_shared"`
+	IsGlobalShared     bool     `json:"is_global_shared"`
 	IsPendingExtShared bool     `json:"is_pending_ext_shared"`
 	IsPrivate          bool     `json:"is_private"`
 	IsMpIM             bool     `json:"is_mpim"`
@@ -30,6 +31,9 @@ type Conversation struct {
 	NumMembers         int      `json:"num_members"`
 	Priority           float64  `json:"priority"`
 	User               string   `json:"user"`
+	ConnectedTeamIDs   []string `json:"connected_team_ids,omitempty"`
+	SharedTeamIDs      []string `json:"shared_team_ids,omitempty"`
+	InternalTeamIDs    []string `json:"internal_team_ids,omitempty"`
 
 	// TODO support pending_shared
 	// TODO support previous_names


### PR DESCRIPTION
Adding `connected_team_ids` to `Conversation` struct.

When conversation.info is called, the response comes with a list of team_ids that are connected to the channel. Currently some fields from the response are missing from `Conversation` struct.

`connected_team_ids`
`internal_team_ids`
`shared_team_ids`
`is_global_shared`

![image](https://github.com/slack-go/slack/assets/33224337/193ef6a0-1f7b-45b6-b1fa-d5a4545835f3)
