### PR TITLE
[chore]: support only the last 3 versions of go

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,6 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.18"
-          - "1.19"
-          - "1.20"
-          - "1.21"
           - "1.22"
           - "1.23"
           - "1.24"
@@ -33,7 +29,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.20"
+          go-version: "1.22"
           cache: false
       - uses: actions/checkout@v4
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,14 @@
 module github.com/slack-go/slack
 
-go 1.16
+go 1.22
+
+require (
+	github.com/go-test/deep v1.0.4
+	github.com/gorilla/websocket v1.4.2
+	github.com/stretchr/testify v1.2.2
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-test/deep v1.0.4
-	github.com/gorilla/websocket v1.4.2
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.2.2
 )


### PR DESCRIPTION
The go language only provides support for the two versions before the latest one, essentially supporting 3 versions.

I want to try moving to a world in which we do the same, with best effort on any versions beyond the past 2. It doesn't mean it won't work, but I'd prefer to keep things as simple as I can with the smallest possible area for support and maintenance.