### PR TITLE
Fix: always add context to errors during block serde

### DIFF
--- a/block_conv.go
+++ b/block_conv.go
@@ -2,7 +2,6 @@ package slack
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 )
 
@@ -133,7 +132,7 @@ func (b *InputBlock) UnmarshalJSON(data []byte) error {
 	case "number_input":
 		e = &NumberInputBlockElement{}
 	default:
-		return errors.New("unsupported block element type")
+		return fmt.Errorf("unsupported block element type %v", s.TypeVal)
 	}
 
 	if err := json.Unmarshal(a.Element, e); err != nil {
@@ -431,7 +430,7 @@ func (e *ContextElements) UnmarshalJSON(data []byte) error {
 
 			e.Elements = append(e.Elements, elem.(*ImageBlockElement))
 		default:
-			return errors.New("unsupported context element type")
+			return fmt.Errorf("unsupported context element type %v", contextElementType)
 		}
 	}
 


### PR DESCRIPTION
Maintains consistency with existing code:

https://github.com/slack-go/slack/blob/86cd1bdb0575308dd7cc8345cf15e7b724bfafbf/block_conv.go#L213-L215

Adds critical context to errors during the many ~headaches~ joys of developing with the slack block kit.