### PR TITLE
Support Slack Files in ImageBlockElement

### DIFF
--- a/block_element.go
+++ b/block_element.go
@@ -117,9 +117,10 @@ func (s UnknownBlockElement) ElementType() MessageElementType {
 //
 // More Information: https://api.slack.com/reference/messaging/block-elements#image
 type ImageBlockElement struct {
-	Type     MessageElementType `json:"type"`
-	ImageURL string             `json:"image_url"`
-	AltText  string             `json:"alt_text"`
+	Type      MessageElementType `json:"type"`
+	ImageURL  string             `json:"image_url"`
+	AltText   string             `json:"alt_text"`
+	SlackFile *SlackFileObject   `json:"slack_file,omitempty"`
 }
 
 // ElementType returns the type of the Element
@@ -137,6 +138,16 @@ func NewImageBlockElement(imageURL, altText string) *ImageBlockElement {
 		Type:     METImage,
 		ImageURL: imageURL,
 		AltText:  altText,
+	}
+}
+
+// NewImageBlockElementSlackFile returns a new instance of an image block element
+// TODO: BREAKING CHANGE - This should be combined with the function above
+func NewImageBlockElementSlackFile(slackFile *SlackFileObject, altText string) *ImageBlockElement {
+	return &ImageBlockElement{
+		Type:      METImage,
+		SlackFile: slackFile,
+		AltText:   altText,
 	}
 }
 

--- a/block_element_test.go
+++ b/block_element_test.go
@@ -14,6 +14,15 @@ func TestNewImageBlockElement(t *testing.T) {
 	assert.Equal(t, imageElement.AltText, "Location Pin Icon")
 }
 
+func TestNewImageBlockElementSlackFile(t *testing.T) {
+	slackFile := &SlackFileObject{URL: "https://api.slack.com/img/blocks/bkb_template_images/tripAgentLocationMarker.png"}
+	imageElement := NewImageBlockElementSlackFile(slackFile, "Location Pin Icon")
+
+	assert.Equal(t, string(imageElement.Type), "image")
+	assert.Contains(t, imageElement.SlackFile.URL, "tripAgentLocationMarker")
+	assert.Equal(t, imageElement.AltText, "Location Pin Icon")
+}
+
 func TestNewButtonBlockElement(t *testing.T) {
 	btnTxt := NewTextBlockObject("plain_text", "Next 2 Results", false, false)
 	btnElement := NewButtonBlockElement("test", "click_me_123", btnTxt)

--- a/block_image.go
+++ b/block_image.go
@@ -41,3 +41,15 @@ func NewImageBlock(imageURL, altText, blockID string, title *TextBlockObject) *I
 		Title:    title,
 	}
 }
+
+// NewImageBlockSlackFile returns an instance of a new Image Block type
+// TODO: BREAKING CHANGE - This should be combined with the function above
+func NewImageBlockSlackFile(slackFile *SlackFileObject, altText string, blockID string, title *TextBlockObject) *ImageBlock {
+	return &ImageBlock{
+		Type:      MBTImage,
+		SlackFile: slackFile,
+		AltText:   altText,
+		BlockID:   blockID,
+		Title:     title,
+	}
+}

--- a/block_image_test.go
+++ b/block_image_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewImageBlock(t *testing.T) {
+func TestImageURLForNewImageBlock(t *testing.T) {
 	imageText := NewTextBlockObject("plain_text", "Location", false, false)
 	imageBlock := NewImageBlock("https://api.slack.com/img/blocks/bkb_template_images/tripAgentLocationMarker.png", "Marker", "test", imageText)
 
@@ -17,4 +17,18 @@ func TestNewImageBlock(t *testing.T) {
 	assert.Equal(t, imageBlock.BlockID, "test")
 	assert.Contains(t, imageBlock.Title.Text, "Location")
 	assert.Contains(t, imageBlock.ImageURL, "tripAgentLocationMarker.png")
+}
+
+func TestSlackFileForNewImageBlock(t *testing.T) {
+	imageText := NewTextBlockObject("plain_text", "Location", false, false)
+	slackFile := &SlackFileObject{URL: "https://api.slack.com/img/blocks/bkb_template_images/tripAgentLocationMarker.png"}
+	imageBlock := NewImageBlockSlackFile(slackFile, "Marker", "test", imageText)
+
+	assert.Equal(t, imageBlock.BlockType(), MBTImage)
+	assert.Equal(t, string(imageBlock.Type), "image")
+	assert.Equal(t, imageBlock.Title.Type, "plain_text")
+	assert.Equal(t, imageBlock.ID(), "test")
+	assert.Equal(t, imageBlock.BlockID, "test")
+	assert.Contains(t, imageBlock.Title.Text, "Location")
+	assert.Contains(t, imageBlock.SlackFile.URL, "tripAgentLocationMarker.png")
 }


### PR DESCRIPTION
Supporting slack_file in ImageBlockElement: 1438
- Add support for slack_file to ImageBlockElement
- update tests involving ImageBlockElement where ImageURL is set as a function arg
- fix support for slack_file in ImageBlock
- update tests involving ImageBlock where ImageURL is set as a function arg
- Update examples for both ImageBlock and ImageBlockElement

This does change the function signature of both NewImageBlockElement and NewImageBlock. If you would instead prefer slack-file specific versions of each of these functions so that the existing function signature can remain the same, let me know.
