### PR TITLE
Block Object: Validate text min and max length

### DIFF
--- a/block_object.go
+++ b/block_object.go
@@ -147,6 +147,16 @@ func (s TextBlockObject) Validate() error {
 		return errors.New("emoji cannot be true in mrkdown")
 	}
 
+	// https://api.slack.com/reference/block-kit/composition-objects#text__fields
+	if len(s.Text) == 0 {
+		return errors.New("text must have a minimum length of 1")
+	}
+
+	// https://api.slack.com/reference/block-kit/composition-objects#text__fields
+	if len(s.Text) > 3000 {
+		return errors.New("text cannot be longer than 3000 characters")
+	}
+
 	return nil
 }
 

--- a/block_object_test.go
+++ b/block_object_test.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -125,6 +126,24 @@ func TestValidateTextBlockObject(t *testing.T) {
 				Verbatim: false,
 			},
 			expected: errors.New("emoji cannot be true in mrkdown"),
+		},
+		{
+			input: TextBlockObject{
+				Type:     "mrkdwn",
+				Text:     "",
+				Emoji:    false,
+				Verbatim: false,
+			},
+			expected: errors.New("text must have a minimum length of 1"),
+		},
+		{
+			input: TextBlockObject{
+				Type:     "mrkdwn",
+				Text:     strings.Repeat("a", 3001),
+				Emoji:    false,
+				Verbatim: false,
+			},
+			expected: errors.New("text cannot be longer than 3000 characters"),
 		},
 	}
 


### PR DESCRIPTION
The validate block wasn't validating the text size. This was generating a confusing `invalid_block` error when we were sending a message that was longer than the allowed max value, even though we were calling validate() before sending.

Adds:
- Text field min size validation of 1
- Text field max size validation of 3000
- Tests for both cases