### PR TITLE
Edited field in the app mention event

### DIFF
--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -28,6 +28,9 @@ type AppMentionEvent struct {
 
 	// BotID is filled out when a bot triggers the app_mention event
 	BotID string `json:"bot_id,omitempty"`
+
+	// When the app is mentioned in the edited message
+	Edited *Edited `json:"edited,omitempty"`
 }
 
 // AppHomeOpenedEvent Your Slack app home was opened.


### PR DESCRIPTION
This commit add edited field to the app mention event

Sometimes it is important to react on the mention only once. The field helps to distinguish whether the message is original or edited

https://github.com/slack-go/slack/issues/961

Example:
```
{
    "envelope_id": "********",
    "payload": {
        "token": "********",
        "team_id": "T********",
        "api_app_id": "A********",
        "event": {
            "client_msg_id": "********",
            "type": "app_mention",
            "text": "********",
            "user": "U********",
            "ts": "1706785424.099119",
            "blocks": [
                {
                    "type": "rich_text",
                    "block_id": "7Kvco",
                    "elements": [
                        {
                            "type": "rich_text_section",
                            "elements": [
                                {
                                    "type": "text",
                                    "text": "text"
                                }
                            ]
                        }
                    ]
                }
            ],
            "team": "T********",
            "edited": {
                "user": "U********",
                "ts": "1706785427.000000"
            },
            "thread_ts": "1706785424.099119",
            "reply_count": 1,
            "reply_users_count": 1,
            "latest_reply": "1706785424.915589",
            "reply_users": [
                "U********"
            ],
            "is_locked": false,
            "subscribed": false,
            "channel": "C********",
            "event_ts": "1706785424.099119"
        },
        "type": "event_callback",
        "event_id": "********",
        "event_time": 1706785424,
        "authorizations": [
            {
                "enterprise_id": null,
                "team_id": "T********",
                "user_id": "U********",
                "is_bot": true,
                "is_enterprise_install": false
            }
        ],
        "is_ext_shared_channel": false,
        "event_context": "********"
    },
    "type": "events_api",
    "accepts_response_payload": false,
    "retry_attempt": 0,
    "retry_reason": ""
}
```