### PR TITLE
feat: add file access field to file struct for slackevents

### DIFF
--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -465,6 +465,7 @@ type File struct {
 	DisplayAsBot       bool   `json:"display_as_bot"`
 	Username           string `json:"username"`
 	URLPrivate         string `json:"url_private"`
+	FileAccess         string `json:"file_access"`
 	URLPrivateDownload string `json:"url_private_download"`
 	Thumb64            string `json:"thumb_64"`
 	Thumb80            string `json:"thumb_80"`


### PR DESCRIPTION
##### Description

This PR consist of adding a new field, `file_access` to the slackevents File Object.

When a slack event is received from a slack connect channel, file data will not be included in the payload and requires an extra step to make API call to fetch the file data i.e. `files.info`. Slack includes the field `file_access` to determine this. More info https://api.slack.com/types/file#slack_connect_files

