### PR TITLE
feat: Add missing Blocks to UploadFileContextV2

### DIFF
--- a/files.go
+++ b/files.go
@@ -175,6 +175,7 @@ type UploadFileV2Parameters struct {
 	Filename        string
 	Title           string
 	InitialComment  string
+	Blocks          Blocks
 	Channel         string
 	ThreadTimestamp string
 	AltTxt          string
@@ -209,6 +210,7 @@ type FileSummary struct {
 
 type CompleteUploadExternalParameters struct {
 	Files           []FileSummary
+	Blocks          Blocks
 	Channel         string
 	InitialComment  string
 	ThreadTimestamp string
@@ -586,6 +588,13 @@ func (api *Client) CompleteUploadExternalContext(ctx context.Context, params Com
 	if params.InitialComment != "" {
 		values.Add("initial_comment", params.InitialComment)
 	}
+	if params.Blocks.BlockSet != nil && params.InitialComment == "" {
+		blocksBytes, err := json.Marshal(params.Blocks)
+		if err != nil {
+			return nil, err
+		}
+		values.Add("blocks", string(blocksBytes))
+	}
 	if params.ThreadTimestamp != "" {
 		values.Add("thread_ts", params.ThreadTimestamp)
 	}
@@ -649,6 +658,7 @@ func (api *Client) UploadFileV2Context(ctx context.Context, params UploadFileV2P
 		Channel:         params.Channel,
 		InitialComment:  params.InitialComment,
 		ThreadTimestamp: params.ThreadTimestamp,
+		Blocks:          params.Blocks,
 	})
 	if err != nil {
 		return nil, err

--- a/files_test.go
+++ b/files_test.go
@@ -478,6 +478,39 @@ func TestCompleteUploadExternalContext(t *testing.T) {
 			},
 		},
 		{
+			title: "Testing with blocks",
+			params: CompleteUploadExternalParameters{
+				Files: []FileSummary{
+					{
+						ID: "ID1",
+					},
+					{
+						ID:    "ID2",
+						Title: "Title2",
+					},
+				},
+				Channel:         "test-channel",
+				ThreadTimestamp: "1234567890.123456",
+				Blocks: Blocks{BlockSet: []Block{
+					NewSectionBlock(
+						NewTextBlockObject("plain_text", "This is a section block", false, false), nil, nil),
+				},
+				},
+			},
+			wantResponse: CompleteUploadExternalResponse{
+				Files: []FileSummary{
+					{
+						ID: "ID1",
+					},
+					{
+						ID:    "ID2",
+						Title: "Title2",
+					},
+				},
+				SlackResponse: SlackResponse{Ok: true},
+			},
+		},
+		{
 			title: "Testing with error",
 			params: CompleteUploadExternalParameters{
 				Files: []FileSummary{


### PR DESCRIPTION
see https://github.com/slack-go/slack/issues/1434

This adds the missing optional dependency for Blocks to the upload file method, allowing users to use rich blocks and buttons during the file upload process.

Confirmed that new tests are passing, as well as the Blocks functioning correctly in the app I'm currently developing.