### PR TITLE
[fix] function execution events accept interfaces not strings

### DIFF
--- a/examples/function/function.go
+++ b/examples/function/function.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/slackevents"
 	"github.com/slack-go/slack/socketmode"
-	"os"
 )
 
 func main() {
@@ -38,7 +39,7 @@ func main() {
 						if callbackID == "sample_function" {
 							userId := ev.Inputs["user_id"]
 							payload := map[string]string{
-								"user_id": userId,
+								"user_id": userId.(string),
 							}
 
 							err := api.FunctionCompleteSuccess(ev.FunctionExecutionID, slack.FunctionCompleteSuccessRequestOptionOutput(payload))

--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -986,11 +986,11 @@ type FunctionExecutedEvent struct {
 		DateUpdated int64  `json:"date_updated"`
 		DateDeleted int64  `json:"date_deleted"`
 	} `json:"function"`
-	Inputs              map[string]string `json:"inputs"`
-	FunctionExecutionID string            `json:"function_execution_id"`
-	WorkflowExecutionID string            `json:"workflow_execution_id"`
-	EventTs             string            `json:"event_ts"`
-	BotAccessToken      string            `json:"bot_access_token"`
+	Inputs              map[string]interface{} `json:"inputs"`
+	FunctionExecutionID string                 `json:"function_execution_id"`
+	WorkflowExecutionID string                 `json:"workflow_execution_id"`
+	EventTs             string                 `json:"event_ts"`
+	BotAccessToken      string                 `json:"bot_access_token"`
 }
 
 type InviteRequestedEvent struct {

--- a/slackevents/inner_events_test.go
+++ b/slackevents/inner_events_test.go
@@ -2559,6 +2559,20 @@ func TestFunctionExecutedEvent(t *testing.T) {
 					"description": "Message recipient",
 					"title": "User",
 					"is_required": true
+				},
+				{
+					"type": "integer",
+					"name": "timestamp",
+					"description": "Timestamp of the event",
+					"title": "Timestamp",
+					"is_required": true
+				},
+				{
+					"type": "boolean",
+					"name": "enabled",
+					"description": "Indicates if the feature is enabled",
+					"title": "Enabled",
+					"is_required": true
 				}
 			],
 			"output_parameters": [
@@ -2577,8 +2591,10 @@ func TestFunctionExecutedEvent(t *testing.T) {
 		},
 		"inputs": {
 			"user_id": "USER12345678",
+			"timestamp": 1698947481,
+			"enabled": true,
 			"message_context": {
-				"channel_id": "C07H1ER7U66",
+				"channel_id": "C0123456789",
 				"message_ts": "1733331835.871019"
 			}
 		},
@@ -2587,6 +2603,17 @@ func TestFunctionExecutedEvent(t *testing.T) {
 		"event_ts": "1698958075.998738",
 		"bot_access_token": "abcd-1325532282098-1322446258629-6123648410839-527a1cab3979cad288c9e20330d212cf"
 	}`
+
+	type MessageContext struct {
+		ChannelId string `json:"channel_id"`
+		MessageTs string `json:"message_ts"`
+	}
+	type TestInputs struct {
+		UserId    string         `json:"user_id"`
+		Timestamp int            `json:"timestamp"`
+		Enabled   bool           `json:"enabled"`
+		Context   MessageContext `json:"message_context"`
+	}
 
 	var event FunctionExecutedEvent
 	if err := json.Unmarshal([]byte(jsonStr), &event); err != nil {
@@ -2604,6 +2631,21 @@ func TestFunctionExecutedEvent(t *testing.T) {
 	if event.FunctionExecutionID != "Fx1234567O9L" {
 		t.Fail()
 	}
+
+	inputStr, err := json.Marshal(event.Inputs)
+	if err != nil {
+		t.Errorf("Failed to marshal Inputs of FunctionExecutedEvent: %v", err)
+	}
+	testInputs := new(TestInputs)
+	err = json.Unmarshal(inputStr, testInputs)
+	if err != nil {
+		t.Errorf("Failed to unmarshal Inputs of FunctionExecutedEvent: %v", err)
+	}
+	assert.Equal(t, "USER12345678", testInputs.UserId)
+	assert.Equal(t, 1698947481, testInputs.Timestamp)
+	assert.True(t, testInputs.Enabled)
+	assert.Equal(t, "C0123456789", testInputs.Context.ChannelId)
+	assert.Equal(t, "1733331835.871019", testInputs.Context.MessageTs)
 }
 
 func TestInviteRequestedEvent(t *testing.T) {

--- a/slackevents/inner_events_test.go
+++ b/slackevents/inner_events_test.go
@@ -2547,6 +2547,13 @@ func TestFunctionExecutedEvent(t *testing.T) {
 			"type": "app",
 			"input_parameters": [
 				{
+					"type": "slack#/types/message_context",
+					"name": "message_context",
+					"description": "",
+					"title": "Message Context",
+					"is_required": true
+				},
+				{
 					"type": "slack#/types/user_id",
 					"name": "user_id",
 					"description": "Message recipient",
@@ -2568,7 +2575,13 @@ func TestFunctionExecutedEvent(t *testing.T) {
 			"date_updated": 1698947481,
 			"date_deleted": 0
 		},
-		"inputs": { "user_id": "USER12345678" },
+		"inputs": {
+			"user_id": "USER12345678",
+			"message_context": {
+				"channel_id": "C07H1ER7U66",
+				"message_ts": "1733331835.871019"
+			}
+		},
 		"function_execution_id": "Fx1234567O9L",
 		"workflow_execution_id": "WxABC123DEF0",
 		"event_ts": "1698958075.998738",


### PR DESCRIPTION
##### API changes **[BREAKING]**
In the initial implementation of this change, we assumed that the input types would always be `map[string]string`. However, Slack can send inputs with various types, not just strings. This update modifies the mapping to use an `interface{}` to handle these different input types. Additionally, the test has been updated to include an example of a real payload received from Slack to ensure proper handling of these cases.


##### Example
```json
{
  "event": {
    "type": "function_executed",
    "function": {
      "id": "Fn07TRTH0EKX",
      "callback_id": "d70234",
      "title": "Test",
      "description": "Test.",
      "type": "app",
      "input_parameters": [
        {
          "type": "slack#/types/message_context",
          "name": "message_context",
          "description": "Test",
          "title": "Mesage Context",
          "is_required": true
        }
      ]
    },
    "inputs": {
      "message_context": {
        "channel_id": "C07H1ER7U66",
        "message_ts": "1733331835.871019"
      },
    },
    "function_execution_id": "Fx08387NLCNT",
    "workflow_execution_id": "Wx084BHAGCMN",
    "event_ts": "1733331846.861810"
  }
}
```