### PR TITLE
feat: add PlainText and PreviewPlainText fields to File struct

### DIFF
--- a/files.go
+++ b/files.go
@@ -95,6 +95,9 @@ type File struct {
 	From    []EmailFileUserInfo `json:"from"`
 	Cc      []EmailFileUserInfo `json:"cc"`
 	Headers EmailHeaders        `json:"headers"`
+
+	PlainText        string `json:"plain_text"`
+	PreviewPlainText string `json:"preview_plain_text"`
 }
 
 type EmailFileUserInfo struct {


### PR DESCRIPTION
## Summary

Add `plain_text` and `preview_plain_text` JSON fields to the `File` struct for email file objects.

When emails are sent to Slack channels via the [Send emails to Slack](https://slack.com/help/articles/206819278-Send-emails-to-Slack) integration, the API returns these fields containing the email body as plain text. Currently they are silently discarded during unmarshalling.

Fixes #1521

## Changes

Two fields added to `File` in `files.go`:

```go
PlainText        string `json:"plain_text"`
PreviewPlainText string `json:"preview_plain_text"`
```

This follows the same pattern as #1370 (`Subject`, `To`, `From`, `Cc`) and #1380 (`Headers`).

## Test plan

- `make pr-prep` passes (fmt, lint, test-race, test-integration)