### PR TITLE
Add support for table blocks

### DIFF
--- a/block.go
+++ b/block.go
@@ -17,6 +17,7 @@ const (
 	MBTCall     MessageBlockType = "call"
 	MBTVideo    MessageBlockType = "video"
 	MBTMarkdown MessageBlockType = "markdown"
+	MBTTable    MessageBlockType = "table"
 )
 
 // Block defines an interface all block types should implement

--- a/block_table.go
+++ b/block_table.go
@@ -1,0 +1,55 @@
+package slack
+
+// TableBlock defines a block that lets you use a table to display your data.
+//
+// More Information: https://docs.slack.dev/reference/block-kit/blocks/table-block/
+type TableBlock struct {
+	Type           MessageBlockType   `json:"type"`
+	BlockID        string             `json:"block_id,omitempty"`
+	Rows           [][]*RichTextBlock `json:"rows"`
+	ColumnSettings []ColumnSetting    `json:"column_settings,omitempty"`
+}
+
+type ColumnAlignment string
+
+const (
+	ColumnAlignmentLeft   ColumnAlignment = "left"
+	ColumnAlignmentCenter ColumnAlignment = "center"
+	ColumnAlignmentRight  ColumnAlignment = "right"
+)
+
+type ColumnSetting struct {
+	Align     ColumnAlignment `json:"align"`
+	IsWrapped bool            `json:"is_wrapped"`
+}
+
+// BlockType returns the type of the block
+func (s TableBlock) BlockType() MessageBlockType {
+	return s.Type
+}
+
+// ID returns the ID of the block
+func (s TableBlock) ID() string {
+	return s.BlockID
+}
+
+// WithColumnSettings sets the column settings for the Table Block
+func (s *TableBlock) WithColumnSettings(columnSettings ...ColumnSetting) *TableBlock {
+	s.ColumnSettings = columnSettings
+	return s
+}
+
+// AddRow adds a new row of cells to the Table Block
+func (s *TableBlock) AddRow(cells ...*RichTextBlock) *TableBlock {
+	s.Rows = append(s.Rows, append([]*RichTextBlock{}, cells...))
+	return s
+}
+
+// NewTableBlock returns an instance of a Table Block type
+func NewTableBlock(blockID string) *TableBlock {
+	return &TableBlock{
+		Type:    MBTTable,
+		BlockID: blockID,
+		Rows:    make([][]*RichTextBlock, 0),
+	}
+}

--- a/block_table_test.go
+++ b/block_table_test.go
@@ -1,0 +1,138 @@
+package slack
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewTableBlock(t *testing.T) {
+	testPayload := `{
+		"type":"table",
+		"block_id":"test1",
+		"rows": [
+			[{
+				"type":"rich_text",
+				"elements": [
+					{
+						"type":"rich_text_section",
+						"elements": [
+							{
+								"type":"text",
+								"text":"Col1"
+							}
+						]
+					}
+				]
+			},
+			{
+				"type":"rich_text",
+				"elements": [
+					{
+						"type":"rich_text_section",
+						"elements": [
+							{
+								"type":"text",
+								"text":"Col2"
+							}
+						]
+					}
+				]
+			}],
+			[{
+				"type":"rich_text",
+				"elements": [
+					{
+						"type":"rich_text_section",
+						"elements": [
+							{
+								"type":"text",
+								"text":"Val1"
+							}
+						]
+					}
+				]
+			},
+			{
+				"type":"rich_text",
+				"elements": [
+					{
+						"type":"rich_text_section",
+						"elements": [
+							{
+								"type":"text",
+								"text":"Val2"
+							}
+						]
+					}
+				]
+			}]
+		]
+	}`
+
+	tableBlock := NewTableBlock("test1")
+
+	tableBlock.AddRow(&RichTextBlock{
+		Type: MBTRichText,
+		Elements: []RichTextElement{
+			&RichTextSection{
+				Type: RTESection,
+				Elements: []RichTextSectionElement{
+					&RichTextSectionTextElement{Type: RTSEText, Text: "Col1"},
+				},
+			},
+		},
+	}, &RichTextBlock{
+		Type: MBTRichText,
+		Elements: []RichTextElement{
+			&RichTextSection{
+				Type: RTESection,
+				Elements: []RichTextSectionElement{
+					&RichTextSectionTextElement{Type: RTSEText, Text: "Col2"},
+				},
+			},
+		},
+	})
+
+	tableBlock.AddRow(&RichTextBlock{
+		Type: MBTRichText,
+		Elements: []RichTextElement{
+			&RichTextSection{
+				Type: RTESection,
+				Elements: []RichTextSectionElement{
+					&RichTextSectionTextElement{Type: RTSEText, Text: "Val1"},
+				},
+			},
+		},
+	}, &RichTextBlock{
+		Type: MBTRichText,
+		Elements: []RichTextElement{
+			&RichTextSection{
+				Type: RTESection,
+				Elements: []RichTextSectionElement{
+					&RichTextSectionTextElement{Type: RTSEText, Text: "Val2"},
+				},
+			},
+		},
+	})
+
+	assert.Equal(t, tableBlock.BlockType(), MBTTable)
+	assert.Equal(t, string(tableBlock.Type), "table")
+	assert.Equal(t, tableBlock.BlockID, "test1")
+	assert.Equal(t, tableBlock.ID(), "test1")
+	assert.Equal(t, len(tableBlock.Rows), 2)
+	assert.Equal(t, len(tableBlock.ColumnSettings), 0)
+
+	// Check if marshalled payload matches expected JSON
+	marshalled, err := json.Marshal(tableBlock)
+	assert.NoError(t, err)
+
+	var expected, actual map[string]interface{}
+	err = json.Unmarshal([]byte(testPayload), &expected)
+	assert.NoError(t, err)
+	err = json.Unmarshal(marshalled, &actual)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
Through the slack docs it seems possible to build a table block type: https://docs.slack.dev/reference/block-kit/blocks/table-block/

This block type is not yet available through this library. This PR introduces this new block.

### Usage

```go
// initialise the table block
tableBlock := NewTableBlock("test1")

// build the table row by row
tableBlock.AddRow(cells ...*RichTextBlock)
tableBlock.AddRow(cells ...*RichTextBlock)
```
