### PR TITLE
docs(conversation): update GetConversationHistory function comments

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -958,13 +958,13 @@ type GetConversationHistoryResponse struct {
 	Messages []Message `json:"messages"`
 }
 
-// GetConversationHistory joins an existing conversation.
+// GetConversationHistory retrieves the message history from the specified conversation.
 // For more details, see GetConversationHistoryContext documentation.
 func (api *Client) GetConversationHistory(params *GetConversationHistoryParameters) (*GetConversationHistoryResponse, error) {
 	return api.GetConversationHistoryContext(context.Background(), params)
 }
 
-// GetConversationHistoryContext joins an existing conversation with a custom context.
+// GetConversationHistoryContext retrieves the message history from the specified conversation with a custom context.
 // Slack API docs: https://api.slack.com/methods/conversations.history
 func (api *Client) GetConversationHistoryContext(ctx context.Context, params *GetConversationHistoryParameters) (*GetConversationHistoryResponse, error) {
 	values := url.Values{"token": {api.token}, "channel": {params.ChannelID}}


### PR DESCRIPTION
The function comments for `GetConversationHistory` and `GetConversationHistoryContext` were updated to more accurately describe their purpose. The previous comments incorrectly stated that the functions "join an existing conversation" when they actually retrieve message history from a conversation, probably from copying the comments from the `Join` functions
