### PR TITLE
Fix: parse is_enterprise_install string

### DIFF
--- a/slash.go
+++ b/slash.go
@@ -11,7 +11,7 @@ type SlashCommand struct {
 	TeamDomain          string `json:"team_domain"`
 	EnterpriseID        string `json:"enterprise_id,omitempty"`
 	EnterpriseName      string `json:"enterprise_name,omitempty"`
-	IsEnterpriseInstall bool   `json:"is_enterprise_install"`
+	IsEnterpriseInstall bool   `json:"is_enterprise_install,string"`
 	ChannelID           string `json:"channel_id"`
 	ChannelName         string `json:"channel_name"`
 	UserID              string `json:"user_id"`


### PR DESCRIPTION
`Cause: (*fmt.wrapError)(0xc004b8f3c0)(parsing slash command: json: cannot unmarshal string into Go struct field SlashCommand.is_enterprise_install of type bool),`

sometimes we get `"is_enterprise_install":"false"`, sometimes we get `"is_enterprise_install": false`

add `,string`: and now both work
