### PR TITLE
Fix UploadFileV2 when using text content

### DIFF
--- a/files.go
+++ b/files.go
@@ -504,9 +504,8 @@ func (api *Client) getUploadURLExternal(ctx context.Context, params getUploadURL
 func (api *Client) uploadToURL(ctx context.Context, params uploadToURLParameters) (err error) {
 	values := url.Values{}
 	if params.Content != "" {
-		values.Add("content", params.Content)
-		values.Add("token", api.token)
-		err = postForm(ctx, api.httpclient, params.UploadURL, values, nil, api)
+		contentReader := strings.NewReader(params.Content)
+		err = postWithMultipartResponse(ctx, api.httpclient, params.UploadURL, params.Filename, "file", api.token, values, contentReader, nil, api)
 	} else if params.File != "" {
 		err = postLocalWithMultipartResponse(ctx, api.httpclient, params.UploadURL, params.File, "file", api.token, values, nil, api)
 	} else if params.Reader != nil {


### PR DESCRIPTION
Fixes #1290.

`postWithMultipartResponse` works better for uploading this way, per the [Slack docs](https://api.slack.com/messaging/files#uploading_files).

> POST the contents of your file to the URL returned in step 1. This can be done by sending the raw bytes, or **_can be a multipart form ended request_**. If all went well, Slack will respond with an HTTP 200.
