### PR TITLE
fix: Don't require `skin_tone` for rich text emoji element

### DIFF
--- a/block_rich_text.go
+++ b/block_rich_text.go
@@ -340,7 +340,7 @@ func NewRichTextSectionUserElement(userID string, style *RichTextSectionTextStyl
 type RichTextSectionEmojiElement struct {
 	Type     RichTextSectionElementType `json:"type"`
 	Name     string                     `json:"name"`
-	SkinTone int                        `json:"skin_tone"`
+	SkinTone int                        `json:"skin_tone,omitempty"`
 	Unicode  string                     `json:"unicode,omitempty"`
 	Style    *RichTextSectionTextStyle  `json:"style,omitempty"`
 }

--- a/block_rich_text_test.go
+++ b/block_rich_text_test.go
@@ -188,6 +188,16 @@ func TestRichTextSection_UnmarshalJSON(t *testing.T) {
 			nil,
 		},
 		{
+			[]byte(`{"type": "rich_text_section","elements":[{"type": "emoji","name": "+1"}]}`),
+			RichTextSection{
+				Type: RTESection,
+				Elements: []RichTextSectionElement{
+					&RichTextSectionEmojiElement{Type: RTSEEmoji, Name: "+1"},
+				},
+			},
+			nil,
+		},
+		{
 			[]byte(`{"type": "rich_text_section","elements":[{"type": "emoji","name": "+1","unicode": "1f44d-1f3fb","skin_tone": 2}]}`),
 			RichTextSection{
 				Type: RTESection,
@@ -299,7 +309,7 @@ func TestRichTextList_UnmarshalJSON(t *testing.T) {
 
 func TestRichTextQuote_Marshal(t *testing.T) {
 	t.Run("rich_text_section", func(t *testing.T) {
-		const rawRSE = "{\"type\":\"rich_text_section\",\"elements\":[{\"type\":\"text\",\"text\":\"Some Text\"}]}"
+		const rawRSE = "{\"type\":\"rich_text_section\",\"elements\":[{\"type\":\"text\",\"text\":\"Some Text\"},{\"type\":\"emoji\",\"name\":\"+1\"},{\"type\":\"emoji\",\"name\":\"+1\",\"skin_tone\":2}]}"
 
 		var got RichTextSection
 		if err := json.Unmarshal([]byte(rawRSE), &got); err != nil {
@@ -309,6 +319,8 @@ func TestRichTextQuote_Marshal(t *testing.T) {
 			Type: RTESection,
 			Elements: []RichTextSectionElement{
 				&RichTextSectionTextElement{Type: RTSEText, Text: "Some Text"},
+				&RichTextSectionEmojiElement{Type: RTSEEmoji, Name: "+1"},
+				&RichTextSectionEmojiElement{Type: RTSEEmoji, Name: "+1", SkinTone: 2},
 			},
 		}
 


### PR DESCRIPTION
In a rich text `emoji` element, the `skin_tone` value is optional, and when not provided will use the default skin tone. When unmarshalling from JSON, this parameter defaults to an invalid value of 0 (`skin_tone` values range from 2 to 6), resulting in an "invalid_blocks" error when sending a message. This PR allows the `skin_tone` element to be omitted when unmarshalling from JSON.