### PR TITLE
fix(users): correct JSON tag typo in UserProfile.Skype field

### DIFF
--- a/users.go
+++ b/users.go
@@ -25,7 +25,7 @@ type UserProfile struct {
 	DisplayNameNormalized  string                              `json:"display_name_normalized"`
 	AvatarHash             string                              `json:"avatar_hash"`
 	Email                  string                              `json:"email,omitempty"`
-	Skype                  string                              `json:"skyp,omitempty"`
+	Skype                  string                              `json:"skype,omitempty"`
 	Phone                  string                              `json:"phone,omitempty"`
 	Image24                string                              `json:"image_24"`
 	Image32                string                              `json:"image_32"`


### PR DESCRIPTION
## Summary

The JSON tag for the `Skype` field in `UserProfile` (`users.go`) was `"skyp"` instead of `"skype"`, preventing the field from being properly populated when unmarshalling Slack API responses.

- The correct tag `"skype"` is already used in `slackevents/inner_events.go`
- Matches [Slack API documentation](https://docs.slack.dev/reference/objects/user-object)

Fixes #1523