### PR TITLE
Add support for title argument in CreateChannelCanvas method

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -1033,24 +1033,55 @@ func (api *Client) MarkConversationContext(ctx context.Context, channel, ts stri
 	return response.Err()
 }
 
+// createChannelCanvasParams contains arguments for CreateChannelCanvas method call.
+type createChannelCanvasParams struct {
+	title           string
+	documentContent *DocumentContent
+}
+
+// CreateChannelCanvasOption options for the CreateChannelCanvas method call.
+type CreateChannelCanvasOption func(*createChannelCanvasParams)
+
+// CreateChannelCanvasOptionTitle sets the title of the canvas.
+func CreateChannelCanvasOptionTitle(title string) CreateChannelCanvasOption {
+	return func(params *createChannelCanvasParams) {
+		params.title = title
+	}
+}
+
+// CreateChannelCanvasOptionDocumentContent sets the document content of the canvas.
+func CreateChannelCanvasOptionDocumentContent(documentContent DocumentContent) CreateChannelCanvasOption {
+	return func(params *createChannelCanvasParams) {
+		params.documentContent = &documentContent
+	}
+}
+
 // CreateChannelCanvas creates a new canvas in a channel.
 // For more details, see CreateChannelCanvasContext documentation.
-func (api *Client) CreateChannelCanvas(channel string, title string, documentContent DocumentContent) (string, error) {
-	return api.CreateChannelCanvasContext(context.Background(), channel, title, documentContent)
+func (api *Client) CreateChannelCanvas(channel string, documentContent DocumentContent, options ...CreateChannelCanvasOption) (string, error) {
+	return api.CreateChannelCanvasContext(context.Background(), channel, documentContent, options...)
 }
 
 // CreateChannelCanvasContext creates a new canvas in a channel with a custom context.
 // Slack API docs: https://api.slack.com/methods/conversations.canvases.create
-func (api *Client) CreateChannelCanvasContext(ctx context.Context, channel string, title string, documentContent DocumentContent) (string, error) {
+func (api *Client) CreateChannelCanvasContext(ctx context.Context, channel string, documentContent DocumentContent, options ...CreateChannelCanvasOption) (string, error) {
+	params := createChannelCanvasParams{
+		documentContent: &documentContent,
+	}
+
+	for _, opt := range options {
+		opt(&params)
+	}
+
 	values := url.Values{
 		"token":      {api.token},
 		"channel_id": {channel},
 	}
-	if title != "" {
-		values.Add("title", title)
+	if params.title != "" {
+		values.Add("title", params.title)
 	}
-	if documentContent.Type != "" {
-		documentContentJSON, err := json.Marshal(documentContent)
+	if params.documentContent != nil && params.documentContent.Type != "" {
+		documentContentJSON, err := json.Marshal(params.documentContent)
 		if err != nil {
 			return "", err
 		}

--- a/conversation.go
+++ b/conversation.go
@@ -1035,16 +1035,19 @@ func (api *Client) MarkConversationContext(ctx context.Context, channel, ts stri
 
 // CreateChannelCanvas creates a new canvas in a channel.
 // For more details, see CreateChannelCanvasContext documentation.
-func (api *Client) CreateChannelCanvas(channel string, documentContent DocumentContent) (string, error) {
-	return api.CreateChannelCanvasContext(context.Background(), channel, documentContent)
+func (api *Client) CreateChannelCanvas(channel string, title string, documentContent DocumentContent) (string, error) {
+	return api.CreateChannelCanvasContext(context.Background(), channel, title, documentContent)
 }
 
 // CreateChannelCanvasContext creates a new canvas in a channel with a custom context.
 // Slack API docs: https://api.slack.com/methods/conversations.canvases.create
-func (api *Client) CreateChannelCanvasContext(ctx context.Context, channel string, documentContent DocumentContent) (string, error) {
+func (api *Client) CreateChannelCanvasContext(ctx context.Context, channel string, title string, documentContent DocumentContent) (string, error) {
 	values := url.Values{
 		"token":      {api.token},
 		"channel_id": {channel},
+	}
+	if title != "" {
+		values.Add("title", title)
 	}
 	if documentContent.Type != "" {
 		documentContentJSON, err := json.Marshal(documentContent)

--- a/conversation_test.go
+++ b/conversation_test.go
@@ -978,7 +978,7 @@ func TestCreateChannelCanvas(t *testing.T) {
 		Markdown: "> channel canvas!",
 	}
 
-	canvasID, err := api.CreateChannelCanvas("C1234567890", "Test Canvas Title", documentContent)
+	canvasID, err := api.CreateChannelCanvas("C1234567890", documentContent)
 	if err != nil {
 		t.Errorf("Failed to create channel canvas: %v", err)
 		return
@@ -987,18 +987,22 @@ func TestCreateChannelCanvas(t *testing.T) {
 	assert.Equal(t, "F05RQ01LJU0", canvasID)
 }
 
-func TestCreateChannelCanvasWithEmptyTitle(t *testing.T) {
+func TestCreateChannelCanvasWithTitle(t *testing.T) {
 	once.Do(startServer)
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	documentContent := DocumentContent{
 		Type:     "markdown",
-		Markdown: "> channel canvas with empty title!",
+		Markdown: "> channel canvas with title!",
 	}
 
-	canvasID, err := api.CreateChannelCanvas("C1234567890", "", documentContent)
+	canvasID, err := api.CreateChannelCanvas(
+		"C1234567890",
+		documentContent,
+		CreateChannelCanvasOptionTitle("Test Canvas Title"),
+	)
 	if err != nil {
-		t.Errorf("Failed to create channel canvas with empty title: %v", err)
+		t.Errorf("Failed to create channel canvas with title: %v", err)
 		return
 	}
 

--- a/conversation_test.go
+++ b/conversation_test.go
@@ -957,6 +957,7 @@ func TestMarkConversation(t *testing.T) {
 
 func createChannelCanvasHandler(rw http.ResponseWriter, r *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
+
 	response, _ := json.Marshal(struct {
 		SlackResponse
 		CanvasID string `json:"canvas_id"`
@@ -977,9 +978,27 @@ func TestCreateChannelCanvas(t *testing.T) {
 		Markdown: "> channel canvas!",
 	}
 
-	canvasID, err := api.CreateChannelCanvas("C1234567890", documentContent)
+	canvasID, err := api.CreateChannelCanvas("C1234567890", "Test Canvas Title", documentContent)
 	if err != nil {
 		t.Errorf("Failed to create channel canvas: %v", err)
+		return
+	}
+
+	assert.Equal(t, "F05RQ01LJU0", canvasID)
+}
+
+func TestCreateChannelCanvasWithEmptyTitle(t *testing.T) {
+	once.Do(startServer)
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
+
+	documentContent := DocumentContent{
+		Type:     "markdown",
+		Markdown: "> channel canvas with empty title!",
+	}
+
+	canvasID, err := api.CreateChannelCanvas("C1234567890", "", documentContent)
+	if err != nil {
+		t.Errorf("Failed to create channel canvas with empty title: %v", err)
 		return
 	}
 


### PR DESCRIPTION
This PR adds support for `title` argument in the `CreateChannelCanvas` method.

Closes #1482.
