### PR TITLE
Configure Dependabot to maintain GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
💁 When browsing this repository earlier, I saw that external actions are referenced using commit SHAs. This is useful as a way of ensuring that the version of a specific workflow doesn't drift unexpectedly but it also means that they need to be maintained (whether actively or not).

This change configures @dependabot to do the hard work of looking after those external action references and updating them as needed.