### PR TITLE
feat: handle unmarshal table block

### DIFF
--- a/block_conv.go
+++ b/block_conv.go
@@ -77,6 +77,8 @@ func (b *Blocks) UnmarshalJSON(data []byte) error {
 			block = &CallBlock{}
 		case "video":
 			block = &VideoBlock{}
+		case "table":
+			block = &TableBlock{}
 		default:
 			block = &UnknownBlock{}
 		}


### PR DESCRIPTION
##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

done

Extending the unmarshal logic missed in https://github.com/slack-go/slack/pull/1490

Before
<img width="440" height="135" alt="image" src="https://github.com/user-attachments/assets/96d144ac-e862-4dec-9f7f-c0117863a217" />

After
<img width="434" height="130" alt="image" src="https://github.com/user-attachments/assets/55dc9b18-0f55-49e0-be3a-12b36425a7fb" />