### PR TITLE
Support publishing a messge to a specific thread

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -377,6 +377,7 @@ func (t responseURLSender) BuildRequestContext(ctx context.Context) (*http.Reque
 	req, err := jsonReq(ctx, t.endpoint, Msg{
 		Text:            t.values.Get("text"),
 		Timestamp:       t.values.Get("ts"),
+		ThreadTimestamp: t.values.Get("thread_ts"),
 		Attachments:     t.attachments,
 		Blocks:          t.blocks,
 		Metadata:        t.metadata,


### PR DESCRIPTION
Support publishing a messge to a specific thread https://api.slack.com/interactivity/handling#publishing_in_thread

From slack interactivity documentation:
Publishing responses in thread 
If you want to publish a message to a specific thread, you'll need to include an attribute response_type and set its value to in_channel. Then, to specify the thread, include a thread_ts.

Also, be sure to set replace_original to false or you'll overwrite the message you're wanting to respond to!