### PR TITLE
feat: add '&debug_reconnects=true' to websocket url

### DIFF
--- a/examples/socketmode/socketmode.go
+++ b/examples/socketmode/socketmode.go
@@ -141,6 +141,8 @@ func main() {
 				}
 
 				client.Ack(*evt.Request, payload)
+			case socketmode.EventTypeHello:
+				client.Debugf("Hello received!")
 			default:
 				fmt.Fprintf(os.Stderr, "Unexpected event type received: %s\n", evt.Type)
 			}

--- a/examples/socketmode_handler/socketmode_handler.go
+++ b/examples/socketmode_handler/socketmode_handler.go
@@ -49,6 +49,7 @@ func main() {
 	socketmodeHandler.Handle(socketmode.EventTypeConnecting, middlewareConnecting)
 	socketmodeHandler.Handle(socketmode.EventTypeConnectionError, middlewareConnectionError)
 	socketmodeHandler.Handle(socketmode.EventTypeConnected, middlewareConnected)
+	socketmodeHandler.Handle(socketmode.EventTypeHello, middlewareHello)
 
 	//\\ EventTypeEventsAPI //\\
 	// Handle all EventsAPI
@@ -83,6 +84,10 @@ func middlewareConnectionError(evt *socketmode.Event, client *socketmode.Client)
 
 func middlewareConnected(evt *socketmode.Event, client *socketmode.Client) {
 	fmt.Println("Connected to Slack with Socket Mode.")
+}
+
+func middlewareHello(evt *socketmode.Event, client *socketmode.Client) {
+	fmt.Println("Received a hello message. Howdy to you too.")
 }
 
 func middlewareEventsAPI(evt *socketmode.Event, client *socketmode.Client) {

--- a/socket_mode.go
+++ b/socket_mode.go
@@ -30,5 +30,11 @@ func (api *Client) StartSocketModeContext(ctx context.Context) (info *SocketMode
 		api.Debugln("Using URL:", response.SocketModeConnection.URL)
 	}
 
+	// According to the API documentation at https://api.slack.com/apis/socket-mode, we
+	// can add a query parameter `debug_reconnects=true` to the URL to make the connection
+	// time significantly shorter (360 seconds).
+	if api.debug {
+		response.SocketModeConnection.URL += "&debug_reconnects=true"
+	}
 	return &response.SocketModeConnection, response.SocketModeConnection.URL, response.Err()
 }


### PR DESCRIPTION
According to the documentation at https://api.slack.com/apis/socket-mode you can append &debug_reconnects=true to your WebSocket URL when you connect to it in order to make the connection time significantly shorter (360 seconds). That way, you can test and debug reconnects without waiting around.

We're adding this whenever debug mode is enabled in the socketmode client.

Closes #1379.