### PR TITLE
ci: Add go v1.23 to test matrix (test.yml)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
           - '1.20'
           - '1.21'
           - '1.22'
+          - '1.23'
     name: test go-${{ matrix.go }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This pull request adds test coverage for Go `v1.23`.