### PR TITLE
patch(conversations.invite): updates `error` return value to include user IDs for failed invites

### DIFF
--- a/slacktest/data.go
+++ b/slacktest/data.go
@@ -238,6 +238,25 @@ var templateConversationJSON = `
 	}
 }`
 
+var templateConversationInviteFailureJSON = `
+{
+    "ok": false,
+    "error": "%s",
+    "errors": [
+        {
+            "user": "%s",
+            "ok": false,
+            "error": "%s"
+        },
+        {
+            "user": "%s",
+            "ok": false,
+            "error": "%s"
+        }
+    ]
+}
+`
+
 var defaultConversationJSON = fmt.Sprintf(templateConversationJSON, defaultConversationName,
 	nowAsJSONTime(), defaultBotID, defaultConversationName, "", "", 0, "", "", 0, 0)
 
@@ -250,6 +269,9 @@ var renameConversationJSON = fmt.Sprintf(templateConversationJSON, "newName",
 
 var inviteConversationJSON = fmt.Sprintf(templateConversationJSON, defaultConversationName,
 	nowAsJSONTime(), defaultBotID, defaultConversationName, "", "", 0, "", "", 0, 1)
+
+var inviteConversationFailureJSON = fmt.Sprintf(templateConversationInviteFailureJSON,
+	"user_not_found", "U111111", "user_not_found", "U222222", "cant_invite_self")
 
 const inviteSharedResponseJSON = `{
     "ok": true,


### PR DESCRIPTION
This PR updates the `api.Client.InviteUsersToConversationContext` `error` return value to include user IDs responsible for failures in a given request.  Here's the corresponding [issue](https://github.com/slack-go/slack/issues/1433) I filed.

I ran into some a seemingly unrelated test failure when spawning the `TestServer` on a background go-routine like the other test cases (see relevant output below).  Not sure if that's due to the use of an injected `Binder` for my particular test. Regardless, starting and stoping the `TestServer` in place seemed to resolve the issue, not sure if that's an anti-pattern in this particular context.  If so, I'm happy to address that issue, TIA!
```sh
=== RUN   TestRTMInfo                                                                                                                                                                                                                        
    rtm_test.go:35:                                                                                                                                                                                                                          
                Error Trace:    /Users/kevin/code/slack-go/go/slack/slacktest/rtm_test.go:35                                                                                                                                                 
                Error:          did not get connected event in time                                                                                                                                                                          
                Test:           TestRTMInfo 
```


