### PR TITLE
Fix issues with flaky tests

### DIFF
--- a/apps_test.go
+++ b/apps_test.go
@@ -7,8 +7,10 @@ import (
 )
 
 func TestListEventAuthorizations(t *testing.T) {
-	http.HandleFunc("/apps.event.authorizations.list", testListEventAuthorizationsHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/apps.event.authorizations.list", testListEventAuthorizationsHandler)
 
 	api := New("", OptionAppLevelToken("test-token"), OptionAPIURL("http://"+serverAddr+"/"))
 
@@ -38,8 +40,10 @@ func testListEventAuthorizationsHandler(w http.ResponseWriter, r *http.Request) 
 }
 
 func TestUninstallApp(t *testing.T) {
-	http.HandleFunc("/apps.uninstall", testUninstallAppHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/apps.uninstall", testUninstallAppHandler)
 
 	api := New("test-token", OptionAPIURL("http://"+serverAddr+"/"))
 

--- a/assistant_test.go
+++ b/assistant_test.go
@@ -7,9 +7,10 @@ import (
 )
 
 func TestAssistantThreadsSuggestedPrompts(t *testing.T) {
+	s := startServer()
+	s.RegisterHandler("/assistant.threads.setSuggestedPrompts", okJSONHandler)
+	defer s.Close()
 
-	http.HandleFunc("/assistant.threads.setSuggestedPrompts", okJSONHandler)
-	once.Do(startServer)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	params := AssistantThreadsSetSuggestedPromptsParameters{
@@ -28,9 +29,10 @@ func TestAssistantThreadsSuggestedPrompts(t *testing.T) {
 }
 
 func TestSetAssistantThreadsStatus(t *testing.T) {
+	s := startServer()
+	s.RegisterHandler("/assistant.threads.setStatus", okJSONHandler)
+	defer s.Close()
 
-	http.HandleFunc("/assistant.threads.setStatus", okJSONHandler)
-	once.Do(startServer)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	params := AssistantThreadsSetStatusParameters{
@@ -47,7 +49,6 @@ func TestSetAssistantThreadsStatus(t *testing.T) {
 }
 
 func assistantThreadsTitleHandler(rw http.ResponseWriter, r *http.Request) {
-
 	channelID := r.FormValue("channel_id")
 	threadTS := r.FormValue("thread_ts")
 	title := r.FormValue("title")
@@ -55,7 +56,6 @@ func assistantThreadsTitleHandler(rw http.ResponseWriter, r *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
 
 	if channelID != "" && threadTS != "" && title != "" {
-
 		resp, _ := json.Marshal(&addBookmarkResponse{
 			SlackResponse: SlackResponse{Ok: true},
 		})
@@ -63,13 +63,13 @@ func assistantThreadsTitleHandler(rw http.ResponseWriter, r *http.Request) {
 	} else {
 		rw.Write([]byte(`{ "ok": false, "error": "errored" }`))
 	}
-
 }
 
 func TestSetAssistantThreadsTitle(t *testing.T) {
+	s := startServer()
+	s.RegisterHandler("/assistant.threads.setTitle", assistantThreadsTitleHandler)
+	defer s.Close()
 
-	http.HandleFunc("/assistant.threads.setTitle", assistantThreadsTitleHandler)
-	once.Do(startServer)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	params := AssistantThreadsSetTitleParameters{
@@ -82,5 +82,4 @@ func TestSetAssistantThreadsTitle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
-
 }

--- a/audit_test.go
+++ b/audit_test.go
@@ -45,9 +45,10 @@ func getAuditLogs(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestGetAuditLogs(t *testing.T) {
-	http.HandleFunc("/audit/v1/logs", getAuditLogs)
+	s := startServer()
+	s.RegisterHandler("/audit/v1/logs", getAuditLogs)
+	defer s.Close()
 
-	once.Do(startServer)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	events, nextCursor, err := api.GetAuditLogs(AuditLogParameters{})

--- a/auth_test.go
+++ b/auth_test.go
@@ -29,9 +29,10 @@ func getTeamList(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestListTeams(t *testing.T) {
-	http.HandleFunc("/auth.teams.list", getTeamList)
+	s := startServer()
+	s.RegisterHandler("/auth.teams.list", getTeamList)
+	defer s.Close()
 
-	once.Do(startServer)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	teams, cursor, err := api.ListTeams(ListTeamsParameters{})

--- a/bookmarks_test.go
+++ b/bookmarks_test.go
@@ -43,8 +43,10 @@ func addBookmarkLinkHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestAddBookmarkLink(t *testing.T) {
-	http.HandleFunc("/bookmarks.add", addBookmarkLinkHandler)
-	once.Do(startServer)
+	s := startServer()
+	s.RegisterHandler("/bookmarks.add", addBookmarkLinkHandler)
+	defer s.Close()
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	params := AddBookmarkParameters{
 		Title: "test",
@@ -80,8 +82,11 @@ func listBookmarksHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestListBookmarks(t *testing.T) {
-	http.HandleFunc("/bookmarks.list", listBookmarksHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/bookmarks.list", listBookmarksHandler)
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	channel := "CXXXXXXXX"
 	bookmarks, err := api.ListBookmarks(channel)
@@ -115,10 +120,12 @@ func removeBookmarkHandler(bookmark *Bookmark) func(rw http.ResponseWriter, r *h
 }
 
 func TestRemoveBookmark(t *testing.T) {
+	s := startServer()
+	defer s.Close()
+
 	channel := "CXXXXXXXX"
 	bookmark := getTestBookmark(channel, "BkXXXXX")
-	http.HandleFunc("/bookmarks.remove", removeBookmarkHandler(&bookmark))
-	once.Do(startServer)
+	s.RegisterHandler("/bookmarks.remove", removeBookmarkHandler(&bookmark))
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	err := api.RemoveBookmark(channel, bookmark.ID)
@@ -163,6 +170,9 @@ func editBookmarkHandler(bookmarks []Bookmark) func(rw http.ResponseWriter, r *h
 }
 
 func TestEditBookmark(t *testing.T) {
+	s := startServer()
+	defer s.Close()
+
 	channel := "CXXXXXXXX"
 	bookmarks := []Bookmark{
 		getTestBookmark(channel, "Bk001"),
@@ -170,8 +180,7 @@ func TestEditBookmark(t *testing.T) {
 		getTestBookmark(channel, "Bk003"),
 		getTestBookmark(channel, "Bk004"),
 	}
-	http.HandleFunc("/bookmarks.edit", editBookmarkHandler(bookmarks))
-	once.Do(startServer)
+	s.RegisterHandler("/bookmarks.edit", editBookmarkHandler(bookmarks))
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	smileEmoji := ":smile:"

--- a/bots_test.go
+++ b/bots_test.go
@@ -24,9 +24,11 @@ func getBotInfo(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestGetBotInfo(t *testing.T) {
-	http.HandleFunc("/bots.info", getBotInfo)
+	s := startServer()
+	defer s.Close()
 
-	once.Do(startServer)
+	s.RegisterHandler("/bots.info", getBotInfo)
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	bot, err := api.GetBotInfo(GetBotInfoParameters{Bot: "B02875YLA"})

--- a/canvas_test.go
+++ b/canvas_test.go
@@ -28,8 +28,10 @@ func createCanvasHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestCreateCanvas(t *testing.T) {
-	http.HandleFunc("/canvases.create", createCanvasHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/canvases.create", createCanvasHandler)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	documentContent := DocumentContent{
@@ -60,8 +62,10 @@ func deleteCanvasHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestDeleteCanvas(t *testing.T) {
-	http.HandleFunc("/canvases.delete", deleteCanvasHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/canvases.delete", deleteCanvasHandler)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	err := api.DeleteCanvas("F1234ABCD")
@@ -83,8 +87,10 @@ func editCanvasHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestEditCanvas(t *testing.T) {
-	http.HandleFunc("/canvases.edit", editCanvasHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/canvases.edit", editCanvasHandler)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	params := EditCanvasParams{
@@ -120,8 +126,10 @@ func setCanvasAccessHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestSetCanvasAccess(t *testing.T) {
-	http.HandleFunc("/canvases.access.set", setCanvasAccessHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/canvases.access.set", setCanvasAccessHandler)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	params := SetCanvasAccessParams{
@@ -150,8 +158,11 @@ func deleteCanvasAccessHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestDeleteCanvasAccess(t *testing.T) {
-	http.HandleFunc("/canvases.access.delete", deleteCanvasAccessHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/canvases.access.delete", deleteCanvasAccessHandler)
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	params := DeleteCanvasAccessParams{
@@ -188,8 +199,11 @@ func lookupCanvasSectionsHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestLookupCanvasSections(t *testing.T) {
-	http.HandleFunc("/canvases.sections.lookup", lookupCanvasSectionsHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/canvases.sections.lookup", lookupCanvasSectionsHandler)
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	params := LookupCanvasSectionsParams{

--- a/conversation_test.go
+++ b/conversation_test.go
@@ -393,8 +393,11 @@ func getUsersInConversation(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestGetUsersInConversation(t *testing.T) {
-	http.HandleFunc("/conversations.members", getUsersInConversation)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/conversations.members", getUsersInConversation)
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	params := GetUsersInConversationParameters{
 		ChannelID: "CXXXXXXXX",
@@ -413,8 +416,11 @@ func TestGetUsersInConversation(t *testing.T) {
 }
 
 func TestArchiveConversation(t *testing.T) {
-	http.HandleFunc("/conversations.archive", okJSONHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/conversations.archive", okJSONHandler)
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	err := api.ArchiveConversation("CXXXXXXXX")
 	if err != nil {
@@ -424,8 +430,11 @@ func TestArchiveConversation(t *testing.T) {
 }
 
 func TestUnArchiveConversation(t *testing.T) {
-	http.HandleFunc("/conversations.unarchive", okJSONHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/conversations.unarchive", okJSONHandler)
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	err := api.UnArchiveConversation("CXXXXXXXX")
 	if err != nil {
@@ -473,8 +482,11 @@ func okInviteSharedJsonHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestSetTopicOfConversation(t *testing.T) {
-	http.HandleFunc("/conversations.setTopic", okChannelJsonHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/conversations.setTopic", okChannelJsonHandler)
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	inputChannel := getTestChannel()
 	channel, err := api.SetTopicOfConversation("CXXXXXXXX", inputChannel.Topic.Value)
@@ -488,8 +500,11 @@ func TestSetTopicOfConversation(t *testing.T) {
 }
 
 func TestSetPurposeOfConversation(t *testing.T) {
-	http.HandleFunc("/conversations.setPurpose", okChannelJsonHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/conversations.setPurpose", okChannelJsonHandler)
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	inputChannel := getTestChannel()
 	channel, err := api.SetPurposeOfConversation("CXXXXXXXX", inputChannel.Purpose.Value)
@@ -503,8 +518,11 @@ func TestSetPurposeOfConversation(t *testing.T) {
 }
 
 func TestRenameConversation(t *testing.T) {
-	http.HandleFunc("/conversations.rename", okChannelJsonHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/conversations.rename", okChannelJsonHandler)
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	inputChannel := getTestChannel()
 	channel, err := api.RenameConversation("CXXXXXXXX", inputChannel.Name)
@@ -518,8 +536,10 @@ func TestRenameConversation(t *testing.T) {
 }
 
 func TestInviteUsersToConversation(t *testing.T) {
-	http.HandleFunc("/conversations.invite", okChannelJsonHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/conversations.invite", okChannelJsonHandler)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	users := []string{"UXXXXXXX1", "UXXXXXXX2"}
 	channel, err := api.InviteUsersToConversation("CXXXXXXXX", users...)
@@ -534,8 +554,10 @@ func TestInviteUsersToConversation(t *testing.T) {
 }
 
 func TestInviteSharedToConversation(t *testing.T) {
-	http.HandleFunc("/conversations.inviteShared", okInviteSharedJsonHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/conversations.inviteShared", okInviteSharedJsonHandler)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	t.Run("user_ids", func(t *testing.T) {
@@ -593,8 +615,10 @@ func TestInviteSharedToConversation(t *testing.T) {
 }
 
 func TestKickUserFromConversation(t *testing.T) {
-	http.HandleFunc("/conversations.kick", okJSONHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/conversations.kick", okJSONHandler)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	err := api.KickUserFromConversation("CXXXXXXXX", "UXXXXXXXX")
 	if err != nil {
@@ -615,8 +639,10 @@ func closeConversationHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestCloseConversation(t *testing.T) {
-	http.HandleFunc("/conversations.close", closeConversationHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/conversations.close", closeConversationHandler)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	_, _, err := api.CloseConversation("CXXXXXXXX")
 	if err != nil {
@@ -626,8 +652,10 @@ func TestCloseConversation(t *testing.T) {
 }
 
 func TestCreateConversation(t *testing.T) {
-	http.HandleFunc("/conversations.create", okChannelJsonHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/conversations.create", okChannelJsonHandler)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	channel, err := api.CreateConversation(CreateConversationParams{ChannelName: "CXXXXXXXX"})
 	if err != nil {
@@ -641,8 +669,10 @@ func TestCreateConversation(t *testing.T) {
 }
 
 func TestGetConversationInfo(t *testing.T) {
-	http.HandleFunc("/conversations.info", okChannelJsonHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/conversations.info", okChannelJsonHandler)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	channel, err := api.GetConversationInfo(&GetConversationInfoInput{
 		ChannelID: "CXXXXXXXX",
@@ -684,8 +714,10 @@ func leaveConversationHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestLeaveConversation(t *testing.T) {
-	http.HandleFunc("/conversations.leave", leaveConversationHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/conversations.leave", leaveConversationHandler)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	_, err := api.LeaveConversation("CXXXXXXXX")
 	if err != nil {
@@ -710,8 +742,10 @@ func getConversationRepliesHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestGetConversationReplies(t *testing.T) {
-	http.HandleFunc("/conversations.replies", getConversationRepliesHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/conversations.replies", getConversationRepliesHandler)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	params := GetConversationRepliesParameters{
 		ChannelID: "CXXXXXXXX",
@@ -739,8 +773,10 @@ func getConversationsHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestGetConversations(t *testing.T) {
-	http.HandleFunc("/conversations.list", getConversationsHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/conversations.list", getConversationsHandler)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	params := GetConversationsParameters{}
 	_, _, err := api.GetConversations(&params)
@@ -763,8 +799,10 @@ func openConversationHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestOpenConversation(t *testing.T) {
-	http.HandleFunc("/conversations.open", openConversationHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/conversations.open", openConversationHandler)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	params := OpenConversationParameters{ChannelID: "CXXXXXXXX"}
 	_, _, _, err := api.OpenConversation(&params)
@@ -789,8 +827,10 @@ func joinConversationHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestJoinConversation(t *testing.T) {
-	http.HandleFunc("/conversations.join", joinConversationHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/conversations.join", joinConversationHandler)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	_, _, _, err := api.JoinConversation("CXXXXXXXX")
 	if err != nil {
@@ -807,8 +847,10 @@ func getConversationHistoryHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestGetConversationHistory(t *testing.T) {
-	http.HandleFunc("/conversations.history", getConversationHistoryHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/conversations.history", getConversationHistoryHandler)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	params := GetConversationHistoryParameters{ChannelID: "CXXXXXXXX"}
 	_, err := api.GetConversationHistory(&params)
@@ -826,8 +868,10 @@ func markConversationHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestMarkConversation(t *testing.T) {
-	http.HandleFunc("/conversations.mark", markConversationHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/conversations.mark", markConversationHandler)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	err := api.MarkConversation("CXXXXXXXX", "1401383885.000061")
 	if err != nil {
@@ -849,8 +893,11 @@ func createChannelCanvasHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestCreateChannelCanvas(t *testing.T) {
-	http.HandleFunc("/conversations.canvases.create", createChannelCanvasHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/conversations.canvases.create", createChannelCanvasHandler)
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	documentContent := DocumentContent{

--- a/dialog_test.go
+++ b/dialog_test.go
@@ -284,8 +284,10 @@ func openDialogHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestOpenDialog(t *testing.T) {
-	http.HandleFunc("/dialog.open", openDialogHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/dialog.open", openDialogHandler)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	dialog, err := unmarshalDialog()
 	if err != nil {

--- a/dnd_test.go
+++ b/dnd_test.go
@@ -7,11 +7,13 @@ import (
 )
 
 func TestSlack_EndDND(t *testing.T) {
-	http.HandleFunc("/dnd.endDnd", func(w http.ResponseWriter, r *http.Request) {
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/dnd.endDnd", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{ "ok": true }`))
 	})
-	once.Do(startServer)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	err := api.EndDND()
 	if err != nil {
@@ -20,7 +22,10 @@ func TestSlack_EndDND(t *testing.T) {
 }
 
 func TestSlack_EndSnooze(t *testing.T) {
-	http.HandleFunc("/dnd.endSnooze", func(w http.ResponseWriter, r *http.Request) {
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/dnd.endSnooze", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{ "ok": true,
                           "dnd_enabled": true,
@@ -34,7 +39,6 @@ func TestSlack_EndSnooze(t *testing.T) {
 		NextEndTimestamp:   1450454400,
 		SnoozeInfo:         SnoozeInfo{SnoozeEnabled: false},
 	}
-	once.Do(startServer)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	snoozeState, err := api.EndSnooze()
 	if err != nil {
@@ -47,7 +51,10 @@ func TestSlack_EndSnooze(t *testing.T) {
 }
 
 func TestSlack_GetDNDInfo(t *testing.T) {
-	http.HandleFunc("/dnd.info", func(w http.ResponseWriter, r *http.Request) {
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/dnd.info", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{
             "ok": true,
@@ -69,7 +76,6 @@ func TestSlack_GetDNDInfo(t *testing.T) {
 			SnoozeRemaining: 1196,
 		},
 	}
-	once.Do(startServer)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	userDNDInfoResponse, err := api.GetDNDInfo(nil)
 	if err != nil {
@@ -82,7 +88,10 @@ func TestSlack_GetDNDInfo(t *testing.T) {
 }
 
 func TestSlack_GetDNDTeamInfo(t *testing.T) {
-	http.HandleFunc("/dnd.teamInfo", func(w http.ResponseWriter, r *http.Request) {
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/dnd.teamInfo", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{
             "ok": true,
@@ -112,7 +121,6 @@ func TestSlack_GetDNDTeamInfo(t *testing.T) {
 			NextEndTimestamp:   1,
 		},
 	}
-	once.Do(startServer)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	usersDNDInfoResponse, err := api.GetDNDTeamInfo(nil)
 	if err != nil {
@@ -125,7 +133,10 @@ func TestSlack_GetDNDTeamInfo(t *testing.T) {
 }
 
 func TestSlack_SetSnooze(t *testing.T) {
-	http.HandleFunc("/dnd.setSnooze", func(w http.ResponseWriter, r *http.Request) {
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/dnd.setSnooze", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{
             "ok": true,
@@ -141,7 +152,6 @@ func TestSlack_SetSnooze(t *testing.T) {
 			SnoozeRemaining: 60,
 		},
 	}
-	once.Do(startServer)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	snoozeResponse, err := api.SetSnooze(60)
 	if err != nil {

--- a/emoji_test.go
+++ b/emoji_test.go
@@ -17,9 +17,10 @@ func getEmojiHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestGetEmoji(t *testing.T) {
-	http.HandleFunc("/emoji.list", getEmojiHandler)
+	s := startServer()
+	defer s.Close()
 
-	once.Do(startServer)
+	s.RegisterHandler("/emoji.list", getEmojiHandler)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	emojisResponse := map[string]string{
 		"bowtie":   "https://my.slack.com/emoji/bowtie/46ec6f2bb0.png",

--- a/examples/modal/modal.go
+++ b/examples/modal/modal.go
@@ -18,8 +18,9 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/slack-go/slack"
 	"time"
+
+	"github.com/slack-go/slack"
 )
 
 func generateModalRequest() slack.ModalViewRequest {

--- a/function_execute_test.go
+++ b/function_execute_test.go
@@ -42,13 +42,14 @@ func postSuccess(rw http.ResponseWriter, r *http.Request) {
 }
 
 func postFailure(rw http.ResponseWriter, r *http.Request) {
-	rw.Header().Set("Content-Type", "application/json")
 	response := []byte(`{
-			"ok": false,
-			"error": "function_execution_not_found"
+		"ok": false,
+		"error": "function_execution_not_found"
 	}`)
-	rw.Write(response)
+
+	rw.Header().Set("Content-Type", "application/json")
 	rw.WriteHeader(500)
+	rw.Write(response)
 }
 
 func TestFunctionComplete(t *testing.T) {

--- a/function_execute_test.go
+++ b/function_execute_test.go
@@ -53,9 +53,10 @@ func postFailure(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestFunctionComplete(t *testing.T) {
-	http.HandleFunc("/functions.completeSuccess", postHandler(t))
-
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+	
+	s.RegisterHandler("/functions.completeSuccess", postHandler(t))
 
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 

--- a/function_execute_test.go
+++ b/function_execute_test.go
@@ -56,7 +56,7 @@ func postFailure(rw http.ResponseWriter) {
 func TestFunctionComplete(t *testing.T) {
 	s := startServer()
 	defer s.Close()
-	
+
 	s.RegisterHandler("/functions.completeSuccess", postHandler(t))
 
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))

--- a/manifests_test.go
+++ b/manifests_test.go
@@ -8,8 +8,10 @@ import (
 )
 
 func TestCreateManifest(t *testing.T) {
-	http.HandleFunc("/apps.manifest.create", handleCreateManifest)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/apps.manifest.create", handleCreateManifest)
 
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
@@ -33,10 +35,12 @@ func handleCreateManifest(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestDeleteManifest(t *testing.T) {
-	http.HandleFunc("/apps.manifest.delete", handleDeleteManifest)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/apps.manifest.delete", handleDeleteManifest)
 	expectedResponse := SlackResponse{Ok: true}
 
-	once.Do(startServer)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	resp, err := api.DeleteManifest("token", "app id")
@@ -58,7 +62,10 @@ func handleDeleteManifest(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestExportManifest(t *testing.T) {
-	http.HandleFunc("/apps.manifest.export", handleExportManifest)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/apps.manifest.export", handleExportManifest)
 	expectedResponse := getTestManifest()
 
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
@@ -82,7 +89,10 @@ func handleExportManifest(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestUpdateManifest(t *testing.T) {
-	http.HandleFunc("/apps.manifest.update", handleUpdateManifest)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/apps.manifest.update", handleUpdateManifest)
 	expectedResponse := UpdateManifestResponse{AppId: "app id"}
 
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
@@ -107,7 +117,10 @@ func handleUpdateManifest(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestValidateManifest(t *testing.T) {
-	http.HandleFunc("/apps.manifest.validate", handleValidateManifest)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/apps.manifest.validate", handleValidateManifest)
 	expectedResponse := ManifestResponse{SlackResponse: SlackResponse{Ok: true}}
 
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))

--- a/misc_test.go
+++ b/misc_test.go
@@ -31,13 +31,12 @@ func parseResponseHandler(rw http.ResponseWriter, r *http.Request) {
 	rw.Write(response)
 }
 
-func setParseResponseHandler() {
-	http.HandleFunc("/parseResponse", parseResponseHandler)
-}
-
 func TestParseResponse(t *testing.T) {
-	parseResponseOnce.Do(setParseResponseHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/parseResponse", parseResponseHandler)
+
 	APIURL := "http://" + serverAddr + "/"
 	values := url.Values{
 		"token": {validToken},
@@ -51,8 +50,11 @@ func TestParseResponse(t *testing.T) {
 }
 
 func TestParseResponseNoToken(t *testing.T) {
-	parseResponseOnce.Do(setParseResponseHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/parseResponse", parseResponseHandler)
+
 	APIURL := "http://" + serverAddr + "/"
 	values := url.Values{}
 
@@ -70,8 +72,11 @@ func TestParseResponseNoToken(t *testing.T) {
 }
 
 func TestParseResponseInvalidToken(t *testing.T) {
-	parseResponseOnce.Do(setParseResponseHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/parseResponse", parseResponseHandler)
+
 	APIURL := "http://" + serverAddr + "/"
 	values := url.Values{
 		"token": {"whatever"},

--- a/pins_test.go
+++ b/pins_test.go
@@ -37,7 +37,9 @@ func (rh *pinsHandler) handler(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestSlack_AddPin(t *testing.T) {
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	tests := []struct {
 		channel    string
@@ -70,7 +72,7 @@ func TestSlack_AddPin(t *testing.T) {
 		},
 	}
 	var rh *pinsHandler
-	http.HandleFunc("/pins.add", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
+	s.RegisterHandler("/pins.add", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
 	for i, test := range tests {
 		rh = newPinsHandler()
 		err := api.AddPin(test.channel, test.ref)
@@ -84,7 +86,9 @@ func TestSlack_AddPin(t *testing.T) {
 }
 
 func TestSlack_RemovePin(t *testing.T) {
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	tests := []struct {
 		channel    string
@@ -117,7 +121,7 @@ func TestSlack_RemovePin(t *testing.T) {
 		},
 	}
 	var rh *pinsHandler
-	http.HandleFunc("/pins.remove", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
+	s.RegisterHandler("/pins.remove", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
 	for i, test := range tests {
 		rh = newPinsHandler()
 		err := api.RemovePin(test.channel, test.ref)
@@ -131,10 +135,12 @@ func TestSlack_RemovePin(t *testing.T) {
 }
 
 func TestSlack_ListPins(t *testing.T) {
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	rh := newPinsHandler()
-	http.HandleFunc("/pins.list", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
+	s.RegisterHandler("/pins.list", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
 	rh.response = `{"ok": true,
     "items": [
         {

--- a/reactions_test.go
+++ b/reactions_test.go
@@ -40,7 +40,9 @@ func (rh *reactionsHandler) handler(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestSlack_AddReaction(t *testing.T) {
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	tests := []struct {
 		name       string
@@ -74,7 +76,7 @@ func TestSlack_AddReaction(t *testing.T) {
 		},
 	}
 	var rh *reactionsHandler
-	http.HandleFunc("/reactions.add", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
+	s.RegisterHandler("/reactions.add", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
 	for i, test := range tests {
 		rh = newReactionsHandler()
 		err := api.AddReaction(test.name, test.ref)
@@ -88,7 +90,9 @@ func TestSlack_AddReaction(t *testing.T) {
 }
 
 func TestSlack_RemoveReaction(t *testing.T) {
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	tests := []struct {
 		name       string
@@ -122,7 +126,7 @@ func TestSlack_RemoveReaction(t *testing.T) {
 		},
 	}
 	var rh *reactionsHandler
-	http.HandleFunc("/reactions.remove", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
+	s.RegisterHandler("/reactions.remove", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
 	for i, test := range tests {
 		rh = newReactionsHandler()
 		err := api.RemoveReaction(test.name, test.ref)
@@ -136,7 +140,9 @@ func TestSlack_RemoveReaction(t *testing.T) {
 }
 
 func TestSlack_GetReactions(t *testing.T) {
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	tests := []struct {
 		ref           ItemRef
@@ -232,7 +238,7 @@ func TestSlack_GetReactions(t *testing.T) {
 		},
 	}
 	var rh *reactionsHandler
-	http.HandleFunc("/reactions.get", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
+	s.RegisterHandler("/reactions.get", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
 	for i, test := range tests {
 		rh = newReactionsHandler()
 		rh.response = test.json
@@ -250,10 +256,12 @@ func TestSlack_GetReactions(t *testing.T) {
 }
 
 func TestSlack_ListReactions(t *testing.T) {
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	rh := newReactionsHandler()
-	http.HandleFunc("/reactions.list", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
+	s.RegisterHandler("/reactions.list", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
 	rh.response = `{"ok": true,
     "items": [
         {

--- a/reminders_test.go
+++ b/reminders_test.go
@@ -39,7 +39,9 @@ func (rh *remindersHandler) handler(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestSlack_AddReminder(t *testing.T) {
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	tests := []struct {
 		chanID     string
@@ -99,7 +101,7 @@ func TestSlack_AddReminder(t *testing.T) {
 		},
 	}
 	var rh *remindersHandler
-	http.HandleFunc("/reminders.add", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
+	s.RegisterHandler("/reminders.add", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
 	for i, test := range tests {
 		rh = newRemindersHandler()
 		var err error
@@ -120,7 +122,9 @@ func TestSlack_AddReminder(t *testing.T) {
 }
 
 func TestSlack_DeleteReminder(t *testing.T) {
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	tests := []struct {
 		reminder   string
@@ -143,7 +147,7 @@ func TestSlack_DeleteReminder(t *testing.T) {
 		},
 	}
 	var rh *remindersHandler
-	http.HandleFunc("/reminders.delete", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
+	s.RegisterHandler("/reminders.delete", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
 	for i, test := range tests {
 		rh = newRemindersHandler()
 		err := api.DeleteReminder(test.reminder)
@@ -191,7 +195,6 @@ func (m *mockRemindersListHTTPClient) Do(*http.Request) (*http.Response, error) 
 func TestSlack_ListReminders(t *testing.T) {
 	expectedIDs := []string{"Rm12345678", "Gm12345678"}
 
-	once.Do(startServer)
 	api := &Client{
 		endpoint:   "http://" + serverAddr + "/",
 		token:      "testing-token",

--- a/remotefiles_test.go
+++ b/remotefiles_test.go
@@ -15,8 +15,11 @@ func addRemoteFileHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestAddRemoteFile(t *testing.T) {
-	http.HandleFunc("/files.remote.add", addRemoteFileHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/files.remote.add", addRemoteFileHandler)
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	params := RemoteFileParameters{
 		ExternalID:  "externalID",
@@ -29,7 +32,6 @@ func TestAddRemoteFile(t *testing.T) {
 }
 
 func TestAddRemoteFileWithoutTitle(t *testing.T) {
-	once.Do(startServer)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	params := RemoteFileParameters{
 		ExternalID:  "externalID",
@@ -48,8 +50,11 @@ func listRemoteFileHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestListRemoteFile(t *testing.T) {
-	http.HandleFunc("/files.remote.list", listRemoteFileHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/files.remote.list", listRemoteFileHandler)
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	params := ListRemoteFilesParameters{}
 	if _, err := api.ListRemoteFiles(params); err != nil {
@@ -65,8 +70,11 @@ func getRemoteFileInfoHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestGetRemoteFileInfo(t *testing.T) {
-	http.HandleFunc("/files.remote.info", getRemoteFileInfoHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/files.remote.info", getRemoteFileInfoHandler)
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	if _, err := api.GetRemoteFileInfo("ExternalID", ""); err != nil {
 		t.Errorf("Unexpected error: %s", err)
@@ -74,7 +82,6 @@ func TestGetRemoteFileInfo(t *testing.T) {
 }
 
 func TestGetRemoteFileInfoWithoutID(t *testing.T) {
-	once.Do(startServer)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	_, err := api.GetRemoteFileInfo("", "")
 	if err == nil {
@@ -86,7 +93,6 @@ func TestGetRemoteFileInfoWithoutID(t *testing.T) {
 }
 
 func TestGetRemoteFileInfoWithFileIDAndExternalID(t *testing.T) {
-	once.Do(startServer)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	_, err := api.GetRemoteFileInfo("ExternalID", "FileID")
 	if err == nil {
@@ -105,8 +111,11 @@ func shareRemoteFileHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestShareRemoteFile(t *testing.T) {
-	http.HandleFunc("/files.remote.share", shareRemoteFileHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/files.remote.share", shareRemoteFileHandler)
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	if _, err := api.ShareRemoteFile([]string{"channel"}, "ExternalID", ""); err != nil {
 		t.Errorf("Unexpected error: %s", err)
@@ -114,7 +123,6 @@ func TestShareRemoteFile(t *testing.T) {
 }
 
 func TestShareRemoteFileWithoutChannels(t *testing.T) {
-	once.Do(startServer)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	if _, err := api.ShareRemoteFile([]string{}, "ExternalID", ""); err != ErrParametersMissing {
 		t.Errorf("Expected ErrParametersMissing. got %s", err)
@@ -122,7 +130,6 @@ func TestShareRemoteFileWithoutChannels(t *testing.T) {
 }
 
 func TestShareRemoteFileWithoutID(t *testing.T) {
-	once.Do(startServer)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	_, err := api.ShareRemoteFile([]string{"channel"}, "", "")
 	if err == nil {
@@ -141,8 +148,11 @@ func updateRemoteFileHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestUpdateRemoteFile(t *testing.T) {
-	http.HandleFunc("/files.remote.update", updateRemoteFileHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/files.remote.update", updateRemoteFileHandler)
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	params := RemoteFileParameters{
 		ExternalURL: "http://example.com/",
@@ -161,8 +171,11 @@ func removeRemoteFileHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestRemoveRemoteFile(t *testing.T) {
-	http.HandleFunc("/files.remote.remove", removeRemoteFileHandler)
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/files.remote.remove", removeRemoteFileHandler)
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	if err := api.RemoveRemoteFile("ExternalID", ""); err != nil {
 		t.Errorf("Unexpected error: %s", err)
@@ -170,7 +183,6 @@ func TestRemoveRemoteFile(t *testing.T) {
 }
 
 func TestRemoveRemoteFileWithoutID(t *testing.T) {
-	once.Do(startServer)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	err := api.RemoveRemoteFile("", "")
 	if err == nil {
@@ -182,7 +194,6 @@ func TestRemoveRemoteFileWithoutID(t *testing.T) {
 }
 
 func TestRemoveRemoteFileWithFileIDAndExternalID(t *testing.T) {
-	once.Do(startServer)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	err := api.RemoveRemoteFile("ExternalID", "FileID")
 	if err == nil {

--- a/slash_test.go
+++ b/slash_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 func TestSlash_ServeHTTP(t *testing.T) {
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
 	serverURL := fmt.Sprintf("http://%s/slash", serverAddr)
 
 	tests := []struct {
@@ -67,7 +69,7 @@ func TestSlash_ServeHTTP(t *testing.T) {
 
 	var slashCommand SlashCommand
 	client := &http.Client{}
-	http.HandleFunc("/slash", func(w http.ResponseWriter, r *http.Request) {
+	s.RegisterHandler("/slash", func(w http.ResponseWriter, r *http.Request) {
 		var err error
 		slashCommand, err = SlashCommandParse(r)
 		if err != nil {

--- a/stars_test.go
+++ b/stars_test.go
@@ -38,7 +38,9 @@ func (sh *starsHandler) handler(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestSlack_AddStar(t *testing.T) {
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	tests := []struct {
 		channel    string
@@ -71,7 +73,7 @@ func TestSlack_AddStar(t *testing.T) {
 		},
 	}
 	var rh *starsHandler
-	http.HandleFunc("/stars.add", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
+	s.RegisterHandler("/stars.add", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
 	for i, test := range tests {
 		rh = newStarsHandler()
 		err := api.AddStar(test.channel, test.ref)
@@ -85,7 +87,9 @@ func TestSlack_AddStar(t *testing.T) {
 }
 
 func TestSlack_RemoveStar(t *testing.T) {
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	tests := []struct {
 		channel    string
@@ -118,7 +122,7 @@ func TestSlack_RemoveStar(t *testing.T) {
 		},
 	}
 	var rh *starsHandler
-	http.HandleFunc("/stars.remove", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
+	s.RegisterHandler("/stars.remove", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
 	for i, test := range tests {
 		rh = newStarsHandler()
 		err := api.RemoveStar(test.channel, test.ref)
@@ -132,10 +136,12 @@ func TestSlack_RemoveStar(t *testing.T) {
 }
 
 func TestSlack_ListStars(t *testing.T) {
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 	rh := newStarsHandler()
-	http.HandleFunc("/stars.list", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
+	s.RegisterHandler("/stars.list", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
 	rh.response = `{"ok": true,
     "items": [
         {

--- a/team_test.go
+++ b/team_test.go
@@ -28,9 +28,11 @@ func getTeamInfo(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestGetTeamInfo(t *testing.T) {
-	http.HandleFunc("/team.info", getTeamInfo)
+	s := startServer()
+	defer s.Close()
 
-	once.Do(startServer)
+	s.RegisterHandler("/team.info", getTeamInfo)
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	teamInfo, err := api.GetTeamInfo()
@@ -93,9 +95,11 @@ func getTeamProfile(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestGetTeamProfile(t *testing.T) {
-	http.HandleFunc("/team.profile.get", getTeamProfile)
+	s := startServer()
+	defer s.Close()
 
-	once.Do(startServer)
+	s.RegisterHandler("/team.profile.get", getTeamProfile)
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	teamProfile, err := api.GetTeamProfile()
@@ -161,9 +165,11 @@ func getTeamAccessLogs(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestGetAccessLogs(t *testing.T) {
-	http.HandleFunc("/team.accessLogs", getTeamAccessLogs)
+	s := startServer()
+	defer s.Close()
 
-	once.Do(startServer)
+	s.RegisterHandler("/team.accessLogs", getTeamAccessLogs)
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	logins, paging, err := api.GetAccessLogs(NewAccessLogParameters())

--- a/testserver_test.go
+++ b/testserver_test.go
@@ -1,0 +1,36 @@
+package slack
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestServer provides a wrapper around httptest.Server with added functionality
+// for Slack API testing
+type TestServer struct {
+	Server *httptest.Server
+	Mux    *http.ServeMux
+	URL    string
+	Client *Client
+}
+
+// NewTestServer creates a new test server with a fresh mux and a configured Slack client
+func NewTestServer(t *testing.T, token string) *TestServer {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+
+	client := New(token, OptionAPIURL(server.URL+"/"))
+
+	return &TestServer{
+		Server: server,
+		Mux:    mux,
+		URL:    server.URL,
+		Client: client,
+	}
+}
+
+// Close shuts down the test server
+func (ts *TestServer) Close() {
+	ts.Server.Close()
+}

--- a/tokens_test.go
+++ b/tokens_test.go
@@ -8,10 +8,12 @@ import (
 )
 
 func TestRotateTokens(t *testing.T) {
-	http.HandleFunc("/tooling.tokens.rotate", handleRotateToken)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/tooling.tokens.rotate", handleRotateToken)
 	expected := getTestTokenResponse()
 
-	once.Do(startServer)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	tok, err := api.RotateTokens("expired-config", "old-refresh")

--- a/usergroups_test.go
+++ b/usergroups_test.go
@@ -55,7 +55,9 @@ func (ugh *userGroupsHandler) handler(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestCreateUserGroup(t *testing.T) {
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	tests := []struct {
@@ -77,7 +79,7 @@ func TestCreateUserGroup(t *testing.T) {
 	}
 
 	var rh *userGroupsHandler
-	http.HandleFunc("/usergroups.create", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
+	s.RegisterHandler("/usergroups.create", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
 
 	for i, test := range tests {
 		rh = newUserGroupsHandler()
@@ -134,9 +136,11 @@ func getUserGroups(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestGetUserGroups(t *testing.T) {
-	http.HandleFunc("/usergroups.list", getUserGroups)
+	s := startServer()
+	defer s.Close()
 
-	once.Do(startServer)
+	s.RegisterHandler("/usergroups.list", getUserGroups)
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	userGroups, err := api.GetUserGroups(GetUserGroupsOptionIncludeUsers(true))
@@ -216,7 +220,9 @@ func updateUserGroupsHandler() *userGroupsHandler {
 	}
 }
 func TestUpdateUserGroup(t *testing.T) {
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	emptyDescription := ""
@@ -265,7 +271,7 @@ func TestUpdateUserGroup(t *testing.T) {
 	}
 
 	var rh *userGroupsHandler
-	http.HandleFunc("/usergroups.update", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
+	s.RegisterHandler("/usergroups.update", func(w http.ResponseWriter, r *http.Request) { rh.handler(w, r) })
 
 	for i, test := range tests {
 		rh = updateUserGroupsHandler()

--- a/views_test.go
+++ b/views_test.go
@@ -23,7 +23,15 @@ func (h *viewsHandler) handler(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestSlack_OpenView(t *testing.T) {
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
+	s.RegisterHandler("/message_limit_exceeded", func(rw http.ResponseWriter, r *http.Request) {
+		// When a workspace's message limit is exceeded we get a 429 without a Retry-After header
+		rw.WriteHeader(http.StatusTooManyRequests)
+		rw.Write([]byte("message_limit_exceeded"))
+	})
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	cases := []struct {
@@ -193,7 +201,7 @@ func TestSlack_OpenView(t *testing.T) {
 	}
 
 	h := &viewsHandler{}
-	http.HandleFunc("/views.open", h.handler)
+	s.RegisterHandler("/views.open", h.handler)
 	for _, c := range cases {
 		t.Run(c.caseName, func(t *testing.T) {
 			h.rawResponse = c.rawResp
@@ -222,7 +230,9 @@ func TestSlack_OpenView(t *testing.T) {
 }
 
 func TestSlack_View_PublishView(t *testing.T) {
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	cases := []struct {
@@ -356,7 +366,7 @@ func TestSlack_View_PublishView(t *testing.T) {
 	}
 
 	h := &viewsHandler{}
-	http.HandleFunc("/views.publish", h.handler)
+	s.RegisterHandler("/views.publish", h.handler)
 	for _, c := range cases {
 		t.Run(c.caseName, func(t *testing.T) {
 			h.rawResponse = c.rawResp
@@ -385,7 +395,9 @@ func TestSlack_View_PublishView(t *testing.T) {
 }
 
 func TestSlack_PushView(t *testing.T) {
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	cases := []struct {
@@ -532,7 +544,7 @@ func TestSlack_PushView(t *testing.T) {
 	}
 
 	h := &viewsHandler{}
-	http.HandleFunc("/views.push", h.handler)
+	s.RegisterHandler("/views.push", h.handler)
 	for _, c := range cases {
 		t.Run(c.caseName, func(t *testing.T) {
 			h.rawResponse = c.rawResp
@@ -561,7 +573,9 @@ func TestSlack_PushView(t *testing.T) {
 }
 
 func TestSlack_UpdateView(t *testing.T) {
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
+
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	cases := []struct {
@@ -712,7 +726,7 @@ func TestSlack_UpdateView(t *testing.T) {
 	}
 
 	h := &viewsHandler{}
-	http.HandleFunc("/views.update", h.handler)
+	s.RegisterHandler("/views.update", h.handler)
 	for _, c := range cases {
 		t.Run(c.caseName, func(t *testing.T) {
 			h.rawResponse = c.rawResp

--- a/webhooks_test.go
+++ b/webhooks_test.go
@@ -10,11 +10,12 @@ import (
 )
 
 func TestPostWebhook_OK(t *testing.T) {
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
 
 	var receivedPayload WebhookMessage
 
-	http.HandleFunc("/webhook", func(rw http.ResponseWriter, r *http.Request) {
+	s.RegisterHandler("/webhook", func(rw http.ResponseWriter, r *http.Request) {
 		rw.Header().Set("Content-Type", "application/json")
 
 		decoder := json.NewDecoder(r.Body)
@@ -50,9 +51,10 @@ func TestPostWebhook_OK(t *testing.T) {
 }
 
 func TestPostWebhook_NotOK(t *testing.T) {
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
 
-	http.HandleFunc("/webhook2", func(rw http.ResponseWriter, r *http.Request) {
+	s.RegisterHandler("/webhook2", func(rw http.ResponseWriter, r *http.Request) {
 		rw.WriteHeader(http.StatusInternalServerError)
 		rw.Write([]byte("500 - Something bad happened!"))
 	})
@@ -67,9 +69,10 @@ func TestPostWebhook_NotOK(t *testing.T) {
 }
 
 func TestPostWebhook_MessageLimitExceeded(t *testing.T) {
-	once.Do(startServer)
+	s := startServer()
+	defer s.Close()
 
-	http.HandleFunc("/message_limit_exceeded", func(rw http.ResponseWriter, r *http.Request) {
+	s.RegisterHandler("/message_limit_exceeded", func(rw http.ResponseWriter, r *http.Request) {
 		// When a workspace's message limit is exceeded we get a 429 without a Retry-After header
 		rw.WriteHeader(http.StatusTooManyRequests)
 		rw.Write([]byte("message_limit_exceeded"))


### PR DESCRIPTION
You couldn't run `go test -count=100 -failfast` because the use of `http.HandleFunc` meant that tests were sharing global state — to get around this, I've introduced `startServer()` which uses `mux` to isolate each test. This threw up some interesting cases, including some tests which relied on test data set up by previous tests.

To test this, you can run:

```
go test -shuffle=on -count=10 -failfast
```