### PR TITLE
adds postephemeral handler to slacktest to audit outgoing messages

### DIFF
--- a/slacktest/handlers.go
+++ b/slacktest/handlers.go
@@ -221,20 +221,19 @@ func (sts *Server) postMessageHandler(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
-// handle chat.postEphemeralMessage
+// handle chat.postEphemeral
 func (sts *Server) postEphemeralHandler(w http.ResponseWriter, r *http.Request) {
-	serverAddr := r.Context().Value(ServerBotHubNameContextKey).(string)
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		msg := fmt.Sprintf("error reading body: %s", err.Error())
-		log.Printf(msg)
+		log.Printf("%s", msg)
 		http.Error(w, msg, http.StatusInternalServerError)
 		return
 	}
 	values, vErr := url.ParseQuery(string(data))
 	if vErr != nil {
 		msg := fmt.Sprintf("Unable to decode query params: %s", vErr.Error())
-		log.Printf(msg)
+		log.Printf("%s", msg)
 		http.Error(w, msg, http.StatusInternalServerError)
 		return
 	}
@@ -269,7 +268,7 @@ func (sts *Server) postEphemeralHandler(w http.ResponseWriter, r *http.Request) 
 		decoded, err := url.QueryUnescape(attachments)
 		if err != nil {
 			msg := fmt.Sprintf("Unable to decode attachments: %s", err.Error())
-			log.Printf(msg)
+			log.Printf("%s", msg)
 			http.Error(w, msg, http.StatusInternalServerError)
 			return
 		}
@@ -277,7 +276,7 @@ func (sts *Server) postEphemeralHandler(w http.ResponseWriter, r *http.Request) 
 		aJErr := json.Unmarshal([]byte(decoded), &attaches)
 		if aJErr != nil {
 			msg := fmt.Sprintf("Unable to decode attachments string to json: %s", aJErr.Error())
-			log.Printf(msg)
+			log.Printf("%s", msg)
 			http.Error(w, msg, http.StatusInternalServerError)
 			return
 		}
@@ -288,7 +287,7 @@ func (sts *Server) postEphemeralHandler(w http.ResponseWriter, r *http.Request) 
 		decoded, err := url.QueryUnescape(blocks)
 		if err != nil {
 			msg := fmt.Sprintf("Unable to decode blocks: %s", err.Error())
-			log.Printf(msg)
+			log.Printf("%s", msg)
 			http.Error(w, msg, http.StatusInternalServerError)
 			return
 		}
@@ -296,7 +295,7 @@ func (sts *Server) postEphemeralHandler(w http.ResponseWriter, r *http.Request) 
 		dbJErr := json.Unmarshal([]byte(decoded), &decodedBlocks)
 		if dbJErr != nil {
 			msg := fmt.Sprintf("Unable to decode blocks string to json: %s", dbJErr.Error())
-			log.Printf(msg)
+			log.Printf("%s", msg)
 			http.Error(w, msg, http.StatusInternalServerError)
 			return
 		}
@@ -305,11 +304,11 @@ func (sts *Server) postEphemeralHandler(w http.ResponseWriter, r *http.Request) 
 	jsonMessage, jsonErr := json.Marshal(m)
 	if jsonErr != nil {
 		msg := fmt.Sprintf("Unable to marshal message: %s", jsonErr.Error())
-		log.Printf(msg)
+		log.Printf("%s", msg)
 		http.Error(w, msg, http.StatusInternalServerError)
 		return
 	}
-	go sts.queueForWebsocket(string(jsonMessage), serverAddr)
+	sts.SendToWebsocket(string(jsonMessage))
 	_ = json.NewEncoder(w).Encode(resp)
 }
 

--- a/slacktest/handlers_test.go
+++ b/slacktest/handlers_test.go
@@ -32,6 +32,16 @@ func TestPostMessageHandler(t *testing.T) {
 	assert.NotEmpty(t, tstamp, "timestamp should not be empty")
 }
 
+func TestPostEphemeralHandler(t *testing.T) {
+	s := NewTestServer()
+	go s.Start()
+
+	client := slack.New("ABCDEFG", slack.OptionAPIURL(s.GetAPIURL()))
+	tstamp, err := client.PostEphemeral("fake_channel", "fake_user", slack.MsgOptionText("some ephemeral text", false), slack.MsgOptionPostMessageParameters(slack.PostMessageParameters{}))
+	assert.NoError(t, err, "should not error out")
+	assert.NotEmpty(t, tstamp, "timestamp should not be empty")
+}
+
 func TestServerCreateConversationHandler(t *testing.T) {
 	s := NewTestServer()
 	go s.Start()

--- a/slacktest/handlers_test.go
+++ b/slacktest/handlers_test.go
@@ -40,6 +40,8 @@ func TestPostEphemeralHandler(t *testing.T) {
 	tstamp, err := client.PostEphemeral("fake_channel", "fake_user", slack.MsgOptionText("some ephemeral text", false), slack.MsgOptionPostMessageParameters(slack.PostMessageParameters{}))
 	assert.NoError(t, err, "should not error out")
 	assert.NotEmpty(t, tstamp, "timestamp should not be empty")
+
+	assert.True(t, s.SawOutgoingMessage("some ephemeral text"))
 }
 
 func TestServerCreateConversationHandler(t *testing.T) {

--- a/slacktest/server.go
+++ b/slacktest/server.go
@@ -50,6 +50,7 @@ func NewTestServer(custom ...Binder) *Server {
 	s.Handle("/rtm.start", rtmStartHandler)
 	s.Handle("/rtm.connect", RTMConnectHandler)
 	s.Handle("/chat.postMessage", s.postMessageHandler)
+	s.Handle("/chat.postEphemeral", s.postEphemeralHandler)
 	s.Handle("/conversations.create", createConversationHandler)
 	s.Handle("/conversations.setTopic", setConversationTopicHandler)
 	s.Handle("/conversations.setPurpose", setConversationPurposeHandler)


### PR DESCRIPTION
Bringing from https://github.com/slack-go/slack/pull/1105 to this one.

Closes #1105.