### PR TITLE
Return a StatusCodeError when a workspace's message limit is exceeded

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -306,7 +306,7 @@ func timerReset(t *time.Timer, d time.Duration) {
 }
 
 func checkStatusCode(resp *http.Response, d Debug) error {
-	if resp.StatusCode == http.StatusTooManyRequests {
+	if resp.StatusCode == http.StatusTooManyRequests && resp.Header.Get("Retry-After") != "" {
 		retry, err := strconv.ParseInt(resp.Header.Get("Retry-After"), 10, 64)
 		if err != nil {
 			return err


### PR DESCRIPTION
Currently, this library throws a `strconv.NumError` when attempting to post messages to a Slack workspace that has exceeded its message limit. It does so because Slack returns a 429 without a `Retry-After` header for those requests.

This PR improves the situation by instead returning a `StatusCodeError`. I couldn't see any obvious way to provide a more detailed error without creating a new error class. To only additional information returned from Slack for these errors is a body that reads `message_limit_exceeded`.