### PR TITLE
Add ID() to the Block interface

### DIFF
--- a/block.go
+++ b/block.go
@@ -26,6 +26,7 @@ const (
 // to ensure consistency between blocks.
 type Block interface {
 	BlockType() MessageBlockType
+	ID() string
 }
 
 // Blocks is a convenience struct defined to allow dynamic unmarshalling of

--- a/block_action.go
+++ b/block_action.go
@@ -14,6 +14,11 @@ func (s ActionBlock) BlockType() MessageBlockType {
 	return s.Type
 }
 
+// ID returns the ID of the block
+func (s ActionBlock) ID() string {
+	return s.BlockID
+}
+
 // NewActionBlock returns a new instance of an Action Block
 func NewActionBlock(blockID string, elements ...BlockElement) *ActionBlock {
 	return &ActionBlock{

--- a/block_action_test.go
+++ b/block_action_test.go
@@ -7,13 +7,13 @@ import (
 )
 
 func TestNewActionBlock(t *testing.T) {
-
 	approveBtnTxt := NewTextBlockObject("plain_text", "Approve", false, false)
 	approveBtn := NewButtonBlockElement("", "click_me_123", approveBtnTxt)
-
 	actionBlock := NewActionBlock("test", approveBtn)
+
+	assert.Equal(t, actionBlock.BlockType(), MBTAction)
 	assert.Equal(t, string(actionBlock.Type), "actions")
 	assert.Equal(t, actionBlock.BlockID, "test")
+	assert.Equal(t, actionBlock.ID(), "test")
 	assert.Equal(t, len(actionBlock.Elements.ElementSet), 1)
-
 }

--- a/block_call.go
+++ b/block_call.go
@@ -14,7 +14,12 @@ func (s CallBlock) BlockType() MessageBlockType {
 	return s.Type
 }
 
-// NewFileBlock returns a new instance of a file block
+// ID returns the ID of the block
+func (s CallBlock) ID() string {
+	return s.BlockID
+}
+
+// NewCallBlock returns a new instance of a call block
 func NewCallBlock(callID string) *CallBlock {
 	return &CallBlock{
 		Type:   MBTCall,

--- a/block_call_test.go
+++ b/block_call_test.go
@@ -8,6 +8,10 @@ import (
 
 func TestNewCallBlock(t *testing.T) {
 	callBlock := NewCallBlock("ACallID")
+
+	assert.Equal(t, callBlock.BlockType(), MBTCall)
 	assert.Equal(t, string(callBlock.Type), "call")
 	assert.Equal(t, callBlock.CallID, "ACallID")
+	assert.Equal(t, callBlock.BlockID, "")
+	assert.Equal(t, callBlock.ID(), "")
 }

--- a/block_context.go
+++ b/block_context.go
@@ -15,6 +15,11 @@ func (s ContextBlock) BlockType() MessageBlockType {
 	return s.Type
 }
 
+// ID returns the ID of the block
+func (s ContextBlock) ID() string {
+	return s.BlockID
+}
+
 type ContextElements struct {
 	Elements []MixedElement
 }

--- a/block_context_test.go
+++ b/block_context_test.go
@@ -7,15 +7,14 @@ import (
 )
 
 func TestNewContextBlock(t *testing.T) {
-
 	locationPinImage := NewImageBlockElement("https://api.slack.com/img/blocks/bkb_template_images/tripAgentLocationMarker.png", "Location Pin Icon")
 	textExample := NewTextBlockObject("plain_text", "Location: Central Business District", true, false)
-
 	elements := []MixedElement{locationPinImage, textExample}
-
 	contextBlock := NewContextBlock("test", elements...)
+
+	assert.Equal(t, contextBlock.BlockType(), MBTContext)
 	assert.Equal(t, string(contextBlock.Type), "context")
 	assert.Equal(t, contextBlock.BlockID, "test")
+	assert.Equal(t, contextBlock.ID(), "test")
 	assert.Equal(t, len(contextBlock.ContextElements.Elements), 2)
-
 }

--- a/block_divider.go
+++ b/block_divider.go
@@ -13,10 +13,14 @@ func (s DividerBlock) BlockType() MessageBlockType {
 	return s.Type
 }
 
+// ID returns the ID of the block
+func (s DividerBlock) ID() string {
+	return s.BlockID
+}
+
 // NewDividerBlock returns a new instance of a divider block
 func NewDividerBlock() *DividerBlock {
 	return &DividerBlock{
 		Type: MBTDivider,
 	}
-
 }

--- a/block_divider_test.go
+++ b/block_divider_test.go
@@ -7,8 +7,10 @@ import (
 )
 
 func TestNewDividerBlock(t *testing.T) {
-
 	dividerBlock := NewDividerBlock()
-	assert.Equal(t, string(dividerBlock.Type), "divider")
 
+	assert.Equal(t, dividerBlock.BlockType(), MBTDivider)
+	assert.Equal(t, string(dividerBlock.Type), "divider")
+	assert.Equal(t, dividerBlock.BlockID, "")
+	assert.Equal(t, dividerBlock.ID(), "")
 }

--- a/block_element_test.go
+++ b/block_element_test.go
@@ -7,17 +7,14 @@ import (
 )
 
 func TestNewImageBlockElement(t *testing.T) {
-
 	imageElement := NewImageBlockElement("https://api.slack.com/img/blocks/bkb_template_images/tripAgentLocationMarker.png", "Location Pin Icon")
 
 	assert.Equal(t, string(imageElement.Type), "image")
 	assert.Contains(t, imageElement.ImageURL, "tripAgentLocationMarker")
 	assert.Equal(t, imageElement.AltText, "Location Pin Icon")
-
 }
 
 func TestNewButtonBlockElement(t *testing.T) {
-
 	btnTxt := NewTextBlockObject("plain_text", "Next 2 Results", false, false)
 	btnElement := NewButtonBlockElement("test", "click_me_123", btnTxt)
 
@@ -25,11 +22,9 @@ func TestNewButtonBlockElement(t *testing.T) {
 	assert.Equal(t, btnElement.ActionID, "test")
 	assert.Equal(t, btnElement.Value, "click_me_123")
 	assert.Equal(t, btnElement.Text.Text, "Next 2 Results")
-
 }
 
 func TestWithStyleForButtonElement(t *testing.T) {
-
 	// these values are irrelevant in this test
 	btnTxt := NewTextBlockObject("plain_text", "Next 2 Results", false, false)
 	btnElement := NewButtonBlockElement("test", "click_me_123", btnTxt)
@@ -40,21 +35,17 @@ func TestWithStyleForButtonElement(t *testing.T) {
 	assert.Equal(t, btnElement.Style, Style("primary"))
 	btnElement.WithStyle(StyleDanger)
 	assert.Equal(t, btnElement.Style, Style("danger"))
-
 }
 
 func TestWithURLForButtonElement(t *testing.T) {
-
 	btnTxt := NewTextBlockObject("plain_text", "Next 2 Results", false, false)
 	btnElement := NewButtonBlockElement("test", "click_me_123", btnTxt)
 
 	btnElement.WithURL("https://foo.bar")
 	assert.Equal(t, btnElement.URL, "https://foo.bar")
-
 }
 
 func TestNewOptionsSelectBlockElement(t *testing.T) {
-
 	testOptionText := NewTextBlockObject("plain_text", "Option One", false, false)
 	testOption := NewOptionBlockObject("test", testOptionText, nil)
 
@@ -62,11 +53,9 @@ func TestNewOptionsSelectBlockElement(t *testing.T) {
 	assert.Equal(t, option.Type, "static_select")
 	assert.Equal(t, len(option.Options), 1)
 	assert.Nil(t, option.OptionGroups)
-
 }
 
 func TestNewOptionsGroupSelectBlockElement(t *testing.T) {
-
 	testOptionText := NewTextBlockObject("plain_text", "Option One", false, false)
 	testOption := NewOptionBlockObject("test", testOptionText, nil)
 	testLabel := NewTextBlockObject("plain_text", "Test Label", false, false)
@@ -77,11 +66,9 @@ func TestNewOptionsGroupSelectBlockElement(t *testing.T) {
 	assert.Equal(t, optGroup.Type, "static_select")
 	assert.Equal(t, optGroup.ActionID, "test")
 	assert.Equal(t, len(optGroup.OptionGroups), 1)
-
 }
 
 func TestNewOptionsMultiSelectBlockElement(t *testing.T) {
-
 	testOptionText := NewTextBlockObject("plain_text", "Option One", false, false)
 	testDescriptionText := NewTextBlockObject("plain_text", "Description One", false, false)
 	testOption := NewOptionBlockObject("test", testOptionText, testDescriptionText)
@@ -90,7 +77,6 @@ func TestNewOptionsMultiSelectBlockElement(t *testing.T) {
 	assert.Equal(t, option.Type, "static_select")
 	assert.Equal(t, len(option.Options), 1)
 	assert.Nil(t, option.OptionGroups)
-
 }
 
 func TestNewOptionsGroupMultiSelectBlockElement(t *testing.T) {

--- a/block_file.go
+++ b/block_file.go
@@ -15,6 +15,11 @@ func (s FileBlock) BlockType() MessageBlockType {
 	return s.Type
 }
 
+// ID returns the ID of the block
+func (s FileBlock) ID() string {
+	return s.BlockID
+}
+
 // NewFileBlock returns a new instance of a file block
 func NewFileBlock(blockID string, externalID string, source string) *FileBlock {
 	return &FileBlock{

--- a/block_file_test.go
+++ b/block_file_test.go
@@ -8,8 +8,11 @@ import (
 
 func TestNewFileBlock(t *testing.T) {
 	fileBlock := NewFileBlock("test", "external_id", "source")
+
+	assert.Equal(t, fileBlock.BlockType(), MBTFile)
 	assert.Equal(t, string(fileBlock.Type), "file")
 	assert.Equal(t, fileBlock.BlockID, "test")
+	assert.Equal(t, fileBlock.ID(), "test")
 	assert.Equal(t, fileBlock.ExternalID, "external_id")
 	assert.Equal(t, fileBlock.Source, "source")
 }

--- a/block_header.go
+++ b/block_header.go
@@ -14,6 +14,11 @@ func (s HeaderBlock) BlockType() MessageBlockType {
 	return s.Type
 }
 
+// ID returns the ID of the block
+func (s HeaderBlock) ID() string {
+	return s.BlockID
+}
+
 // HeaderBlockOption allows configuration of options for a new header block
 type HeaderBlockOption func(*HeaderBlock)
 

--- a/block_header_test.go
+++ b/block_header_test.go
@@ -7,11 +7,12 @@ import (
 )
 
 func TestNewHeaderBlock(t *testing.T) {
-
 	textInfo := NewTextBlockObject("plain_text", "This is quite the header", false, false)
-
 	headerBlock := NewHeaderBlock(textInfo, HeaderBlockOptionBlockID("test_block"))
+
+	assert.Equal(t, headerBlock.BlockType(), MBTHeader)
 	assert.Equal(t, string(headerBlock.Type), "header")
+	assert.Equal(t, headerBlock.ID(), "test_block")
 	assert.Equal(t, headerBlock.BlockID, "test_block")
 	assert.Equal(t, headerBlock.Text.Type, "plain_text")
 	assert.Contains(t, headerBlock.Text.Text, "quite the header")

--- a/block_image.go
+++ b/block_image.go
@@ -12,6 +12,11 @@ type ImageBlock struct {
 	SlackFile *SlackFileObject `json:"slack_file,omitempty"`
 }
 
+// ID returns the ID of the block
+func (s ImageBlock) ID() string {
+	return s.BlockID
+}
+
 // SlackFileObject Defines an object containing Slack file information to be used in an
 // image block or image element.
 //

--- a/block_image_test.go
+++ b/block_image_test.go
@@ -7,14 +7,14 @@ import (
 )
 
 func TestNewImageBlock(t *testing.T) {
-
 	imageText := NewTextBlockObject("plain_text", "Location", false, false)
 	imageBlock := NewImageBlock("https://api.slack.com/img/blocks/bkb_template_images/tripAgentLocationMarker.png", "Marker", "test", imageText)
 
+	assert.Equal(t, imageBlock.BlockType(), MBTImage)
 	assert.Equal(t, string(imageBlock.Type), "image")
 	assert.Equal(t, imageBlock.Title.Type, "plain_text")
+	assert.Equal(t, imageBlock.ID(), "test")
 	assert.Equal(t, imageBlock.BlockID, "test")
 	assert.Contains(t, imageBlock.Title.Text, "Location")
 	assert.Contains(t, imageBlock.ImageURL, "tripAgentLocationMarker.png")
-
 }

--- a/block_input.go
+++ b/block_input.go
@@ -18,6 +18,11 @@ func (s InputBlock) BlockType() MessageBlockType {
 	return s.Type
 }
 
+// ID returns the ID of the block
+func (s InputBlock) ID() string {
+	return s.BlockID
+}
+
 // NewInputBlock returns a new instance of an input block
 func NewInputBlock(blockID string, label, hint *TextBlockObject, element BlockElement) *InputBlock {
 	return &InputBlock{

--- a/block_input_test.go
+++ b/block_input_test.go
@@ -11,7 +11,10 @@ func TestNewInputBlock(t *testing.T) {
 	element := NewDatePickerBlockElement("action_id")
 	hint := NewTextBlockObject("plain_text", "hint", false, false)
 	inputBlock := NewInputBlock("test", label, hint, element)
+
+	assert.Equal(t, inputBlock.BlockType(), MBTInput)
 	assert.Equal(t, string(inputBlock.Type), "input")
+	assert.Equal(t, inputBlock.ID(), "test")
 	assert.Equal(t, inputBlock.BlockID, "test")
 	assert.Equal(t, inputBlock.Label, label)
 	assert.Equal(t, inputBlock.Element, element)

--- a/block_object_test.go
+++ b/block_object_test.go
@@ -9,28 +9,23 @@ import (
 )
 
 func TestNewImageBlockObject(t *testing.T) {
-
 	imageObject := NewImageBlockElement("https://api.slack.com/img/blocks/bkb_template_images/beagle.png", "Beagle")
 
 	assert.Equal(t, string(imageObject.Type), "image")
 	assert.Equal(t, imageObject.AltText, "Beagle")
 	assert.Contains(t, imageObject.ImageURL, "beagle.png")
-
 }
 
 func TestNewTextBlockObject(t *testing.T) {
-
 	textObject := NewTextBlockObject("plain_text", "test", true, false)
 
 	assert.Equal(t, textObject.Type, "plain_text")
 	assert.Equal(t, textObject.Text, "test")
 	assert.True(t, textObject.Emoji, "Emoji property should be true")
 	assert.False(t, textObject.Verbatim, "Verbatim should be false")
-
 }
 
 func TestNewConfirmationBlockObject(t *testing.T) {
-
 	titleObj := NewTextBlockObject("plain_text", "testTitle", false, false)
 	textObj := NewTextBlockObject("plain_text", "testText", false, false)
 	confirmObj := NewTextBlockObject("plain_text", "testConfirm", false, false)
@@ -41,11 +36,9 @@ func TestNewConfirmationBlockObject(t *testing.T) {
 	assert.Equal(t, confirmation.Text.Text, "testText")
 	assert.Equal(t, confirmation.Confirm.Text, "testConfirm")
 	assert.Nil(t, confirmation.Deny, "Deny should be nil")
-
 }
 
 func TestWithStyleForConfirmation(t *testing.T) {
-
 	// these values are irrelevant in this test
 	titleObj := NewTextBlockObject("plain_text", "testTitle", false, false)
 	textObj := NewTextBlockObject("plain_text", "testText", false, false)
@@ -58,11 +51,9 @@ func TestWithStyleForConfirmation(t *testing.T) {
 	assert.Equal(t, confirmation.Style, Style("primary"))
 	confirmation.WithStyle(StyleDanger)
 	assert.Equal(t, confirmation.Style, Style("danger"))
-
 }
 
 func TestNewOptionBlockObject(t *testing.T) {
-
 	valTextObj := NewTextBlockObject("plain_text", "testText", false, false)
 	valDescriptionObj := NewTextBlockObject("plain_text", "testDescription", false, false)
 	optObj := NewOptionBlockObject("testOpt", valTextObj, valDescriptionObj)
@@ -70,11 +61,9 @@ func TestNewOptionBlockObject(t *testing.T) {
 	assert.Equal(t, optObj.Text.Text, "testText")
 	assert.Equal(t, optObj.Description.Text, "testDescription")
 	assert.Equal(t, optObj.Value, "testOpt")
-
 }
 
 func TestNewOptionGroupBlockElement(t *testing.T) {
-
 	labelObj := NewTextBlockObject("plain_text", "testLabel", false, false)
 	valTextObj := NewTextBlockObject("plain_text", "testText", false, false)
 	optObj := NewOptionBlockObject("testOpt", valTextObj, nil)
@@ -83,7 +72,6 @@ func TestNewOptionGroupBlockElement(t *testing.T) {
 
 	assert.Equal(t, optGroup.Label.Text, "testLabel")
 	assert.Len(t, optGroup.Options, 1, "Options should contain one element")
-
 }
 
 func TestValidateTextBlockObject(t *testing.T) {

--- a/block_rich_text.go
+++ b/block_rich_text.go
@@ -16,6 +16,11 @@ func (b RichTextBlock) BlockType() MessageBlockType {
 	return b.Type
 }
 
+// ID returns the ID of the block
+func (s RichTextBlock) ID() string {
+	return s.BlockID
+}
+
 func (e *RichTextBlock) UnmarshalJSON(b []byte) error {
 	var raw struct {
 		Type        MessageBlockType  `json:"type"`

--- a/block_rich_text_test.go
+++ b/block_rich_text_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -82,6 +83,15 @@ const (
 		]
 	}`
 )
+
+func TestNewRichTextBlock(t *testing.T) {
+	richTextBlock := NewRichTextBlock("test_block")
+
+	assert.Equal(t, richTextBlock.BlockType(), MBTRichText)
+	assert.Equal(t, string(richTextBlock.Type), "rich_text")
+	assert.Equal(t, string(richTextBlock.BlockID), "test_block")
+	assert.Equal(t, string(richTextBlock.ID()), "test_block")
+}
 
 func TestRichTextBlock_UnmarshalJSON(t *testing.T) {
 	cases := []struct {

--- a/block_rich_text_test.go
+++ b/block_rich_text_test.go
@@ -89,8 +89,8 @@ func TestNewRichTextBlock(t *testing.T) {
 
 	assert.Equal(t, richTextBlock.BlockType(), MBTRichText)
 	assert.Equal(t, string(richTextBlock.Type), "rich_text")
-	assert.Equal(t, string(richTextBlock.BlockID), "test_block")
-	assert.Equal(t, string(richTextBlock.ID()), "test_block")
+	assert.Equal(t, richTextBlock.BlockID, "test_block")
+	assert.Equal(t, richTextBlock.ID(), "test_block")
 }
 
 func TestRichTextBlock_UnmarshalJSON(t *testing.T) {

--- a/block_section.go
+++ b/block_section.go
@@ -17,6 +17,11 @@ func (s SectionBlock) BlockType() MessageBlockType {
 	return s.Type
 }
 
+// ID returns the ID of the block
+func (s SectionBlock) ID() string {
+	return s.BlockID
+}
+
 // SectionBlockOption allows configuration of options for a new section block
 type SectionBlockOption func(*SectionBlock)
 

--- a/block_section_test.go
+++ b/block_section_test.go
@@ -7,17 +7,17 @@ import (
 )
 
 func TestNewSectionBlock(t *testing.T) {
-
 	textInfo := NewTextBlockObject("mrkdwn", "*<fakeLink.toHotelPage.com|The Ritz-Carlton New Orleans>*\n★★★★★\n$340 per night\nRated: 9.1 - Excellent", false, false)
-
 	sectionBlock := NewSectionBlock(textInfo, nil, nil, SectionBlockOptionBlockID("test_block"))
+
+	assert.Equal(t, sectionBlock.BlockType(), MBTSection)
 	assert.Equal(t, string(sectionBlock.Type), "section")
 	assert.Equal(t, sectionBlock.BlockID, "test_block")
+	assert.Equal(t, sectionBlock.ID(), "test_block")
 	assert.Equal(t, len(sectionBlock.Fields), 0)
 	assert.Nil(t, sectionBlock.Accessory)
 	assert.Equal(t, sectionBlock.Text.Type, "mrkdwn")
 	assert.Contains(t, sectionBlock.Text.Text, "New Orleans")
-
 }
 
 func TestNewBlockSectionContainsAddedTextBlockAndAccessory(t *testing.T) {

--- a/block_unknown.go
+++ b/block_unknown.go
@@ -11,3 +11,8 @@ type UnknownBlock struct {
 func (b UnknownBlock) BlockType() MessageBlockType {
 	return b.Type
 }
+
+// ID returns the ID of the block
+func (s UnknownBlock) ID() string {
+	return s.BlockID
+}

--- a/block_video.go
+++ b/block_video.go
@@ -22,6 +22,11 @@ func (s VideoBlock) BlockType() MessageBlockType {
 	return s.Type
 }
 
+// ID returns the ID of the block
+func (s VideoBlock) ID() string {
+	return s.BlockID
+}
+
 // NewVideoBlock returns an instance of a new Video Block type
 func NewVideoBlock(videoURL, thumbnailURL, altText, blockID string, title *TextBlockObject) *VideoBlock {
 	return &VideoBlock{

--- a/block_video_test.go
+++ b/block_video_test.go
@@ -7,17 +7,17 @@ import (
 )
 
 func TestNewVideoBlock(t *testing.T) {
-
 	videoTitle := NewTextBlockObject("plain_text", "VideoTitle", false, false)
 	videoBlock := NewVideoBlock(
 		"https://example.com/example.mp4",
 		"https://example.com/thumbnail.png",
 		"alternative text", "blockID", videoTitle)
 
+	assert.Equal(t, videoBlock.Type, MBTVideo)
 	assert.Equal(t, string(videoBlock.Type), "video")
 	assert.Equal(t, videoBlock.Title.Type, "plain_text")
 	assert.Equal(t, videoBlock.BlockID, "blockID")
+	assert.Equal(t, videoBlock.ID(), "blockID")
 	assert.Contains(t, videoBlock.Title.Text, "VideoTitle")
 	assert.Contains(t, videoBlock.VideoURL, "example.mp4")
-
 }


### PR DESCRIPTION
At incident.io, we often iterate over the contents of Slack views, and often want to add the block ID to various bits of observability (logs, traces). Doing this is quite difficult, because the `Block` interface doesn't allow easy access to the ID — we have to cast each possible kind of block to pull this out.

This PR introduces an `ID()` function to the `Block` interface, making this kind of thing much easier.

I added some tests along the way, and also noticed that `CallBlock` doesn't allow the ID to be set. This doesn't affect us, but you might wish to fix that.
