### PR TITLE
Add RecordChannel to conversation Properties

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -68,12 +68,13 @@ type Purpose struct {
 	LastSet JSONTime `json:"last_set"`
 }
 
-// Properties contains the Canvas associated to the channel.
+// Properties contains additional fields that appear based on the context of the conversation
 type Properties struct {
-	Canvas              Canvas       `json:"canvas"`
-	PostingRestrictedTo RestrictedTo `json:"posting_restricted_to"`
-	Tabs                []Tab        `json:"tabs"`
-	ThreadsRestrictedTo RestrictedTo `json:"threads_restricted_to"`
+	Canvas              Canvas        `json:"canvas"`
+	PostingRestrictedTo RestrictedTo  `json:"posting_restricted_to"`
+	Tabs                []Tab         `json:"tabs"`
+	ThreadsRestrictedTo RestrictedTo  `json:"threads_restricted_to"`
+	RecordChannel       RecordChannel `json:"record_channel"`
 }
 
 type RestrictedTo struct {
@@ -91,6 +92,13 @@ type Canvas struct {
 	FileId       string `json:"file_id"`
 	IsEmpty      bool   `json:"is_empty"`
 	QuipThreadId string `json:"quip_thread_id"`
+}
+
+type RecordChannel struct {
+	RecordID          string `json:"record_id"`
+	RecordType        string `json:"record_type"`
+	RecordLabel       string `json:"record_label"`
+	RecordLabelPlural string `json:"record_label_plural"`
 }
 
 type GetUsersInConversationParameters struct {

--- a/conversation_test.go
+++ b/conversation_test.go
@@ -325,6 +325,88 @@ func TestCreateChannelWithCanvas(t *testing.T) {
 	assertChannelWithCanvas(t, channel)
 }
 
+// Channel with RecordChannel
+var channelWithRecordChannel = `{
+    "id": "C024BE91L",
+    "name": "fun",
+    "is_channel": true,
+    "created": 1360782804,
+    "creator": "U024BE7LH",
+    "is_archived": false,
+    "is_general": false,
+    "members": [
+        "U024BE7LH"
+    ],
+    "topic": {
+        "value": "Fun times",
+        "creator": "U024BE7LV",
+        "last_set": 1369677212
+    },
+    "purpose": {
+        "value": "This channel is for fun",
+        "creator": "U024BE7LH",
+        "last_set": 1360782804
+    },
+    "is_member": true,
+    "last_read": "1401383885.000061",
+    "unread_count": 0,
+    "unread_count_display": 0,
+	"properties": {
+        "record_channel": {
+            "record_id": "S:00D0000000000000EAU:0010000000000000AA2",
+            "record_type": "Account",
+            "record_label": "Account",
+            "record_label_plural": "Accounts"
+        }
+    }
+}`
+
+func unmarshalChannelWithRecordChannel(j string) (*Channel, error) {
+	channel := &Channel{}
+	if err := json.Unmarshal([]byte(j), &channel); err != nil {
+		return nil, err
+	}
+	return channel, nil
+}
+
+func TestChannelWithRecordChannel(t *testing.T) {
+	channel, err := unmarshalChannelWithRecordChannel(channelWithRecordChannel)
+	assert.Nil(t, err)
+	assertChannelWithRecordChannel(t, channel)
+}
+
+func assertChannelWithRecordChannel(t *testing.T, channel *Channel) {
+	assertSimpleChannel(t, channel)
+	assert.Equal(t, "S:00D0000000000000EAU:0010000000000000AA2", channel.Properties.RecordChannel.RecordID)
+	assert.Equal(t, "Account", channel.Properties.RecordChannel.RecordType)
+	assert.Equal(t, "Account", channel.Properties.RecordChannel.RecordLabel)
+	assert.Equal(t, "Accounts", channel.Properties.RecordChannel.RecordLabelPlural)
+}
+
+func TestCreateChannelWithRecordChannel(t *testing.T) {
+	channel := &Channel{}
+	channel.ID = "C024BE91L"
+	channel.Name = "fun"
+	channel.IsChannel = true
+	channel.Created = JSONTime(1360782804)
+	channel.Creator = "U024BE7LH"
+	channel.IsArchived = false
+	channel.IsGeneral = false
+	channel.IsMember = true
+	channel.LastRead = "1401383885.000061"
+	channel.UnreadCount = 0
+	channel.UnreadCountDisplay = 0
+	channel.Properties = &Properties{
+		RecordChannel: RecordChannel{
+			RecordID:          "S:00D0000000000000EAU:0010000000000000AA2",
+			RecordType:        "Account",
+			RecordLabel:       "Account",
+			RecordLabelPlural: "Accounts",
+		},
+	}
+	assertChannelWithRecordChannel(t, channel)
+}
+
 // IM
 var simpleIM = `{
     "id": "D024BFF1M",


### PR DESCRIPTION

Closes #1512.

This PR adds a `RecordChannel` field to `Properties`. I've also updated the comment to clarify that not all properties are Canvas-related.

My use case: I want to be able to read this field after making a call to `GetConversationInfo` / `GetConversationInfoContext`.

The `record_channel` object is documented here: https://docs.slack.dev/reference/objects/conversation-object/. The full structure is not documented as far as I can tell, but I've based my `RecordChannel` struct on a real-world production API response.

I noticed some inconsistencies in the existing SDK when capitalising "ID" (`canvas.FileId` vs `EventAuthorization.TeamID`). I've favoured `RecordID` in my addition, in line with the Go style guide.

Unit tests are included and `make pr-prep` passes without error.