### PR TITLE
feat: Add `focus_on_load` support for remaining block elements

### DIFF
--- a/block_element.go
+++ b/block_element.go
@@ -248,6 +248,7 @@ type SelectBlockElement struct {
 	Filter                       *SelectBlockElementFilter `json:"filter,omitempty"`
 	MinQueryLength               *int                      `json:"min_query_length,omitempty"`
 	Confirm                      *ConfirmationBlockObject  `json:"confirm,omitempty"`
+	FocusOnLoad                  bool                      `json:"focus_on_load,omitempty"`
 }
 
 // SelectBlockElementFilter allows to filter select element conversation options by type.
@@ -339,6 +340,7 @@ type MultiSelectBlockElement struct {
 	MinQueryLength       *int                      `json:"min_query_length,omitempty"`
 	MaxSelectedItems     *int                      `json:"max_selected_items,omitempty"`
 	Confirm              *ConfirmationBlockObject  `json:"confirm,omitempty"`
+	FocusOnLoad          bool                      `json:"focus_on_load,omitempty"`
 }
 
 // ElementType returns the type of the Element
@@ -459,6 +461,7 @@ type DatePickerBlockElement struct {
 	Placeholder *TextBlockObject         `json:"placeholder,omitempty"`
 	InitialDate string                   `json:"initial_date,omitempty"`
 	Confirm     *ConfirmationBlockObject `json:"confirm,omitempty"`
+	FocusOnLoad bool                     `json:"focus_on_load,omitempty"`
 }
 
 // ElementType returns the type of the Element
@@ -486,6 +489,7 @@ type TimePickerBlockElement struct {
 	InitialTime string                   `json:"initial_time,omitempty"`
 	Confirm     *ConfirmationBlockObject `json:"confirm,omitempty"`
 	Timezone    string                   `json:"timezone,omitempty"`
+	FocusOnLoad bool                     `json:"focus_on_load,omitempty"`
 }
 
 // ElementType returns the type of the Element
@@ -597,6 +601,7 @@ type PlainTextInputBlockElement struct {
 	MinLength            int                   `json:"min_length,omitempty"`
 	MaxLength            int                   `json:"max_length,omitempty"`
 	DispatchActionConfig *DispatchActionConfig `json:"dispatch_action_config,omitempty"`
+	FocusOnLoad          bool                  `json:"focus_on_load,omitempty"`
 }
 
 type DispatchActionConfig struct {
@@ -684,6 +689,7 @@ type CheckboxGroupsBlockElement struct {
 	Options        []*OptionBlockObject     `json:"options"`
 	InitialOptions []*OptionBlockObject     `json:"initial_options,omitempty"`
 	Confirm        *ConfirmationBlockObject `json:"confirm,omitempty"`
+	FocusOnLoad    bool                     `json:"focus_on_load,omitempty"`
 }
 
 // ElementType returns the type of the Element
@@ -710,6 +716,7 @@ type RadioButtonsBlockElement struct {
 	Options       []*OptionBlockObject     `json:"options"`
 	InitialOption *OptionBlockObject       `json:"initial_option,omitempty"`
 	Confirm       *ConfirmationBlockObject `json:"confirm,omitempty"`
+	FocusOnLoad   bool                     `json:"focus_on_load,omitempty"`
 }
 
 // ElementType returns the type of the Element
@@ -740,6 +747,7 @@ type NumberInputBlockElement struct {
 	MinValue             string                `json:"min_value,omitempty"`
 	MaxValue             string                `json:"max_value,omitempty"`
 	DispatchActionConfig *DispatchActionConfig `json:"dispatch_action_config,omitempty"`
+	FocusOnLoad          bool                  `json:"focus_on_load,omitempty"`
 }
 
 // ElementType returns the type of the Element


### PR DESCRIPTION
This adds `focus_on_load` to the remaining Slack BlockKit Block Elements that support it:
* `{static,external,users,conversations,channels}_select`
* `multi_{static,external,users,conversations,channels}_select`
* `datepicker`
* `timepicker`
* `plain_text_input`
* `checkboxes`
* `radio_buttons`
* `number_input`

Closes: #1518
