### PR TITLE
feat: add include_icon to auth.teams.list

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"context"
 	"net/url"
+	"strconv"
 )
 
 // AuthRevokeResponse contains our Auth response from the auth.revoke endpoint
@@ -47,8 +48,9 @@ type listTeamsResponse struct {
 }
 
 type ListTeamsParameters struct {
-	Limit  int
-	Cursor string
+	Limit       int
+	Cursor      string
+	IncludeIcon *bool
 }
 
 // ListTeams returns all workspaces a token can access.
@@ -65,6 +67,9 @@ func (api *Client) ListTeamsContext(ctx context.Context, params ListTeamsParamet
 	}
 	if params.Cursor != "" {
 		values.Add("cursor", params.Cursor)
+	}
+	if params.IncludeIcon != nil {
+		values.Add("include_icon", strconv.FormatBool(*params.IncludeIcon))
 	}
 
 	response := &listTeamsResponse{}


### PR DESCRIPTION
According to https://api.slack.com/methods/auth.teams.list, there's an optional argument named `include_icon`.