### PR TITLE
feat: add markdown block

### DIFF
--- a/block.go
+++ b/block.go
@@ -1,9 +1,5 @@
 package slack
 
-// @NOTE: Blocks are in beta and subject to change.
-
-// More Information: https://api.slack.com/block-kit
-
 // MessageBlockType defines a named string type to define each block type
 // as a constant for use within the package.
 type MessageBlockType string
@@ -20,6 +16,7 @@ const (
 	MBTRichText MessageBlockType = "rich_text"
 	MBTCall     MessageBlockType = "call"
 	MBTVideo    MessageBlockType = "video"
+	MBTMarkdown MessageBlockType = "markdown"
 )
 
 // Block defines an interface all block types should implement

--- a/block_markdown.go
+++ b/block_markdown.go
@@ -1,0 +1,34 @@
+package slack
+
+// MarkdownBlock defines a block that lets you use markdown to format your text.
+//
+// This block can be used with AI apps when you expect a markdown response from an LLM
+// that can get lost in translation rendering in Slack. Providing it in a markdown block
+// leaves the translating to Slack to ensure your message appears as intended. Note that
+// passing a single block may result in multiple blocks after translation.
+//
+// More Information: https://api.slack.com/reference/block-kit/blocks#markdown
+type MarkdownBlock struct {
+	Type    MessageBlockType `json:"type"`
+	BlockID string           `json:"block_id,omitempty"`
+	Text    string           `json:"text"`
+}
+
+// BlockType returns the type of the block
+func (s MarkdownBlock) BlockType() MessageBlockType {
+	return s.Type
+}
+
+// ID returns the ID of the block
+func (s MarkdownBlock) ID() string {
+	return s.BlockID
+}
+
+// NewMarkdownBlock returns an instance of a new Markdown Block type
+func NewMarkdownBlock(blockID, text string) *MarkdownBlock {
+	return &MarkdownBlock{
+		Type:    MBTMarkdown,
+		BlockID: blockID,
+		Text:    text,
+	}
+}

--- a/block_markdown_test.go
+++ b/block_markdown_test.go
@@ -1,0 +1,17 @@
+package slack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewMarkdownBlock(t *testing.T) {
+	markdownBlock := NewMarkdownBlock("test", "*asfd*")
+
+	assert.Equal(t, markdownBlock.BlockType(), MBTMarkdown)
+	assert.Equal(t, string(markdownBlock.Type), "markdown")
+	assert.Equal(t, markdownBlock.ID(), "test")
+	assert.Equal(t, markdownBlock.BlockID, "test")
+	assert.Equal(t, markdownBlock.Text, "*asfd*")
+}


### PR DESCRIPTION
There's a new block for markdown per changelog entry at https://api.slack.com/changelog#entry-february_2025_0.

More information can be found in
https://api.slack.com/reference/block-kit/blocks#markdown.