### PR TITLE
feat: add a few missing fields to conversation

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -38,9 +38,8 @@ type Conversation struct {
 	InternalTeamIDs    []string `json:"internal_team_ids,omitempty"`
 	ContextTeamID      string   `json:"context_team_id,omitempty"`
 	ConversationHostID string   `json:"conversation_host_id,omitempty"`
-
-	// TODO support pending_shared
-	// TODO support previous_names
+	PreviousNames      []string `json:"previous_names,omitempty"`
+	PendingShared      []string `json:"pending_shared,omitempty"`
 }
 
 // GroupConversation is the foundation for Group and Channel
@@ -70,7 +69,21 @@ type Purpose struct {
 
 // Properties contains the Canvas associated to the channel.
 type Properties struct {
-	Canvas Canvas `json:"canvas"`
+	Canvas              Canvas       `json:"canvas"`
+	PostingRestrictedTo RestrictedTo `json:"posting_restricted_to"`
+	Tabs                []Tab        `json:"tabs"`
+	ThreadsRestrictedTo RestrictedTo `json:"threads_restricted_to"`
+}
+
+type RestrictedTo struct {
+	Type []string `json:"type"`
+	User []string `json:"user"`
+}
+
+type Tab struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+	Type  string `json:"type"`
 }
 
 type Canvas struct {

--- a/examples/conversations/conversations.go
+++ b/examples/conversations/conversations.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/slack-go/slack"
+)
+
+func main() {
+	botToken := os.Getenv("SLACK_BOT_TOKEN")
+	if botToken == "" {
+		fmt.Fprintf(os.Stderr, "SLACK_BOT_TOKEN must be set.\n")
+		os.Exit(1)
+	}
+
+	api := slack.New(botToken)
+	params := slack.GetConversationsParameters{
+		ExcludeArchived: true,
+		Limit:           100,
+	}
+	channels, _, err := api.GetConversations(&params)
+	if err != nil {
+		fmt.Printf("%s\n", err)
+		return
+	}
+	for _, channel := range channels {
+		fmt.Printf("Channel: %v\n", channel)
+	}
+}


### PR DESCRIPTION
Added:

- `previous_names`
- `pending_shared`

Also added to `Properties`:

- `posting_restricted_to`
- `tabs`
- `threads_restricted_to`

As part of that, also added new types: `RestrictedTo` and `Tab`.