### PR TITLE
fix: slacktest GetSeenOutboundMessages race condition

### DIFF
--- a/slacktest/funcs.go
+++ b/slacktest/funcs.go
@@ -15,11 +15,9 @@ func (sts *Server) queueForWebsocket(s, hubname string) {
 	channel, err := getHubForServer(hubname)
 	if err != nil {
 		log.Printf("Unable to get server's channels: %s", err.Error())
+	} else {
+		channel.sent <- s
 	}
-	sts.seenOutboundMessages.Lock()
-	sts.seenOutboundMessages.messages = append(sts.seenOutboundMessages.messages, s)
-	sts.seenOutboundMessages.Unlock()
-	channel.sent <- s
 }
 
 func handlePendingMessages(c *websocket.Conn, hubname string) {
@@ -43,9 +41,7 @@ func (sts *Server) postProcessMessage(m, hubname string) {
 		log.Printf("Unable to get server's channels: %s", err.Error())
 		return
 	}
-	sts.seenInboundMessages.Lock()
-	sts.seenInboundMessages.messages = append(sts.seenInboundMessages.messages, m)
-	sts.seenInboundMessages.Unlock()
+	sts.seenInboundMessages.observe(m)
 	// send to firehose
 	channel.seen <- m
 }

--- a/slacktest/server_test.go
+++ b/slacktest/server_test.go
@@ -27,7 +27,7 @@ func TestCustomNewServer(t *testing.T) {
 
 func TestServerSendMessageToChannel(t *testing.T) {
 	s := NewTestServer()
-	go s.Start()
+	s.Start()
 	s.SendMessageToChannel("C123456789", "some text")
 	time.Sleep(2 * time.Second)
 	assert.True(t, s.SawOutgoingMessage("some text"))
@@ -36,7 +36,7 @@ func TestServerSendMessageToChannel(t *testing.T) {
 
 func TestServerSendMessageToBot(t *testing.T) {
 	s := NewTestServer()
-	go s.Start()
+	s.Start()
 	s.SendMessageToBot("C123456789", "some text")
 	expectedMsg := fmt.Sprintf("<@%s> %s", s.BotID, "some text")
 	time.Sleep(2 * time.Second)
@@ -46,7 +46,7 @@ func TestServerSendMessageToBot(t *testing.T) {
 
 func TestBotDirectMessageBotHandler(t *testing.T) {
 	s := NewTestServer()
-	go s.Start()
+	s.Start()
 	s.SendDirectMessageToBot("some text")
 	expectedMsg := "some text"
 	time.Sleep(2 * time.Second)
@@ -55,14 +55,14 @@ func TestBotDirectMessageBotHandler(t *testing.T) {
 }
 
 func TestGetSeenOutboundMessages(t *testing.T) {
-	maxWait := 5 * time.Second
 	s := NewTestServer()
-	go s.Start()
+	s.Start()
 
 	s.SendMessageToChannel("foo", "should see this message")
-	time.Sleep(maxWait)
+
 	seenOutbound := s.GetSeenOutboundMessages()
-	assert.True(t, len(seenOutbound) > 0)
+	assert.Len(t, seenOutbound, 1)
+
 	hadMessage := false
 	for _, msg := range seenOutbound {
 		var m = slack.Message{}
@@ -79,7 +79,7 @@ func TestGetSeenOutboundMessages(t *testing.T) {
 func TestGetSeenInboundMessages(t *testing.T) {
 	maxWait := 5 * time.Second
 	s := NewTestServer()
-	go s.Start()
+	s.Start()
 
 	api := slack.New("ABCDEFG", slack.OptionAPIURL(s.GetAPIURL()))
 	rtm := api.NewRTM()
@@ -108,7 +108,7 @@ func TestGetSeenInboundMessages(t *testing.T) {
 func TestSendChannelInvite(t *testing.T) {
 	maxWait := 5 * time.Second
 	s := NewTestServer()
-	go s.Start()
+	s.Start()
 	rtm := s.GetTestRTMInstance()
 	go rtm.ManageConnection()
 	evChan := make(chan (slack.Channel), 1)
@@ -137,7 +137,7 @@ func TestSendChannelInvite(t *testing.T) {
 func TestSendGroupInvite(t *testing.T) {
 	maxWait := 5 * time.Second
 	s := NewTestServer()
-	go s.Start()
+	s.Start()
 	rtm := s.GetTestRTMInstance()
 	go rtm.ManageConnection()
 	evChan := make(chan (slack.Channel), 1)
@@ -165,12 +165,12 @@ func TestSendGroupInvite(t *testing.T) {
 
 func TestServerSawMessage(t *testing.T) {
 	s := NewTestServer()
-	go s.Start()
+	s.Start()
 	assert.False(t, s.SawMessage("foo"), "should not have seen any message")
 }
 
 func TestServerSawOutgoingMessage(t *testing.T) {
 	s := NewTestServer()
-	go s.Start()
+	s.Start()
 	assert.False(t, s.SawOutgoingMessage("foo"), "should not have seen any message")
 }

--- a/slacktest/types.go
+++ b/slacktest/types.go
@@ -40,13 +40,27 @@ type hub struct {
 }
 
 type messageChannels struct {
-	seen   chan (string)
-	sent   chan (string)
-	posted chan (slack.Message)
+	seen   chan string
+	sent   chan string
+	posted chan slack.Message
 }
 type messageCollection struct {
 	sync.RWMutex
 	messages []string
+}
+
+func (mc *messageCollection) observe(msg string) {
+	mc.Lock()
+	defer mc.Unlock()
+	mc.messages = append(mc.messages, msg)
+}
+
+func (mc *messageCollection) get() []string {
+	mc.RLock()
+	defer mc.RUnlock()
+
+	m := mc.messages
+	return m
 }
 
 type serverChannels struct {
@@ -68,7 +82,7 @@ type Server struct {
 	BotName              string
 	BotID                string
 	ServerAddr           string
-	SeenFeed             chan (string)
+	SeenFeed             chan string
 	channels             *serverChannels
 	groups               *serverGroups
 	seenInboundMessages  *messageCollection


### PR DESCRIPTION
This patch addresses issue #1361.

The storage backing GetSeenOutboundMessages is updated in a goroutine that may or may not be executed in time for assertions against this method. This patch updates the storage to be updated synchronously in the handler, while maintaining the asynchronous queue behavior for websockets handlers.

The test case has been updated to remove the sleep statement that likely worked around this very issue.

I opted to change the locking behavior to be more closely related with the messageCollection type. There is a smaller version of this fix that move the lock/update/unlock block into the callsite of each queue update, if that is preferable.