### PR TITLE
Fix UploadFileV2 to return File instead of FileSummary

### DIFF
--- a/files.go
+++ b/files.go
@@ -197,7 +197,7 @@ type completeUploadExternalParameters struct {
 
 type completeUploadExternalResponse struct {
 	SlackResponse
-	Files []FileSummary `json:"files"`
+	Files []File `json:"files"`
 }
 
 type fileResponseFull struct {
@@ -548,7 +548,7 @@ func (api *Client) completeUploadExternal(ctx context.Context, fileID string, pa
 //  1. Get an upload URL using files.getUploadURLExternal API
 //  2. Send the file as a post to the URL provided by slack
 //  3. Complete the upload and share it to the specified channel using files.completeUploadExternal
-func (api *Client) UploadFileV2(params UploadFileV2Parameters) (*FileSummary, error) {
+func (api *Client) UploadFileV2(params UploadFileV2Parameters) (*File, error) {
 	return api.UploadFileV2Context(context.Background(), params)
 }
 
@@ -556,7 +556,7 @@ func (api *Client) UploadFileV2(params UploadFileV2Parameters) (*FileSummary, er
 //  1. Get an upload URL using files.getUploadURLExternal API
 //  2. Send the file as a post to the URL provided by slack
 //  3. Complete the upload and share it to the specified channel using files.completeUploadExternal
-func (api *Client) UploadFileV2Context(ctx context.Context, params UploadFileV2Parameters) (file *FileSummary, err error) {
+func (api *Client) UploadFileV2Context(ctx context.Context, params UploadFileV2Parameters) (file *File, err error) {
 	if params.Filename == "" {
 		return nil, fmt.Errorf("file.upload.v2: filename cannot be empty")
 	}

--- a/files_test.go
+++ b/files_test.go
@@ -229,7 +229,7 @@ func urlFileUploadHandler(rw http.ResponseWriter, r *http.Request) {
 func completeURLUpload(rw http.ResponseWriter, r *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
 	response, _ := json.Marshal(completeUploadExternalResponse{
-		Files: []FileSummary{
+		Files: []File{
 			{
 				ID:    "RandomID",
 				Title: "",

--- a/misc.go
+++ b/misc.go
@@ -83,7 +83,7 @@ func downloadFile(ctx context.Context, client httpClient, token string, download
 		return err
 	}
 
-	var bearer = "Bearer " + token
+	bearer := "Bearer " + token
 	req.Header.Add("Authorization", bearer)
 
 	resp, err := client.Do(req)
@@ -181,7 +181,6 @@ func postWithMultipartResponse(ctx context.Context, client httpClient, path, nam
 	req.Header.Add("Content-Type", wr.FormDataContentType())
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	resp, err := client.Do(req)
-
 	if err != nil {
 		return err
 	}
@@ -331,9 +330,7 @@ func newTextParser(dst interface{}) responseParser {
 
 func newContentTypeParser(dst interface{}) responseParser {
 	return func(req *http.Response) (err error) {
-		var (
-			ctype string
-		)
+		var ctype string
 
 		if ctype, _, err = mime.ParseMediaType(req.Header.Get("Content-Type")); err != nil {
 			return err


### PR DESCRIPTION
By returning `FileSummary` instead of a `File` object, in most cases, we have to make another call to get file info, which requires `files:read` permission scope. This in fact breaks many existing apps.

This change makes the Go sdk somewhat more in-line with other SDKs.

##### Pull Request Guidelines

These are recommendations for pull requests.
They are strictly guidelines to help manage expectations.

##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### Examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.
