### PR TITLE
Fix message event struct

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -17,6 +17,10 @@ type Message struct {
 	Msg
 	SubMessage      *Msg `json:"message,omitempty"`
 	PreviousMessage *Msg `json:"previous_message,omitempty"`
+	// Root is the message that was broadcast to the channel when the SubType is
+	// thread_broadcast. If this is not a thread_broadcast message event, this
+	// value is nil.
+	Root *Msg `json:"root,omitempty"`
 }
 
 // Msg SubTypes (https://api.slack.com/events/message)

--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -284,9 +284,8 @@ type MessageEvent struct {
 	SourceTeam string `json:"source_team,omitempty"`
 
 	// Edited Message
-	Message         *MessageEvent `json:"message,omitempty"`
-	PreviousMessage *MessageEvent `json:"previous_message,omitempty"`
-	Edited          *Edited       `json:"edited,omitempty"`
+	Message         *slack.Message `json:"message,omitempty"`
+	PreviousMessage *slack.Message `json:"previous_message,omitempty"`
 
 	// Deleted Message
 	DeletedTimeStamp string `json:"deleted_ts,omitempty"`
@@ -298,19 +297,6 @@ type MessageEvent struct {
 	BotID    string `json:"bot_id,omitempty"`
 	Username string `json:"username,omitempty"`
 	Icons    *Icon  `json:"icons,omitempty"`
-
-	Upload bool   `json:"upload"`
-	Files  []File `json:"files"`
-
-	Blocks      slack.Blocks       `json:"blocks,omitempty"`
-	Attachments []slack.Attachment `json:"attachments,omitempty"`
-
-	Metadata slack.SlackMetadata `json:"metadata,omitempty"`
-
-	// Root is the message that was broadcast to the channel when the SubType is
-	// thread_broadcast. If this is not a thread_broadcast message event, this
-	// value is nil.
-	Root *MessageEvent `json:"root"`
 }
 
 // MemberJoinedChannelEvent A member joined a public or private channel

--- a/slackevents/inner_events_test.go
+++ b/slackevents/inner_events_test.go
@@ -423,16 +423,12 @@ func TestThreadBroadcastEvent(t *testing.T) {
 		t.Error(err)
 	}
 
-	if me.Root != nil {
-		t.Error("me.Root should be nil")
-	}
-
 	if me.Message.Root == nil {
 		t.Fatal("me.Message.Root is nil")
 	}
 
-	if me.Message.Root.TimeStamp != "1355517523.000005" {
-		t.Errorf("me.Message.Root.TimeStamp = %q, want %q", me.Root.TimeStamp, "1355517523.000005")
+	if me.Message.Root.Timestamp != "1355517523.000005" {
+		t.Errorf("me.Message.Root.Timestamp = %q, want %q", me.Message.Root.Timestamp, "1355517523.000005")
 	}
 }
 


### PR DESCRIPTION
This has been the source of many bugs.

Slack's docs say that a 'message event' contains a 'message' which is the same type as other representations of a message in slack. However, the library has previously represented this as a nested MessageEvent which is recursively nested. That creates lots of bugs, as you can never know if you're looking at the outer MessageEvent (which contains the event information) or the inner MessageEvent (which contains the message itself).

Instead, we can use our canonical Message instead.

Note that we also have to add a `root` onto Message, as this is populated for thread_broadcast events (for legacy reasons).