### PR TITLE
Additional field to the File structure

### DIFF
--- a/files.go
+++ b/files.go
@@ -89,6 +89,7 @@ type File struct {
 	NumStars        int                 `json:"num_stars"`
 	IsStarred       bool                `json:"is_starred"`
 	Shares          Share               `json:"shares"`
+	Subject         string              `json:"subject"`
 	To              []EmailFileUserInfo `json:"to"`
 	From            []EmailFileUserInfo `json:"from"`
 }

--- a/files.go
+++ b/files.go
@@ -79,19 +79,21 @@ type File struct {
 	Lines            int    `json:"lines"`
 	LinesMore        int    `json:"lines_more"`
 
-	IsPublic        bool                `json:"is_public"`
-	PublicURLShared bool                `json:"public_url_shared"`
-	Channels        []string            `json:"channels"`
-	Groups          []string            `json:"groups"`
-	IMs             []string            `json:"ims"`
-	InitialComment  Comment             `json:"initial_comment"`
-	CommentsCount   int                 `json:"comments_count"`
-	NumStars        int                 `json:"num_stars"`
-	IsStarred       bool                `json:"is_starred"`
-	Shares          Share               `json:"shares"`
-	Subject         string              `json:"subject"`
-	To              []EmailFileUserInfo `json:"to"`
-	From            []EmailFileUserInfo `json:"from"`
+	IsPublic        bool     `json:"is_public"`
+	PublicURLShared bool     `json:"public_url_shared"`
+	Channels        []string `json:"channels"`
+	Groups          []string `json:"groups"`
+	IMs             []string `json:"ims"`
+	InitialComment  Comment  `json:"initial_comment"`
+	CommentsCount   int      `json:"comments_count"`
+	NumStars        int      `json:"num_stars"`
+	IsStarred       bool     `json:"is_starred"`
+	Shares          Share    `json:"shares"`
+
+	Subject string              `json:"subject"`
+	To      []EmailFileUserInfo `json:"to"`
+	From    []EmailFileUserInfo `json:"from"`
+	Cc      []EmailFileUserInfo `json:"cc"`
 }
 
 type EmailFileUserInfo struct {

--- a/files.go
+++ b/files.go
@@ -79,16 +79,24 @@ type File struct {
 	Lines            int    `json:"lines"`
 	LinesMore        int    `json:"lines_more"`
 
-	IsPublic        bool     `json:"is_public"`
-	PublicURLShared bool     `json:"public_url_shared"`
-	Channels        []string `json:"channels"`
-	Groups          []string `json:"groups"`
-	IMs             []string `json:"ims"`
-	InitialComment  Comment  `json:"initial_comment"`
-	CommentsCount   int      `json:"comments_count"`
-	NumStars        int      `json:"num_stars"`
-	IsStarred       bool     `json:"is_starred"`
-	Shares          Share    `json:"shares"`
+	IsPublic        bool                `json:"is_public"`
+	PublicURLShared bool                `json:"public_url_shared"`
+	Channels        []string            `json:"channels"`
+	Groups          []string            `json:"groups"`
+	IMs             []string            `json:"ims"`
+	InitialComment  Comment             `json:"initial_comment"`
+	CommentsCount   int                 `json:"comments_count"`
+	NumStars        int                 `json:"num_stars"`
+	IsStarred       bool                `json:"is_starred"`
+	Shares          Share               `json:"shares"`
+	To              []EmailFileUserInfo `json:"to"`
+	From            []EmailFileUserInfo `json:"from"`
+}
+
+type EmailFileUserInfo struct {
+	Address  string `json:"address"`
+	Name     string `json:"name"`
+	Original string `json:"original"`
 }
 
 type Share struct {


### PR DESCRIPTION
Slack has a feature called 'Send emails to Slack' - https://slack.com/intl/en-gb/help/articles/206819278-Send-emails-to-Slack

When emails are sent to this channel, they become Slack files with additional fields containing sender and receiver information. 

I added two new fields to properly support the unmarshaling of file metadata.