### PR TITLE
Expose is_enterprise_install field

### DIFF
--- a/interactions.go
+++ b/interactions.go
@@ -33,29 +33,30 @@ const (
 
 // InteractionCallback is sent from slack when a user interactions with a button or dialog.
 type InteractionCallback struct {
-	Type            InteractionType         `json:"type"`
-	Token           string                  `json:"token"`
-	CallbackID      string                  `json:"callback_id"`
-	ResponseURL     string                  `json:"response_url"`
-	TriggerID       string                  `json:"trigger_id"`
-	ActionTs        string                  `json:"action_ts"`
-	Team            Team                    `json:"team"`
-	Channel         Channel                 `json:"channel"`
-	User            User                    `json:"user"`
-	OriginalMessage Message                 `json:"original_message"`
-	Message         Message                 `json:"message"`
-	Name            string                  `json:"name"`
-	Value           string                  `json:"value"`
-	MessageTs       string                  `json:"message_ts"`
-	AttachmentID    string                  `json:"attachment_id"`
-	ActionCallback  ActionCallbacks         `json:"actions"`
-	View            View                    `json:"view"`
-	ActionID        string                  `json:"action_id"`
-	APIAppID        string                  `json:"api_app_id"`
-	BlockID         string                  `json:"block_id"`
-	Container       Container               `json:"container"`
-	Enterprise      Enterprise              `json:"enterprise"`
-	WorkflowStep    InteractionWorkflowStep `json:"workflow_step"`
+	Type                InteractionType         `json:"type"`
+	Token               string                  `json:"token"`
+	CallbackID          string                  `json:"callback_id"`
+	ResponseURL         string                  `json:"response_url"`
+	TriggerID           string                  `json:"trigger_id"`
+	ActionTs            string                  `json:"action_ts"`
+	Team                Team                    `json:"team"`
+	Channel             Channel                 `json:"channel"`
+	User                User                    `json:"user"`
+	OriginalMessage     Message                 `json:"original_message"`
+	Message             Message                 `json:"message"`
+	Name                string                  `json:"name"`
+	Value               string                  `json:"value"`
+	MessageTs           string                  `json:"message_ts"`
+	AttachmentID        string                  `json:"attachment_id"`
+	ActionCallback      ActionCallbacks         `json:"actions"`
+	View                View                    `json:"view"`
+	ActionID            string                  `json:"action_id"`
+	APIAppID            string                  `json:"api_app_id"`
+	BlockID             string                  `json:"block_id"`
+	Container           Container               `json:"container"`
+	Enterprise          Enterprise              `json:"enterprise"`
+	IsEnterpriseInstall bool                    `json:"is_enterprise_install"`
+	WorkflowStep        InteractionWorkflowStep `json:"workflow_step"`
 	DialogSubmissionCallback
 	ViewSubmissionCallback
 	ViewClosedCallback


### PR DESCRIPTION
##### Pull Request Guidelines

These are recommendations for pull requests.
They are strictly guidelines to help manage expectations.

##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [x] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

Just exposing an existing field within the InteractionCallback object returned from Slack.