### PR TITLE
Additional field to the File structure

### DIFF
--- a/files.go
+++ b/files.go
@@ -90,10 +90,11 @@ type File struct {
 	IsStarred       bool     `json:"is_starred"`
 	Shares          Share    `json:"shares"`
 
-	Subject string              `json:"subject"`
-	To      []EmailFileUserInfo `json:"to"`
-	From    []EmailFileUserInfo `json:"from"`
-	Cc      []EmailFileUserInfo `json:"cc"`
+	Subject string                 `json:"subject"`
+	To      []EmailFileUserInfo    `json:"to"`
+	From    []EmailFileUserInfo    `json:"from"`
+	Cc      []EmailFileUserInfo    `json:"cc"`
+	Headers map[string]interface{} `json:"headers"`
 }
 
 type EmailFileUserInfo struct {

--- a/files.go
+++ b/files.go
@@ -90,17 +90,24 @@ type File struct {
 	IsStarred       bool     `json:"is_starred"`
 	Shares          Share    `json:"shares"`
 
-	Subject string                 `json:"subject"`
-	To      []EmailFileUserInfo    `json:"to"`
-	From    []EmailFileUserInfo    `json:"from"`
-	Cc      []EmailFileUserInfo    `json:"cc"`
-	Headers map[string]interface{} `json:"headers"`
+	Subject string              `json:"subject"`
+	To      []EmailFileUserInfo `json:"to"`
+	From    []EmailFileUserInfo `json:"from"`
+	Cc      []EmailFileUserInfo `json:"cc"`
+	Headers EmailHeaders        `json:"headers"`
 }
 
 type EmailFileUserInfo struct {
 	Address  string `json:"address"`
 	Name     string `json:"name"`
 	Original string `json:"original"`
+}
+
+type EmailHeaders struct {
+	Date      string `json:"date"`
+	InReplyTo string `json:"in_reply_to"`
+	ReplyTo   string `json:"reply_to"`
+	MessageID string `json:"message_id"`
 }
 
 type Share struct {


### PR DESCRIPTION
add Headers field to support headers of an email file attachment.

Example: 
```
"headers": {
    "date": "Thu, 23 Jan 2025 18:09:25 +0100",
    "in_reply_to": null,
    "reply_to": null,
    "message_id": "<email_provider_message_id>"
},
```

related to https://github.com/slack-go/slack/pull/1370
