### PR TITLE
feat: Add support for parsing AppRateLimited events

### DIFF
--- a/slackevents/parsers.go
+++ b/slackevents/parsers.go
@@ -212,6 +212,32 @@ func ParseEvent(rawEvent json.RawMessage, opts ...Option) (EventsAPIEvent, error
 		}
 		return innerEvent, nil
 	}
+
+	if e.Type == AppRateLimited {
+		appRateLimitedEvent := &EventsAPIAppRateLimited{}
+		err = json.Unmarshal(rawEvent, appRateLimitedEvent)
+		if err != nil {
+			return EventsAPIEvent{
+				"",
+				"",
+				"unmarshalling_error",
+				"",
+				"",
+				&slack.UnmarshallingErrorEvent{ErrorObj: err},
+				EventsAPIInnerEvent{},
+			}, err
+		}
+		return EventsAPIEvent{
+			e.Token,
+			e.TeamID,
+			e.Type,
+			e.APIAppID,
+			e.EnterpriseID,
+			appRateLimitedEvent,
+			EventsAPIInnerEvent{},
+		}, nil
+	}
+
 	urlVerificationEvent := &EventsAPIURLVerificationEvent{}
 	err = json.Unmarshal(rawEvent, urlVerificationEvent)
 	if err != nil {

--- a/slackevents/parsers_test.go
+++ b/slackevents/parsers_test.go
@@ -73,6 +73,33 @@ func TestParseURLVerificationEvent(t *testing.T) {
 	}
 }
 
+func TestParseAppRateLimitedEvent(t *testing.T) {
+	event := `
+		{
+			"token": "fake-token",
+			"team_id": "T123ABC456",
+			"minute_rate_limited": 1518467820,
+			"api_app_id": "A123ABC456",
+			"type": "app_rate_limited"
+		}
+	`
+	msg, e := ParseEvent(json.RawMessage(event), OptionVerifyToken(&TokenComparator{"fake-token"}))
+	if e != nil {
+		fmt.Println(e)
+		t.Fail()
+	}
+	switch ev := msg.Data.(type) {
+	case *EventsAPIAppRateLimited:
+		{
+		}
+	default:
+		{
+			fmt.Println(ev)
+			t.Fail()
+		}
+	}
+}
+
 func TestThatOuterCallbackEventHasInnerEvent(t *testing.T) {
 	eventsAPIRawCallbackEvent := `
 			{


### PR DESCRIPTION
The code changes in this commit add support for parsing AppRateLimited events in the `ParseEvent` function. This allows the application to handle rate-limited events from the Slack API.

Ref: https://api.slack.com/apis/events-api#rate-limiting

##### Pull Request Guidelines

These are recommendations for pull requests.
They are strictly guidelines to help manage expectations.

##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead
- [x] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### Examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.
