### PR TITLE
Add interaction callback parser

### DIFF
--- a/interactions.go
+++ b/interactions.go
@@ -3,6 +3,8 @@ package slack
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"net/http"
 )
 
 // InteractionType type of interactions
@@ -72,6 +74,24 @@ type InteractionCallback struct {
 
 type BlockActionStates struct {
 	Values map[string]map[string]BlockAction `json:"values"`
+}
+
+// InteractionCallbackParse parses the HTTP form value "payload" from r, unmarshals
+// it as JSON into an InteractionCallback, and returns the result.
+// It returns an error if the payload is missing or cannot be decoded.
+//
+// See https://github.com/slack-go/slack/issues/660 for context.
+func InteractionCallbackParse(r *http.Request) (InteractionCallback, error) {
+	payload := r.FormValue("payload")
+	if len(payload) == 0 {
+		return InteractionCallback{}, errors.New("payload is empty")
+	}
+
+	var ic InteractionCallback
+	if err := json.Unmarshal([]byte(payload), &ic); err != nil {
+		return InteractionCallback{}, err
+	}
+	return ic, nil
 }
 
 func (ic *InteractionCallback) MarshalJSON() ([]byte, error) {

--- a/interactions_test.go
+++ b/interactions_test.go
@@ -2,6 +2,9 @@ package slack
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -547,4 +550,75 @@ func TestInteractionCallback_In_Thread_Container_Marshal_And_Unmarshal(t *testin
 	actualJSON, err := json.Marshal(actual.Container)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedJSON, actualJSON)
+}
+
+func TestInteractionCallback_Parser(t *testing.T) {
+	payload := `{
+		"type": "block_actions",
+		"actions": [
+			{
+				"type": "multi_conversations_select",
+				"action_id": "multi_convos",
+				"block_id": "test123",
+				"selected_conversations": ["G12345"]
+			}
+		],
+		"container": {
+			"type": "view",
+			"view_id": "V12345"
+		},
+		"state": {
+			"values": {
+				"section_block_id": {
+					"multi_convos": {
+						"type": "multi_conversations_select",
+						"selected_conversations": ["G12345"]
+					}
+				},
+				"other_block_id": {
+					"other_action_id": {
+						"type": "plain_text_input",
+						"value": "test123"
+					}
+				}
+			}
+		}
+	}`
+
+	// create request body
+	body := url.Values{}
+	body.Set("payload", payload)
+
+	// create new request
+	req, err := http.NewRequest(http.MethodPost, "http://slack.example.org/interactions", strings.NewReader(body.Encode()))
+	assert.NoError(t, err)
+	assert.NotNil(t, req)
+
+	// without this header, the parser will not decode the payload
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	// parse payload from request
+	ic, err := InteractionCallbackParse(req)
+	assert.NoError(t, err)
+	assert.NotNil(t, ic)
+
+	// test parsed InteractionCallback payload
+	assert.Equal(t, ic.Type, InteractionTypeBlockActions)
+
+	assert.Equal(t, len(ic.ActionCallback.BlockActions), 1)
+	assert.Equal(t, ic.ActionCallback.BlockActions[0].ActionID, "multi_convos")
+	assert.Equal(t, ic.ActionCallback.BlockActions[0].BlockID, "test123")
+	assert.Equal(t, ic.ActionCallback.BlockActions[0].Type, ActionType(MultiOptTypeConversations))
+	assert.Equal(t, len(ic.ActionCallback.BlockActions[0].SelectedConversations), 1)
+	assert.Equal(t, ic.ActionCallback.BlockActions[0].SelectedConversations[0], "G12345")
+
+	assert.Equal(t, ic.Container.Type, "view")
+	assert.Equal(t, ic.Container.ViewID, "V12345")
+
+	assert.Equal(t, len(ic.BlockActionState.Values), 2)
+	assert.Equal(t, ic.BlockActionState.Values["section_block_id"]["multi_convos"].Type, ActionType(MultiOptTypeConversations))
+	assert.Equal(t, len(ic.BlockActionState.Values["section_block_id"]["multi_convos"].SelectedConversations), 1)
+	assert.Equal(t, ic.BlockActionState.Values["section_block_id"]["multi_convos"].SelectedConversations[0], "G12345")
+	assert.Equal(t, ic.BlockActionState.Values["other_block_id"]["other_action_id"].Type, ActionType(METPlainTextInput))
+	assert.Equal(t, ic.BlockActionState.Values["other_block_id"]["other_action_id"].Value, "test123")
 }


### PR DESCRIPTION
Resolves #660.

### Adds
- `InteractionCallbackParse` function
- Adds a test for the added function

For the sake of consistency, I took inspiration from the argument to [`SlashCommandParse`](https://github.com/snowboardit/slack/blob/28ba0ac9e25fd759fbc95530998cc678218622c3/slash.go#L29-L51) and implemented `InteractionCallbackParse` in a similar fashion. I believe this to be the _most_ idiomatic argument, since we are using the std lib, but I'm relatively new to Go so please let me know if there is a better and more idiomatic approach.

A counter-opinion to this choice is those who use a 3rd party HTTP request wrapper, like `fasthttp.Request` for those who use Fiber. Since it is a different shape than `http.Request`, the request will not be directly compatible with the argument to this function.