### PR TITLE
feat(users): add missing fields to User, UserProfile, and EnterpriseUser

### DIFF
--- a/users.go
+++ b/users.go
@@ -40,6 +40,7 @@ type UserProfile struct {
 	Title                   string                              `json:"title,omitempty"`
 	BotID                   string                              `json:"bot_id,omitempty"`
 	ApiAppID                string                              `json:"api_app_id,omitempty"`
+	AlwaysActive            bool                                `json:"always_active,omitempty"`
 	StatusText              string                              `json:"status_text,omitempty"`
 	StatusEmoji             string                              `json:"status_emoji,omitempty"`
 	StatusEmojiDisplayInfo  []UserProfileStatusEmojiDisplayInfo `json:"status_emoji_display_info,omitempty"`
@@ -142,7 +143,6 @@ type User struct {
 	TwoFactorType          *string        `json:"two_factor_type"`
 	HasFiles               bool           `json:"has_files"`
 	Presence               string         `json:"presence"`
-	AlwaysActive           bool           `json:"always_active,omitempty"`
 	Locale                 string         `json:"locale"`
 	Updated                JSONTime       `json:"updated"`
 	WhoCanShareContactCard string         `json:"who_can_share_contact_card,omitempty"`

--- a/users.go
+++ b/users.go
@@ -17,32 +17,39 @@ const (
 
 // UserProfile contains all the information details of a given user
 type UserProfile struct {
-	FirstName              string                              `json:"first_name,omitempty"`
-	LastName               string                              `json:"last_name,omitempty"`
-	RealName               string                              `json:"real_name"`
-	RealNameNormalized     string                              `json:"real_name_normalized"`
-	DisplayName            string                              `json:"display_name"`
-	DisplayNameNormalized  string                              `json:"display_name_normalized"`
-	AvatarHash             string                              `json:"avatar_hash"`
-	Email                  string                              `json:"email,omitempty"`
-	Skype                  string                              `json:"skyp,omitempty"`
-	Phone                  string                              `json:"phone,omitempty"`
-	Image24                string                              `json:"image_24"`
-	Image32                string                              `json:"image_32"`
-	Image48                string                              `json:"image_48"`
-	Image72                string                              `json:"image_72"`
-	Image192               string                              `json:"image_192"`
-	Image512               string                              `json:"image_512"`
-	ImageOriginal          string                              `json:"image_original,omitempty"`
-	Title                  string                              `json:"title,omitempty"`
-	BotID                  string                              `json:"bot_id,omitempty"`
-	ApiAppID               string                              `json:"api_app_id,omitempty"`
-	StatusText             string                              `json:"status_text,omitempty"`
-	StatusEmoji            string                              `json:"status_emoji,omitempty"`
-	StatusEmojiDisplayInfo []UserProfileStatusEmojiDisplayInfo `json:"status_emoji_display_info,omitempty"`
-	StatusExpiration       int                                 `json:"status_expiration,omitempty"`
-	Team                   string                              `json:"team"`
-	Fields                 UserProfileCustomFields             `json:"fields,omitempty"`
+	FirstName               string                              `json:"first_name,omitempty"`
+	LastName                string                              `json:"last_name,omitempty"`
+	RealName                string                              `json:"real_name"`
+	RealNameNormalized      string                              `json:"real_name_normalized"`
+	DisplayName             string                              `json:"display_name"`
+	DisplayNameNormalized   string                              `json:"display_name_normalized"`
+	Pronouns                string                              `json:"pronouns,omitempty"`
+	AvatarHash              string                              `json:"avatar_hash"`
+	Email                   string                              `json:"email,omitempty"`
+	Skype                   string                              `json:"skyp,omitempty"`
+	Phone                   string                              `json:"phone,omitempty"`
+	Image24                 string                              `json:"image_24"`
+	Image32                 string                              `json:"image_32"`
+	Image48                 string                              `json:"image_48"`
+	Image72                 string                              `json:"image_72"`
+	Image192                string                              `json:"image_192"`
+	Image512                string                              `json:"image_512"`
+	Image1024               string                              `json:"image_1024,omitempty"`
+	ImageOriginal           string                              `json:"image_original,omitempty"`
+	IsCustomImage           bool                                `json:"is_custom_image,omitempty"`
+	Title                   string                              `json:"title,omitempty"`
+	BotID                   string                              `json:"bot_id,omitempty"`
+	ApiAppID                string                              `json:"api_app_id,omitempty"`
+	StatusText              string                              `json:"status_text,omitempty"`
+	StatusEmoji             string                              `json:"status_emoji,omitempty"`
+	StatusEmojiDisplayInfo  []UserProfileStatusEmojiDisplayInfo `json:"status_emoji_display_info,omitempty"`
+	StatusExpiration        int                                 `json:"status_expiration,omitempty"`
+	StatusTextCanonical     string                              `json:"status_text_canonical,omitempty"`
+	HuddleState             string                              `json:"huddle_state,omitempty"`
+	HuddleStateExpirationTS int                                 `json:"huddle_state_expiration_ts,omitempty"`
+	StartDate               string                              `json:"start_date,omitempty"`
+	Team                    string                              `json:"team"`
+	Fields                  UserProfileCustomFields             `json:"fields,omitempty"`
 }
 
 type UserProfileStatusEmojiDisplayInfo struct {
@@ -111,33 +118,35 @@ type UserProfileCustomField struct {
 
 // User contains all the information of a user
 type User struct {
-	ID                string         `json:"id"`
-	TeamID            string         `json:"team_id"`
-	Name              string         `json:"name"`
-	Deleted           bool           `json:"deleted"`
-	Color             string         `json:"color"`
-	RealName          string         `json:"real_name"`
-	TZ                string         `json:"tz,omitempty"`
-	TZLabel           string         `json:"tz_label"`
-	TZOffset          int            `json:"tz_offset"`
-	Profile           UserProfile    `json:"profile"`
-	IsBot             bool           `json:"is_bot"`
-	IsAdmin           bool           `json:"is_admin"`
-	IsOwner           bool           `json:"is_owner"`
-	IsPrimaryOwner    bool           `json:"is_primary_owner"`
-	IsRestricted      bool           `json:"is_restricted"`
-	IsUltraRestricted bool           `json:"is_ultra_restricted"`
-	IsStranger        bool           `json:"is_stranger"`
-	IsAppUser         bool           `json:"is_app_user"`
-	IsInvitedUser     bool           `json:"is_invited_user"`
-	IsEmailConfirmed  bool           `json:"is_email_confirmed"`
-	Has2FA            bool           `json:"has_2fa"`
-	TwoFactorType     *string        `json:"two_factor_type"`
-	HasFiles          bool           `json:"has_files"`
-	Presence          string         `json:"presence"`
-	Locale            string         `json:"locale"`
-	Updated           JSONTime       `json:"updated"`
-	Enterprise        EnterpriseUser `json:"enterprise_user,omitempty"`
+	ID                     string         `json:"id"`
+	TeamID                 string         `json:"team_id"`
+	Name                   string         `json:"name"`
+	Deleted                bool           `json:"deleted"`
+	Color                  string         `json:"color"`
+	RealName               string         `json:"real_name"`
+	TZ                     string         `json:"tz,omitempty"`
+	TZLabel                string         `json:"tz_label"`
+	TZOffset               int            `json:"tz_offset"`
+	Profile                UserProfile    `json:"profile"`
+	IsBot                  bool           `json:"is_bot"`
+	IsAdmin                bool           `json:"is_admin"`
+	IsOwner                bool           `json:"is_owner"`
+	IsPrimaryOwner         bool           `json:"is_primary_owner"`
+	IsRestricted           bool           `json:"is_restricted"`
+	IsUltraRestricted      bool           `json:"is_ultra_restricted"`
+	IsStranger             bool           `json:"is_stranger"`
+	IsAppUser              bool           `json:"is_app_user"`
+	IsInvitedUser          bool           `json:"is_invited_user"`
+	IsEmailConfirmed       bool           `json:"is_email_confirmed"`
+	Has2FA                 bool           `json:"has_2fa"`
+	TwoFactorType          *string        `json:"two_factor_type"`
+	HasFiles               bool           `json:"has_files"`
+	Presence               string         `json:"presence"`
+	AlwaysActive           bool           `json:"always_active,omitempty"`
+	Locale                 string         `json:"locale"`
+	Updated                JSONTime       `json:"updated"`
+	WhoCanShareContactCard string         `json:"who_can_share_contact_card,omitempty"`
+	Enterprise             EnterpriseUser `json:"enterprise_user,omitempty"`
 }
 
 // UserPresence contains details about a user online status
@@ -176,6 +185,7 @@ type EnterpriseUser struct {
 	EnterpriseName string   `json:"enterprise_name"`
 	IsAdmin        bool     `json:"is_admin"`
 	IsOwner        bool     `json:"is_owner"`
+	IsPrimaryOwner bool     `json:"is_primary_owner"`
 	Teams          []string `json:"teams"`
 }
 

--- a/users_test.go
+++ b/users_test.go
@@ -793,6 +793,7 @@ func TestUserUnmarshalJSON(t *testing.T) {
 			"image_1024": "https://example.com/1024.png",
 			"image_original": "https://example.com/original.png",
 			"is_custom_image": true,
+			"always_active": true,
 			"status_text": "Working",
 			"status_emoji": ":computer:",
 			"status_expiration": 0,
@@ -816,7 +817,6 @@ func TestUserUnmarshalJSON(t *testing.T) {
 		"has_2fa": false,
 		"has_files": true,
 		"presence": "active",
-		"always_active": false,
 		"locale": "en-US",
 		"updated": 1648596421,
 		"who_can_share_contact_card": "EVERYONE",
@@ -840,11 +840,11 @@ func TestUserUnmarshalJSON(t *testing.T) {
 	if user.WhoCanShareContactCard != "EVERYONE" {
 		t.Fatalf(`user.WhoCanShareContactCard = %q, want "EVERYONE"`, user.WhoCanShareContactCard)
 	}
-	if user.AlwaysActive != false {
-		t.Fatalf(`user.AlwaysActive = %v, want false`, user.AlwaysActive)
-	}
 
 	// Verify UserProfile fields
+	if user.Profile.AlwaysActive != true {
+		t.Fatalf(`user.Profile.AlwaysActive = %v, want true`, user.Profile.AlwaysActive)
+	}
 	if user.Profile.Pronouns != "they/them" {
 		t.Fatalf(`user.Profile.Pronouns = %q, want "they/them"`, user.Profile.Pronouns)
 	}

--- a/users_test.go
+++ b/users_test.go
@@ -761,6 +761,134 @@ func TestGetUsersHandlesRateLimit(t *testing.T) {
 	}
 }
 
+func TestUserUnmarshalJSON(t *testing.T) {
+	userJSON := `{
+		"id": "U12345678",
+		"team_id": "T12345678",
+		"name": "testuser",
+		"deleted": false,
+		"color": "4bbe2e",
+		"real_name": "Test User",
+		"tz": "America/Los_Angeles",
+		"tz_label": "Pacific Daylight Time",
+		"tz_offset": -25200,
+		"profile": {
+			"first_name": "Test",
+			"last_name": "User",
+			"real_name": "Test User",
+			"real_name_normalized": "Test User",
+			"display_name": "testuser",
+			"display_name_normalized": "testuser",
+			"pronouns": "they/them",
+			"avatar_hash": "abc123",
+			"email": "test@example.com",
+			"skype": "",
+			"phone": "+1234567890",
+			"image_24": "https://example.com/24.png",
+			"image_32": "https://example.com/32.png",
+			"image_48": "https://example.com/48.png",
+			"image_72": "https://example.com/72.png",
+			"image_192": "https://example.com/192.png",
+			"image_512": "https://example.com/512.png",
+			"image_1024": "https://example.com/1024.png",
+			"image_original": "https://example.com/original.png",
+			"is_custom_image": true,
+			"status_text": "Working",
+			"status_emoji": ":computer:",
+			"status_expiration": 0,
+			"status_text_canonical": "",
+			"huddle_state": "in_a_huddle",
+			"huddle_state_expiration_ts": 1648596421,
+			"start_date": "2022-01-01",
+			"team": "T12345678",
+			"fields": []
+		},
+		"is_bot": false,
+		"is_admin": true,
+		"is_owner": false,
+		"is_primary_owner": false,
+		"is_restricted": false,
+		"is_ultra_restricted": false,
+		"is_stranger": false,
+		"is_app_user": false,
+		"is_invited_user": false,
+		"is_email_confirmed": true,
+		"has_2fa": false,
+		"has_files": true,
+		"presence": "active",
+		"always_active": false,
+		"locale": "en-US",
+		"updated": 1648596421,
+		"who_can_share_contact_card": "EVERYONE",
+		"enterprise_user": {
+			"id": "E12345678",
+			"enterprise_id": "E99999999",
+			"enterprise_name": "Test Enterprise",
+			"is_admin": false,
+			"is_owner": false,
+			"is_primary_owner": false,
+			"teams": ["T12345678", "T87654321"]
+		}
+	}`
+
+	var user User
+	if err := json.Unmarshal([]byte(userJSON), &user); err != nil {
+		t.Fatalf("Failed to unmarshal User: %s", err)
+	}
+
+	// Verify User fields
+	if user.WhoCanShareContactCard != "EVERYONE" {
+		t.Fatalf(`user.WhoCanShareContactCard = %q, want "EVERYONE"`, user.WhoCanShareContactCard)
+	}
+	if user.AlwaysActive != false {
+		t.Fatalf(`user.AlwaysActive = %v, want false`, user.AlwaysActive)
+	}
+
+	// Verify UserProfile fields
+	if user.Profile.Pronouns != "they/them" {
+		t.Fatalf(`user.Profile.Pronouns = %q, want "they/them"`, user.Profile.Pronouns)
+	}
+	if user.Profile.Image1024 != "https://example.com/1024.png" {
+		t.Fatalf(`user.Profile.Image1024 = %q, want "https://example.com/1024.png"`, user.Profile.Image1024)
+	}
+	if user.Profile.IsCustomImage != true {
+		t.Fatalf(`user.Profile.IsCustomImage = %v, want true`, user.Profile.IsCustomImage)
+	}
+	if user.Profile.HuddleState != "in_a_huddle" {
+		t.Fatalf(`user.Profile.HuddleState = %q, want "in_a_huddle"`, user.Profile.HuddleState)
+	}
+	if user.Profile.HuddleStateExpirationTS != 1648596421 {
+		t.Fatalf(`user.Profile.HuddleStateExpirationTS = %d, want 1648596421`, user.Profile.HuddleStateExpirationTS)
+	}
+	if user.Profile.StartDate != "2022-01-01" {
+		t.Fatalf(`user.Profile.StartDate = %q, want "2022-01-01"`, user.Profile.StartDate)
+	}
+	if user.Profile.StatusTextCanonical != "" {
+		t.Fatalf(`user.Profile.StatusTextCanonical = %q, want ""`, user.Profile.StatusTextCanonical)
+	}
+
+	// Verify EnterpriseUser fields
+	if user.Enterprise.IsPrimaryOwner != false {
+		t.Fatalf(`user.Enterprise.IsPrimaryOwner = %v, want false`, user.Enterprise.IsPrimaryOwner)
+	}
+	if user.Enterprise.EnterpriseID != "E99999999" {
+		t.Fatalf(`user.Enterprise.EnterpriseID = %q, want "E99999999"`, user.Enterprise.EnterpriseID)
+	}
+
+	// Verify round-trip: marshal and unmarshal should produce the same result
+	marshaled, err := json.Marshal(user)
+	if err != nil {
+		t.Fatalf("Failed to marshal User: %s", err)
+	}
+	var roundTripped User
+	if err := json.Unmarshal(marshaled, &roundTripped); err != nil {
+		t.Fatalf("Failed to unmarshal round-tripped User: %s", err)
+	}
+	if !reflect.DeepEqual(user, roundTripped) {
+		t.Fatal("Round-trip marshal/unmarshal produced different result")
+	}
+}
+
 func TestGetUsersReturnsServerError(t *testing.T) {
 	http.DefaultServeMux = new(http.ServeMux)
 	http.HandleFunc("/users.list", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Add fields documented in the [Slack API User object reference](https://docs.slack.dev/reference/objects/user-object) that were missing from the main structs in `users.go`.

Some of these fields (e.g. `who_can_share_contact_card`, `status_text_canonical`) were already present in `slackevents/inner_events.go` but missing from the main package, causing inconsistency.

### Added fields

**`User`:**
- `who_can_share_contact_card` (string)
- `always_active` (bool)

**`UserProfile`:**
- `pronouns` (string)
- `image_1024` (string)
- `is_custom_image` (bool)
- `status_text_canonical` (string)
- `huddle_state` (string)
- `huddle_state_expiration_ts` (int)
- `start_date` (string)

**`EnterpriseUser`:**
- `is_primary_owner` (bool)

All new fields use `omitempty` to avoid breaking existing behavior.

Fixes #1525
Related to #1459