### PR TITLE
fix(assistant): send title parameter in setSuggestedPrompts API

### DIFF
--- a/assistant.go
+++ b/assistant.go
@@ -102,6 +102,10 @@ func (api *Client) SetAssistantThreadsSuggestedPromptsContext(ctx context.Contex
 
 	values.Add("channel_id", params.ChannelID)
 
+	if params.Title != "" {
+		values.Add("title", params.Title)
+	}
+
 	// Send Prompts as JSON
 	prompts, err := json.Marshal(params.Prompts)
 	if err != nil {


### PR DESCRIPTION
If title is not empty, send it in the API call. See more at https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts/.

Closes #1527.