### PR TITLE
feat: add filter in `MultiSelectBlockElement`

### DIFF
--- a/block_element.go
+++ b/block_element.go
@@ -318,6 +318,7 @@ type MultiSelectBlockElement struct {
 	InitialUsers         []string                  `json:"initial_users,omitempty"`
 	InitialConversations []string                  `json:"initial_conversations,omitempty"`
 	InitialChannels      []string                  `json:"initial_channels,omitempty"`
+	Filter               *SelectBlockElementFilter `json:"filter,omitempty"`
 	MinQueryLength       *int                      `json:"min_query_length,omitempty"`
 	MaxSelectedItems     *int                      `json:"max_selected_items,omitempty"`
 	Confirm              *ConfirmationBlockObject  `json:"confirm,omitempty"`


### PR DESCRIPTION
Hi! This was an existing PR (#1191) that had breaking changes and was unmaintained.

This one does not break anything and only add the missing field.

This is specified at https://api.slack.com/reference/block-kit/block-elements#conversations_select, which is supported by multi-selects.