### PR TITLE
feat: support unmarshalling markdown blocks

### DIFF
--- a/block_conv.go
+++ b/block_conv.go
@@ -63,6 +63,8 @@ func (b *Blocks) UnmarshalJSON(data []byte) error {
 			block = &ImageBlock{}
 		case "input":
 			block = &InputBlock{}
+		case "markdown":
+			block = &MarkdownBlock{}
 		case "rich_text":
 			block = &RichTextBlock{}
 		case "rich_text_input":


### PR DESCRIPTION
Hey 👋 
This PR introduces support for unmarshalling the new [`markdown` Block type](https://api.slack.com/reference/block-kit/blocks#markdown). 
It complements the previously merged PR (https://github.com/slack-go/slack/pull/1372), which added support for the `markdown` Block type itself. 
