### PR TITLE
chore: remove unused GO111MODULE from the tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,6 @@ jobs:
           go-version: ${{ matrix.go }}
       - name: run test
         run: go test -v -race ./...
-        env:
-          GO111MODULE: on
   lint:
     runs-on: ubuntu-22.04
     name: lint


### PR DESCRIPTION
Since Go 1.16 this variable defaults to "on" and we don't support anything below 1.18 in our test suite, so this is effectively a no-op.