### PR TITLE
fix: ensure imageURL or SlackFile for ImageBlockElement

### DIFF
--- a/block_element.go
+++ b/block_element.go
@@ -118,7 +118,7 @@ func (s UnknownBlockElement) ElementType() MessageElementType {
 // More Information: https://api.slack.com/reference/messaging/block-elements#image
 type ImageBlockElement struct {
 	Type      MessageElementType `json:"type"`
-	ImageURL  string             `json:"image_url"`
+	ImageURL  *string            `json:"image_url,omitempty"`
 	AltText   string             `json:"alt_text"`
 	SlackFile *SlackFileObject   `json:"slack_file,omitempty"`
 }
@@ -136,7 +136,7 @@ func (s ImageBlockElement) MixedElementType() MixedElementType {
 func NewImageBlockElement(imageURL, altText string) *ImageBlockElement {
 	return &ImageBlockElement{
 		Type:     METImage,
-		ImageURL: imageURL,
+		ImageURL: &imageURL,
 		AltText:  altText,
 	}
 }

--- a/block_element_test.go
+++ b/block_element_test.go
@@ -10,7 +10,7 @@ func TestNewImageBlockElement(t *testing.T) {
 	imageElement := NewImageBlockElement("https://api.slack.com/img/blocks/bkb_template_images/tripAgentLocationMarker.png", "Location Pin Icon")
 
 	assert.Equal(t, string(imageElement.Type), "image")
-	assert.Contains(t, imageElement.ImageURL, "tripAgentLocationMarker")
+	assert.Contains(t, *imageElement.ImageURL, "tripAgentLocationMarker")
 	assert.Equal(t, imageElement.AltText, "Location Pin Icon")
 }
 
@@ -21,6 +21,7 @@ func TestNewImageBlockElementSlackFile(t *testing.T) {
 	assert.Equal(t, string(imageElement.Type), "image")
 	assert.Contains(t, imageElement.SlackFile.URL, "tripAgentLocationMarker")
 	assert.Equal(t, imageElement.AltText, "Location Pin Icon")
+	assert.Nil(t, imageElement.ImageURL, "ImageURL should be nil when SlackFile is provided")
 }
 
 func TestNewButtonBlockElement(t *testing.T) {

--- a/block_object_test.go
+++ b/block_object_test.go
@@ -15,7 +15,7 @@ func TestNewImageBlockObject(t *testing.T) {
 
 	assert.Equal(t, string(imageObject.Type), "image")
 	assert.Equal(t, imageObject.AltText, "Beagle")
-	assert.Contains(t, imageObject.ImageURL, "beagle.png")
+	assert.Contains(t, *imageObject.ImageURL, "beagle.png")
 }
 
 func TestNewTextBlockObject(t *testing.T) {

--- a/examples/blocks/blocks.go
+++ b/examples/blocks/blocks.go
@@ -483,7 +483,8 @@ func unmarshalExample() {
 				case slack.MixedElementImage:
 					// Assert the block's type to manipulate/extract values
 					imageBlockElem := elem.(*slack.ImageBlockElement)
-					imageBlockElem.ImageURL = "https://api.slack.com/img/blocks/bkb_template_images/profile_1.png"
+					imageURL := "https://api.slack.com/img/blocks/bkb_template_images/profile_1.png"
+					imageBlockElem.ImageURL = &imageURL
 					imageBlockElem.AltText = "MichaelScott"
 					respMixedElements = append(respMixedElements, imageBlockElem)
 				case slack.MixedElementText:


### PR DESCRIPTION
Fixes Issue https://github.com/slack-go/slack/issues/1486


##### Pull Request Guidelines

These are recommendations for pull requests.
They are strictly guidelines to help manage expectations.

##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### Examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.
