### PR TITLE
ci: Adding Go Test Coverage for 1.21 and 1.22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
           - '1.18'
           - '1.19'
           - '1.20'
+          - '1.21'
+          - '1.22'
     name: test go-${{ matrix.go }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This pull request adds test coverage for Go v1.21 and v1.22 to ensure appropriate test coverage with newer versions of Go. I don't expect any issues but a bit of extra test coverage and peace of mind is always nice :)