### PR TITLE
Add some missing admin.conversations endpoints

### DIFF
--- a/admin_conversations.go
+++ b/admin_conversations.go
@@ -1,0 +1,76 @@
+package slack
+
+import (
+	"context"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// Set the workspaces in an Enterprise Grid organisation that connect to a public or
+// private channel.
+// See: https://api.slack.com/methods/admin.conversations.setTeams
+func (api *Client) AdminConversationsSetTeams(ctx context.Context, channelID string, orgChannel *bool, targetTeamIDs *[]string, teamID *string) error {
+	values := url.Values{
+		"token":      {api.token},
+		"channel_id": {channelID},
+	}
+
+	if orgChannel != nil {
+		values.Add("org_channel", strconv.FormatBool(*orgChannel))
+	}
+
+	if targetTeamIDs != nil {
+		values.Add("target_team_ids", strings.Join(*targetTeamIDs, ",")) // ["T123", "T456"] - > "T123,T456"
+	}
+
+	if teamID != nil {
+		values.Add("team_id", *teamID)
+	}
+
+	response := &SlackResponse{}
+	err := api.postMethod(ctx, "admin.conversations.setTeams", values, response)
+	if err != nil {
+		return err
+	}
+
+	return response.Err()
+}
+
+// ConversationsConvertToPrivate converts a public channel to a private channel. To do
+// this, you must have the admin.conversations:write scope. There are other requirements:
+// you should read the Slack documentation for more details.
+// See: https://api.slack.com/methods/admin.conversations.convertToPrivate
+func (api *Client) AdminConversationsConvertToPrivate(ctx context.Context, channelID string) error {
+	values := url.Values{
+		"token":      []string{api.token},
+		"channel_id": []string{channelID},
+	}
+
+	response := &SlackResponse{}
+	err := api.postMethod(ctx, "admin.conversations.convertToPrivate", values, response)
+	if err != nil {
+		return err
+	}
+
+	return response.Err()
+}
+
+// ConversationsConvertToPublic converts a private channel to a public channel. To do
+// this, you must have the admin.conversations:write scope. There are other requirements:
+// you should read the Slack documentation for more details.
+// See: https://api.slack.com/methods/admin.conversations.convertToPublic
+func (api *Client) AdminConversationsConvertToPublic(ctx context.Context, channelID string) error {
+	values := url.Values{
+		"token":      []string{api.token},
+		"channel_id": []string{channelID},
+	}
+
+	response := &SlackResponse{}
+	err := api.postMethod(ctx, "admin.conversations.convertToPublic", values, response)
+	if err != nil {
+		return err
+	}
+
+	return response.Err()
+}

--- a/admin_conversations.go
+++ b/admin_conversations.go
@@ -7,25 +7,34 @@ import (
 	"strings"
 )
 
+// AdminConversationsSetTeamsParams contains arguments for AdminConversationsSetTeams
+// method calls.
+type AdminConversationsSetTeamsParams struct {
+	ChannelID     string
+	OrgChannel    *bool
+	TargetTeamIDs []string
+	TeamID        *string
+}
+
 // Set the workspaces in an Enterprise Grid organisation that connect to a public or
 // private channel.
 // See: https://api.slack.com/methods/admin.conversations.setTeams
-func (api *Client) AdminConversationsSetTeams(ctx context.Context, channelID string, orgChannel *bool, targetTeamIDs *[]string, teamID *string) error {
+func (api *Client) AdminConversationsSetTeams(ctx context.Context, params AdminConversationsSetTeamsParams) error {
 	values := url.Values{
 		"token":      {api.token},
-		"channel_id": {channelID},
+		"channel_id": {params.ChannelID},
 	}
 
-	if orgChannel != nil {
-		values.Add("org_channel", strconv.FormatBool(*orgChannel))
+	if params.OrgChannel != nil {
+		values.Add("org_channel", strconv.FormatBool(*params.OrgChannel))
 	}
 
-	if targetTeamIDs != nil {
-		values.Add("target_team_ids", strings.Join(*targetTeamIDs, ",")) // ["T123", "T456"] - > "T123,T456"
+	if len(params.TargetTeamIDs) > 0 {
+		values.Add("target_team_ids", strings.Join(params.TargetTeamIDs, ",")) // ["T123", "T456"] - > "T123,T456"
 	}
 
-	if teamID != nil {
-		values.Add("team_id", *teamID)
+	if params.TeamID != nil {
+		values.Add("team_id", *params.TeamID)
 	}
 
 	response := &SlackResponse{}

--- a/admin_conversations_test.go
+++ b/admin_conversations_test.go
@@ -1,0 +1,82 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestAdminConversationsSetTeams(t *testing.T) {
+	http.DefaultServeMux = new(http.ServeMux)
+	http.HandleFunc("/admin.conversations.setTeams", mockAdminChannelIDHandler(t))
+	once.Do(startServer)
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
+
+	orgChannel := true
+	teamID := "T789"
+
+	err := api.AdminConversationsSetTeams(context.Background(), AdminConversationsSetTeamsParams{
+		ChannelID:     "C1234567890",
+		OrgChannel:    &orgChannel,
+		TargetTeamIDs: []string{"T123", "T456"},
+		TeamID:        &teamID,
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+		return
+	}
+}
+
+func TestAdminConversationsConvertToPrivate(t *testing.T) {
+	http.DefaultServeMux = new(http.ServeMux)
+	http.HandleFunc("/admin.conversations.convertToPrivate", mockAdminChannelIDHandler(t))
+	once.Do(startServer)
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
+
+	err := api.AdminConversationsConvertToPrivate(context.Background(), "C1234567890")
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+		return
+	}
+}
+
+func TestAdminConversationsConvertToPublic(t *testing.T) {
+	http.DefaultServeMux = new(http.ServeMux)
+	http.HandleFunc("/admin.conversations.convertToPublic", mockAdminChannelIDHandler(t))
+	once.Do(startServer)
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
+
+	err := api.AdminConversationsConvertToPublic(context.Background(), "C1234567890")
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+		return
+	}
+}
+
+// mockAdminChannelIDHandler returns a handler which expects a channel_id to be present
+// in the request, and will fail the test if it isn't present.
+func mockAdminChannelIDHandler(t *testing.T) func(rw http.ResponseWriter, r *http.Request) {
+	return func(rw http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST request, got %s", r.Method)
+		}
+
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("unexpected error: %s", err)
+			return
+		}
+
+		if len(r.Form["channel_id"]) == 0 {
+			t.Error("missing channel_id in request")
+			return
+		}
+
+		rw.Header().Set("Content-Type", "application/json")
+		response, _ := json.Marshal(SlackResponse{
+			Ok: true,
+		})
+
+		rw.Write(response)
+	}
+}


### PR DESCRIPTION
This PR introduces three new methods for:

* `admin.conversations.setTeams`
* `admin.conversations.convertToPrivate`
* `admin.conversations.convertToPublic`

I've left some comments in-line below.