### PR TITLE
chore: bump golangci to 1.63.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,4 +40,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
         with:
-          version: v1.52.2
+          version: v1.63.4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,11 +4,11 @@ run:
 linters:
   disable-all: true
   enable:
+    - gocritic
     - goimports
     - govet
-    - interfacer
     - misspell
-    - structcheck
+    - unused
     - unconvert
 issues:
   new: true


### PR DESCRIPTION
As part of this change also removed the following linters which are deprecated:

- `interfacer`
- `structcheck`

Added the following linters:

- `gocritic` (I might regret this and roll it back, we'll see)
view and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### Examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.