### PR TITLE
Remove a number of unused functions and parameters

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -234,7 +234,7 @@ func (api *Client) SendMessageContext(ctx context.Context, channelID string, opt
 		api.Debugf("Sending request: %s", redactToken(reqBody))
 	}
 
-	if err = doPost(ctx, api.httpclient, req, parser(&response), api); err != nil {
+	if err = doPost(api.httpclient, req, parser(&response), api); err != nil {
 		return "", "", "", err
 	}
 

--- a/function_execute_test.go
+++ b/function_execute_test.go
@@ -26,14 +26,14 @@ func postHandler(t *testing.T) func(rw http.ResponseWriter, r *http.Request) {
 
 		switch req.FunctionExecutionID {
 		case "function-success":
-			postSuccess(rw, r)
+			postSuccess(rw)
 		case "function-failure":
-			postFailure(rw, r)
+			postFailure(rw)
 		}
 	}
 }
 
-func postSuccess(rw http.ResponseWriter, _ *http.Request) {
+func postSuccess(rw http.ResponseWriter) {
 	rw.Header().Set("Content-Type", "application/json")
 	response := []byte(`{
     "ok": true
@@ -41,7 +41,7 @@ func postSuccess(rw http.ResponseWriter, _ *http.Request) {
 	rw.Write(response)
 }
 
-func postFailure(rw http.ResponseWriter, _ *http.Request) {
+func postFailure(rw http.ResponseWriter) {
 	rw.Header().Set("Content-Type", "application/json")
 	response := []byte(`{
 			"ok": false,

--- a/function_execute_test.go
+++ b/function_execute_test.go
@@ -33,7 +33,7 @@ func postHandler(t *testing.T) func(rw http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func postSuccess(rw http.ResponseWriter, r *http.Request) {
+func postSuccess(rw http.ResponseWriter, _ *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
 	response := []byte(`{
     "ok": true
@@ -41,7 +41,7 @@ func postSuccess(rw http.ResponseWriter, r *http.Request) {
 	rw.Write(response)
 }
 
-func postFailure(rw http.ResponseWriter, r *http.Request) {
+func postFailure(rw http.ResponseWriter, _ *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
 	response := []byte(`{
 			"ok": false,

--- a/interactions_test.go
+++ b/interactions_test.go
@@ -494,7 +494,6 @@ func TestInteractionCallback_Container_Marshal_And_Unmarshal(t *testing.T) {
 			IsEphemeral:  false,
 			IsAppUnfurl:  false,
 		},
-		RawState: json.RawMessage(`{}`),
 	}
 
 	actual := new(InteractionCallback)
@@ -537,7 +536,6 @@ func TestInteractionCallback_In_Thread_Container_Marshal_And_Unmarshal(t *testin
 			IsEphemeral:  false,
 			IsAppUnfurl:  false,
 		},
-		RawState: json.RawMessage(`{}`),
 	}
 
 	actual := new(InteractionCallback)

--- a/misc.go
+++ b/misc.go
@@ -124,19 +124,6 @@ func jsonReq(ctx context.Context, endpoint string, body interface{}) (req *http.
 	return req, nil
 }
 
-func parseResponseBody(body io.ReadCloser, intf interface{}, d Debug) error {
-	response, err := io.ReadAll(body)
-	if err != nil {
-		return err
-	}
-
-	if d.Debug() {
-		d.Debugln("parseResponseBody", string(response))
-	}
-
-	return json.Unmarshal(response, intf)
-}
-
 func postLocalWithMultipartResponse(ctx context.Context, client httpClient, method, fpath, fieldname, token string, values url.Values, intf interface{}, d Debug) error {
 	fullpath, err := filepath.Abs(fpath)
 	if err != nil {
@@ -220,7 +207,7 @@ func createFormFields(mw *multipart.Writer, values url.Values) error {
 	return nil
 }
 
-func doPost(ctx context.Context, client httpClient, req *http.Request, parser responseParser, d Debug) error {
+func doPost(client httpClient, req *http.Request, parser responseParser, d Debug) error {
 	resp, err := client.Do(req)
 	if err != nil {
 		return err
@@ -245,7 +232,7 @@ func postJSON(ctx context.Context, client httpClient, endpoint, token string, js
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 
-	return doPost(ctx, client, req, newJSONParser(intf), d)
+	return doPost(client, req, newJSONParser(intf), d)
 }
 
 // post a url encoded form.
@@ -256,7 +243,7 @@ func postForm(ctx context.Context, client httpClient, endpoint string, values ur
 		return err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	return doPost(ctx, client, req, newJSONParser(intf), d)
+	return doPost(client, req, newJSONParser(intf), d)
 }
 
 func getResource(ctx context.Context, client httpClient, endpoint, token string, values url.Values, intf interface{}, d Debug) error {
@@ -269,7 +256,7 @@ func getResource(ctx context.Context, client httpClient, endpoint, token string,
 
 	req.URL.RawQuery = values.Encode()
 
-	return doPost(ctx, client, req, newJSONParser(intf), d)
+	return doPost(client, req, newJSONParser(intf), d)
 }
 
 func parseAdminResponse(ctx context.Context, client httpClient, method string, teamName string, values url.Values, intf interface{}, d Debug) error {
@@ -295,14 +282,6 @@ func okJSONHandler(rw http.ResponseWriter, r *http.Request) {
 		Ok: true,
 	})
 	rw.Write(response)
-}
-
-// timerReset safely reset a timer, see time.Timer.Reset for details.
-func timerReset(t *time.Timer, d time.Duration) {
-	if !t.Stop() {
-		<-t.C
-	}
-	t.Reset(d)
 }
 
 func checkStatusCode(resp *http.Response, d Debug) error {

--- a/team.go
+++ b/team.go
@@ -116,7 +116,7 @@ func (api *Client) accessLogsRequest(ctx context.Context, path string, values ur
 	return response, response.Err()
 }
 
-func (api *Client) teamProfileRequest(ctx context.Context, client httpClient, path string, values url.Values) (*TeamProfileResponse, error) {
+func (api *Client) teamProfileRequest(ctx context.Context, path string, values url.Values) (*TeamProfileResponse, error) {
 	response := &TeamProfileResponse{}
 	err := api.postMethod(ctx, path, values, response)
 	if err != nil {
@@ -184,7 +184,7 @@ func (api *Client) GetTeamProfileContext(ctx context.Context, teamID ...string) 
 		values["team_id"] = teamID
 	}
 
-	response, err := api.teamProfileRequest(ctx, api.httpclient, "team.profile.get", values)
+	response, err := api.teamProfileRequest(ctx, "team.profile.get", values)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
My editor throws up warnings about a number of unused functions and variables. I don't think any of these _should_ be removed, so this change removes them. None of the API changes are to exported methods.