### PR TITLE
Tidy up arguments to _search function

### DIFF
--- a/search.go
+++ b/search.go
@@ -89,7 +89,7 @@ func NewSearchParameters() SearchParameters {
 	}
 }
 
-func (api *Client) _search(ctx context.Context, path, query string, params SearchParameters, files, messages bool) (response *searchResponseFull, error error) {
+func (api *Client) _search(ctx context.Context, path, query string, params SearchParameters) (response *searchResponseFull, error error) {
 	values := url.Values{
 		"token": {api.token},
 		"query": {query},
@@ -103,7 +103,7 @@ func (api *Client) _search(ctx context.Context, path, query string, params Searc
 	if params.SortDirection != DEFAULT_SEARCH_SORT_DIR {
 		values.Add("sort_dir", params.SortDirection)
 	}
-	if params.Highlight != DEFAULT_SEARCH_HIGHLIGHT {
+	if params.Highlight {
 		values.Add("highlight", strconv.Itoa(1))
 	}
 	if params.Count != DEFAULT_SEARCH_COUNT {
@@ -128,7 +128,7 @@ func (api *Client) Search(query string, params SearchParameters) (*SearchMessage
 }
 
 func (api *Client) SearchContext(ctx context.Context, query string, params SearchParameters) (*SearchMessages, *SearchFiles, error) {
-	response, err := api._search(ctx, "search.all", query, params, true, true)
+	response, err := api._search(ctx, "search.all", query, params)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -140,7 +140,7 @@ func (api *Client) SearchFiles(query string, params SearchParameters) (*SearchFi
 }
 
 func (api *Client) SearchFilesContext(ctx context.Context, query string, params SearchParameters) (*SearchFiles, error) {
-	response, err := api._search(ctx, "search.files", query, params, true, false)
+	response, err := api._search(ctx, "search.files", query, params)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +152,7 @@ func (api *Client) SearchMessages(query string, params SearchParameters) (*Searc
 }
 
 func (api *Client) SearchMessagesContext(ctx context.Context, query string, params SearchParameters) (*SearchMessages, error) {
-	response, err := api._search(ctx, "search.messages", query, params, false, true)
+	response, err := api._search(ctx, "search.messages", query, params)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The `search.all`, `search.files` and `search.messages` endpoints all take the same parameters — so the booleans being passed here are redundant: they are not used for anything, nor can they be. This change removes them, and tidies up some redundant boolean logic in the handling of `params.Highlight`.