### PR TITLE
Make it possible to omit fields in the manifest Settings struct

### DIFF
--- a/manifests.go
+++ b/manifests.go
@@ -187,11 +187,11 @@ type Display struct {
 
 // Settings is a group of settings corresponding to the Settings section of the app config pages.
 type Settings struct {
-	AllowedIPAddressRanges []string           `json:"allowed_ip_address_ranges,omitempty" yaml:"allowed_ip_address_ranges,omitempty"`
-	EventSubscriptions     EventSubscriptions `json:"event_subscriptions,omitempty" yaml:"event_subscriptions,omitempty"`
-	Interactivity          Interactivity      `json:"interactivity,omitempty" yaml:"interactivity,omitempty"`
-	OrgDeployEnabled       bool               `json:"org_deploy_enabled,omitempty" yaml:"org_deploy_enabled,omitempty"`
-	SocketModeEnabled      bool               `json:"socket_mode_enabled,omitempty" yaml:"socket_mode_enabled,omitempty"`
+	AllowedIPAddressRanges []string            `json:"allowed_ip_address_ranges,omitempty" yaml:"allowed_ip_address_ranges,omitempty"`
+	EventSubscriptions     *EventSubscriptions `json:"event_subscriptions,omitempty" yaml:"event_subscriptions,omitempty"`
+	Interactivity          *Interactivity      `json:"interactivity,omitempty" yaml:"interactivity,omitempty"`
+	OrgDeployEnabled       bool                `json:"org_deploy_enabled,omitempty" yaml:"org_deploy_enabled,omitempty"`
+	SocketModeEnabled      bool                `json:"socket_mode_enabled,omitempty" yaml:"socket_mode_enabled,omitempty"`
 }
 
 // EventSubscriptions is a group of settings that describe the Events API configuration


### PR DESCRIPTION
This PR changes the `Interactivity` and `EventSubscriptions` fields in the manifest.go `Settings`  struct to pointers so they can be omitted if they're left empty.

This fixes #1460