### PR TITLE
Handle nil being passed in to newTextParser

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -336,6 +336,10 @@ func newJSONParser(dst interface{}) responseParser {
 
 func newTextParser(dst interface{}) responseParser {
 	return func(resp *http.Response) error {
+		if dst == nil {
+			return nil
+		}
+
 		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err


### PR DESCRIPTION
The `dst` variable was flagged as being unused here. In `newJSONParser`, we check if `dst == nil`: this change copies that behaviour in `newTextParser`.