### PR TITLE
feat: add support for optional "loading_messages" parameter in SetAssistantThreadsStatus

### DIFF
--- a/assistant.go
+++ b/assistant.go
@@ -5,13 +5,15 @@ import (
 	"encoding/json"
 	"net/url"
 	"strconv"
+	"strings"
 )
 
 // AssistantThreadSetStatusParameters are the parameters for AssistantThreadSetStatus
 type AssistantThreadsSetStatusParameters struct {
-	ChannelID string `json:"channel_id"`
-	Status    string `json:"status"`
-	ThreadTS  string `json:"thread_ts"`
+	ChannelID       string   `json:"channel_id"`
+	Status          string   `json:"status"`
+	ThreadTS        string   `json:"thread_ts"`
+	LoadingMessages []string `json:"loading_messages,omitempty"`
 }
 
 // AssistantThreadSetTitleParameters are the parameters for AssistantThreadSetTitle
@@ -142,6 +144,10 @@ func (api *Client) SetAssistantThreadsStatusContext(ctx context.Context, params 
 
 	// Always send the status parameter, if empty, it will clear any existing status
 	values.Add("status", params.Status)
+
+	if len(params.LoadingMessages) > 0 {
+		values.Add("loading_messages", strings.Join(params.LoadingMessages, ","))
+	}
 
 	response := struct {
 		SlackResponse

--- a/assistant_test.go
+++ b/assistant_test.go
@@ -35,9 +35,10 @@ func TestSetAssistantThreadsStatus(t *testing.T) {
 	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
 
 	params := AssistantThreadsSetStatusParameters{
-		ChannelID: "CXXXXXXXX",
-		ThreadTS:  "1234567890.123456",
-		Status:    "updated status",
+		ChannelID:       "CXXXXXXXX",
+		ThreadTS:        "1234567890.123456",
+		Status:          "updated status",
+		LoadingMessages: []string{"updating status..."},
 	}
 
 	err := api.SetAssistantThreadsStatus(params)


### PR DESCRIPTION
## Summary of changes

This parameter can be used in assistant-enabled slack apps to display the app status progress under user created threads inside a channel. When not set, slack will show default states with generic text.

Setting the "Status" parameter to an empty string also cleans the loading messages.
Using a comma inside a loading status will cause the message to be split into two rotating statuses. This is a byproduct of the form parsing. The same happens with other APIs and also in the [call generator examples](https://docs.slack.dev/reference/methods/assistant.threads.setStatus/). 

Fixes #1487
