### PR TITLE
fix: Ensures the Emoji Block Kit Unicode is Optional

### DIFF
--- a/block_rich_text.go
+++ b/block_rich_text.go
@@ -341,7 +341,7 @@ type RichTextSectionEmojiElement struct {
 	Type     RichTextSectionElementType `json:"type"`
 	Name     string                     `json:"name"`
 	SkinTone int                        `json:"skin_tone"`
-	Unicode  string                     `json:"unicode,omitempty"`
+	Unicode  *string                    `json:"unicode,omitempty"`
 	Style    *RichTextSectionTextStyle  `json:"style,omitempty"`
 }
 


### PR DESCRIPTION
This pull request is a follow-up to https://github.com/slack-go/slack/pull/1319 to mark the Unicode parameter as optional to maintain backwards compatibility.