### PR TITLE
fix: Assistant Prompts and Status, send channel_id with request

### DIFF
--- a/assistant.go
+++ b/assistant.go
@@ -60,6 +60,8 @@ func (api *Client) SetAssistantThreadsSuggestedPromptsContext(ctx context.Contex
 		values.Add("thread_ts", params.ThreadTS)
 	}
 
+	values.Add("channel_id", params.ChannelID)
+
 	// Send Prompts as JSON
 	prompts, err := json.Marshal(params.Prompts)
 	if err != nil {

--- a/assistant.go
+++ b/assistant.go
@@ -100,6 +100,8 @@ func (api *Client) SetAssistantThreadsStatusContext(ctx context.Context, params 
 		values.Add("thread_ts", params.ThreadTS)
 	}
 
+	values.Add("channel_id", params.ChannelID)
+
 	// Always send the status parameter, if empty, it will clear any existing status
 	values.Add("status", params.Status)
 


### PR DESCRIPTION
This is a fix for [PR 1331](https://github.com/slack-go/slack/pull/1331), which I mistakenly removed the channel_id parameter from the API request during feedback.

Without channel_id provided, the call always returns `invalid_arguments`. 