### PR TITLE
docs: fix deprecated comment for UploadFile and UploadFileContext

### DIFF
--- a/files.go
+++ b/files.go
@@ -355,14 +355,16 @@ func (api *Client) ListFilesContext(ctx context.Context, params ListFilesParamet
 }
 
 // UploadFile uploads a file.
-// DEPRECATED: Use UploadFileV2 instead. This will stop functioning on March 11, 2025.
+//
+// Deprecated: Use [Client.UploadFileV2] instead. This will stop functioning on March 11, 2025.
 // For more details, see: https://api.slack.com/methods/files.upload#markdown
 func (api *Client) UploadFile(params FileUploadParameters) (file *File, err error) {
 	return api.UploadFileContext(context.Background(), params)
 }
 
 // UploadFileContext uploads a file and setting a custom context.
-// DEPRECATED: Use UploadFileV2Context instead. This will stop functioning on March 11, 2025.
+//
+// Deprecated: Use [Client.UploadFileV2Context] instead. This will stop functioning on March 11, 2025.
 // For more details, see: https://api.slack.com/methods/files.upload#markdown
 func (api *Client) UploadFileContext(ctx context.Context, params FileUploadParameters) (file *File, err error) {
 	// Test if user token is valid. This helps because client.Do doesn't like this for some reason. XXX: More


### PR DESCRIPTION
The [UploadFile](https://pkg.go.dev/github.com/slack-go/slack#Client.UploadFile) and [UploadFileContext](https://pkg.go.dev/github.com/slack-go/slack#Client.UploadFileContext) have been deprecated, but pkgsite is not aware of it:

<img width="1153" alt="image" src="https://github.com/user-attachments/assets/4932eae2-d8f7-4e8f-a873-d9df88f35171">

This pull request fixes it.
pkgsite will mark UploadFile and UploadFileContext as DEPRECATED:

<img width="1154" alt="image" src="https://github.com/user-attachments/assets/92995549-65fc-4764-9984-0eb9e0025089">

And some tools will warn use of UploadFile and UploadFileContext.

See https://go.dev/wiki/Deprecated for more detail.