### PR TITLE
ci: Bump GitHub Actions to Latest Versions

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:
           any-of-labels: 'feedback given'
           days-before-stale: 45

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,8 @@ jobs:
           - '1.22'
     name: test go-${{ matrix.go }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
       - name: run test
@@ -31,14 +31,14 @@ jobs:
     runs-on: ubuntu-22.04
     name: lint
     steps:
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.20'
           cache: false
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0
+        uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         with:
           version: v1.52.2


### PR DESCRIPTION
bump GitHub Actions to fix the following warnings.

https://github.com/slack-go/slack/actions/runs/10407631139

<img width="1549" alt="image" src="https://github.com/user-attachments/assets/0791d8c3-dd03-4f3e-b80e-2f65e31719ae">

> The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3, actions/setup-go@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/