### PR TITLE
feat(slackevents): Support metadata in MessageEvent

### DIFF
--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -276,6 +276,8 @@ type MessageEvent struct {
 	Blocks      slack.Blocks       `json:"blocks,omitempty"`
 	Attachments []slack.Attachment `json:"attachments,omitempty"`
 
+	Metadata slack.SlackMetadata `json:"metadata,omitempty"`
+
 	// Root is the message that was broadcast to the channel when the SubType is
 	// thread_broadcast. If this is not a thread_broadcast message event, this
 	// value is nil.

--- a/slackevents/inner_events_test.go
+++ b/slackevents/inner_events_test.go
@@ -300,6 +300,12 @@ func TestMessageEvent(t *testing.T) {
 						"ts": "1355517524.000000"
 					}
 				},
+				"metadata": {
+					"event_type": "example",
+					"event_payload": {
+						"key": "value"
+					}
+				},
 				"previous_message": {
 					"text": "Live long and prospect."
 				}


### PR DESCRIPTION
Support for receiving metadata when reading conversation history was first added in PR #1083. This commit extends metadata support to message events when connected to the Slack WebSocket API.

This aligns with the structure mentioned on Slack's documentation for [Using message metadata](https://api.slack.com/metadata/using#events), and my local testing showed that the metadata does indeed appear properly with this field added. 