### PR TITLE
chore: Adding Deprecation Notice for files.upload

### DIFF
--- a/files.go
+++ b/files.go
@@ -351,12 +351,16 @@ func (api *Client) ListFilesContext(ctx context.Context, params ListFilesParamet
 	return response.Files, &params, nil
 }
 
-// UploadFile uploads a file
+// UploadFile uploads a file.
+// DEPRECATED: Use UploadFileV2 instead. This will stop functioning on March 11, 2025.
+// For more details, see: https://api.slack.com/methods/files.upload#markdown
 func (api *Client) UploadFile(params FileUploadParameters) (file *File, err error) {
 	return api.UploadFileContext(context.Background(), params)
 }
 
-// UploadFileContext uploads a file and setting a custom context
+// UploadFileContext uploads a file and setting a custom context.
+// DEPRECATED: Use UploadFileV2Context instead. This will stop functioning on March 11, 2025.
+// For more details, see: https://api.slack.com/methods/files.upload#markdown
 func (api *Client) UploadFileContext(ctx context.Context, params FileUploadParameters) (file *File, err error) {
 	// Test if user token is valid. This helps because client.Do doesn't like this for some reason. XXX: More
 	// investigation needed, but for now this will do.


### PR DESCRIPTION
This pull request adds a deprecation notice for files.upload and addresses #1287.

> files.upload is deprecated and will stop functioning on March 11, 2025. Use [files.getUploadURLExternal](https://api.slack.com/methods/files.getUploadURLExternal) and [files.completeUploadExternal](https://api.slack.com/methods/files.completeUploadExternal) to upload files instead. Newly created apps will be unable to use files.upload beginning May 8, 2024. See [Uploading files](https://api.slack.com/messaging/files#uploading_files) for more details on the process and [this changelog](https://api.slack.com/changelog/2024-04-a-better-way-to-upload-files-is-here-to-stay) for more on the deprecation.

Reference: https://api.slack.com/methods/files.upload#markdown