### PR TITLE
Add rich_text_value into BlockAction

### DIFF
--- a/block.go
+++ b/block.go
@@ -58,6 +58,7 @@ type BlockAction struct {
 	InitialConversation   string              `json:"initial_conversation"`
 	InitialDate           string              `json:"initial_date"`
 	InitialTime           string              `json:"initial_time"`
+	RichTextValue         RichTextBlock       `json:"rich_text_value"`
 }
 
 // actionType returns the type of the action


### PR DESCRIPTION
Hello, when submitting modal, we would like to parse contents of `RichTextInput` block from `viewState`. Not really sure whether there is a way now to do it, but it appears to me that it is missing.