### PR TITLE
RichTextSectionLinkElement Text omitempty

### DIFF
--- a/block_rich_text.go
+++ b/block_rich_text.go
@@ -376,7 +376,7 @@ func NewRichTextSectionEmojiElement(name string, skinTone int, style *RichTextSe
 type RichTextSectionLinkElement struct {
 	Type  RichTextSectionElementType `json:"type"`
 	URL   string                     `json:"url"`
-	Text  string                     `json:"text"`
+	Text  string                     `json:"text,omitempty"`
 	Style *RichTextSectionTextStyle  `json:"style,omitempty"`
 }
 


### PR DESCRIPTION
The `text` field in a `RichTextSectionLinkElement` is optional.  Sending an empty string results in a Slack error.  The field needs to be omitted if it is unused.

https://api.slack.com/reference/block-kit/blocks#link-element-type
