### PR TITLE
Expose private File Upload V2 methods to support multiple file uploads in a single message

### DIFF
--- a/files.go
+++ b/files.go
@@ -510,10 +510,10 @@ func (api *Client) ShareFilePublicURLContext(ctx context.Context, fileID string)
 // Slack API docs: https://api.slack.com/methods/files.getUploadURLExternal
 func (api *Client) GetUploadURLExternalContext(ctx context.Context, params GetUploadURLExternalParameters) (*GetUploadURLExternalResponse, error) {
 	if params.FileName == "" {
-		return nil, fmt.Errorf("GetUploadURLExternalContext: fileName cannot be empty")
+		return nil, fmt.Errorf("files.getUploadURLExternal: fileName cannot be empty")
 	}
 	if params.FileSize == 0 {
-		return nil, fmt.Errorf("GetUploadURLExternalContext: fileSize cannot be 0")
+		return nil, fmt.Errorf("files.getUploadURLExternal: fileSize cannot be 0")
 	}
 
 	values := url.Values{

--- a/files.go
+++ b/files.go
@@ -510,10 +510,10 @@ func (api *Client) ShareFilePublicURLContext(ctx context.Context, fileID string)
 // Slack API docs: https://api.slack.com/methods/files.getUploadURLExternal
 func (api *Client) GetUploadURLExternalContext(ctx context.Context, params GetUploadURLExternalParameters) (*GetUploadURLExternalResponse, error) {
 	if params.FileName == "" {
-		return nil, fmt.Errorf("files.getUploadURLExternal: fileName cannot be empty")
+		return nil, fmt.Errorf("FileName cannot be empty")
 	}
 	if params.FileSize == 0 {
-		return nil, fmt.Errorf("files.getUploadURLExternal: fileSize cannot be 0")
+		return nil, fmt.Errorf("FileSize cannot be 0")
 	}
 
 	values := url.Values{

--- a/files_test.go
+++ b/files_test.go
@@ -357,7 +357,7 @@ func TestGetUploadURLExternalContext(t *testing.T) {
 				FileName: "",
 				FileSize: 10,
 			},
-			wantErr: fmt.Errorf("files.getUploadURLExternal: fileName cannot be empty"),
+			wantErr: fmt.Errorf("FileName cannot be empty"),
 		},
 		{
 			title: "Testing with invalid parameters: file size 0",
@@ -365,7 +365,7 @@ func TestGetUploadURLExternalContext(t *testing.T) {
 				FileName: "test.txt",
 				FileSize: 0,
 			},
-			wantErr: fmt.Errorf("files.getUploadURLExternal: fileSize cannot be 0"),
+			wantErr: fmt.Errorf("FileSize cannot be 0"),
 		},
 	}
 

--- a/files_test.go
+++ b/files_test.go
@@ -357,7 +357,7 @@ func TestGetUploadURLExternalContext(t *testing.T) {
 				FileName: "",
 				FileSize: 10,
 			},
-			wantErr: fmt.Errorf("GetUploadURLExternalContext: fileName cannot be empty"),
+			wantErr: fmt.Errorf("files.getUploadURLExternal: fileName cannot be empty"),
 		},
 		{
 			title: "Testing with invalid parameters: file size 0",
@@ -365,7 +365,7 @@ func TestGetUploadURLExternalContext(t *testing.T) {
 				FileName: "test.txt",
 				FileSize: 0,
 			},
-			wantErr: fmt.Errorf("GetUploadURLExternalContext: fileSize cannot be 0"),
+			wantErr: fmt.Errorf("files.getUploadURLExternal: fileSize cannot be 0"),
 		},
 	}
 


### PR DESCRIPTION
Hi, thank you for maintaining slack-go!

Currently, `UploadFileV2Context` works by sequentially calling three private methods in the following flow:

1. getUploadURLExternal (retrieves the upload URL)
2. uploadToURL (uploads the file to that URL)
3. completeUploadExternal (finalizes the upload)

Because these methods are private, developers can only upload one file per message via `UploadFileV2Context`. However, the Slack API itself supports uploading multiple files in a single message by running these steps for each file and then calling completeUploadURLExternal for all file IDs together.

To unlock this functionality while still using slack-go, I’ve made the following changes in this PR:

- Made `getUploadURLExternal` and `completeUploadExternal` public
  - This allows developers to orchestrate multiple file uploads (Steps 1–3 repeated for each file) and finalize them all in a single message.
- `uploadToURL` remains private for now. This method is simply a regular POST request handler, not part of Slack’s official API. Since making getUploadURLExternal and completeUploadExternal public already addresses the main use case of uploading multiple files, this might be sufficient.
  - However, if you feel uploadToURL should also be made public for consistency, please let me know and I can include that change in this PR.
  

Thank you for considering this proposal. Being able to handle multi-file uploads in a single Slack message through slack-go would be extremely helpful. If you have any suggestions or an alternative approach, I’d love to hear them!

# Related Issues

- https://github.com/slack-go/slack/issues/1346
- https://github.com/slack-go/slack/issues/1288

##### Pull Request Guidelines

These are recommendations for pull requests.
They are strictly guidelines to help manage expectations.

##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### Examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.
