### PR TITLE
ci: add Go version 1.24 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
           - '1.21'
           - '1.22'
           - '1.23'
+          - '1.24'
     name: test go-${{ matrix.go }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request adds test coverage for Go `v1.24`.