### PR TITLE
feat: Add slack_file to image block

### DIFF
--- a/block_image.go
+++ b/block_image.go
@@ -4,11 +4,21 @@ package slack
 //
 // More Information: https://api.slack.com/reference/messaging/blocks#image
 type ImageBlock struct {
-	Type     MessageBlockType `json:"type"`
-	ImageURL string           `json:"image_url"`
-	AltText  string           `json:"alt_text"`
-	BlockID  string           `json:"block_id,omitempty"`
-	Title    *TextBlockObject `json:"title,omitempty"`
+	Type      MessageBlockType `json:"type"`
+	ImageURL  string           `json:"image_url,omitempty"`
+	AltText   string           `json:"alt_text"`
+	BlockID   string           `json:"block_id,omitempty"`
+	Title     *TextBlockObject `json:"title,omitempty"`
+	SlackFile *SlackFileObject `json:"slack_file,omitempty"`
+}
+
+// SlackFileObject Defines an object containing Slack file information to be used in an
+// image block or image element.
+//
+// More Information: https://api.slack.com/reference/block-kit/composition-objects#slack_file
+type SlackFileObject struct {
+	ID  string `json:"id,omitempty"`
+	URL string `json:"url,omitempty"`
 }
 
 // BlockType returns the type of the block


### PR DESCRIPTION
Image block now allows specifying a slack_file element instead of image_url https://api.slack.com/reference/block-kit/blocks#image

##### Pull Request Guidelines

These are recommendations for pull requests.
They are strictly guidelines to help manage expectations.

##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### Examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.
