### PR TITLE
Unmarshal Timezone state changes / BlockAction for Timepicker

### DIFF
--- a/block.go
+++ b/block.go
@@ -52,6 +52,7 @@ type BlockAction struct {
 	SelectedDate          string              `json:"selected_date"`
 	SelectedTime          string              `json:"selected_time"`
 	SelectedDateTime      int64               `json:"selected_date_time"`
+	Timezone              string              `json:"timezone"`
 	InitialOption         OptionBlockObject   `json:"initial_option"`
 	InitialUser           string              `json:"initial_user"`
 	InitialChannel        string              `json:"initial_channel"`

--- a/interactions_test.go
+++ b/interactions_test.go
@@ -144,6 +144,19 @@ const (
 							"type": "conversations_select",
 							"value": "C1AB2C3DE"
 						}
+					},
+          "some_datetime": {
+            "value": {
+              "type": "datetimepicker",
+              "selected_date_time": null
+            }
+          },
+					"some_timepicker": {
+						"value": {
+							"type": "timepicker",
+							"timezone": "Europe/Berlin",
+							"initial_time": "12:00"
+						}
 					}
 				}
 			},
@@ -304,6 +317,19 @@ func TestViewSubmissionCallback(t *testing.T) {
 						"target_select": {
 							Type:  "conversations_select",
 							Value: "C1AB2C3DE",
+						},
+					},
+					"some_datetime": {
+						"value": BlockAction{
+							Type: "datetimepicker",
+							// No selected datetime!
+						},
+					},
+					"some_timepicker": {
+						"value": BlockAction{
+							Type:        "timepicker",
+							InitialTime: "12:00",
+							Timezone:    "Europe/Berlin",
 						},
 					},
 				},


### PR DESCRIPTION
This diff completes the rest of the implementation from #1448 , as it was accidentally missed out of the first PR.
The first PR allows the user to provide a Timezone to the slack model in blockkit, but this PR allows the application to read state updates from slack (i.e. read a changed timezone value)
