### PR TITLE
feat(work-objects): add Work Objects support for chat unfurl, entity details, and events

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -1,0 +1,132 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+)
+
+// EntityPresentDetailsParameters contains the parameters for entity.presentDetails API method
+type EntityPresentDetailsParameters struct {
+	TriggerID        string                 `json:"trigger_id"`
+	Metadata         *EntityDetailsMetadata `json:"metadata,omitempty"`
+	Error            *EntityDetailsError    `json:"error,omitempty"`
+	UserAuthRequired bool                   `json:"user_auth_required,omitempty"`
+	UserAuthURL      string                 `json:"user_auth_url,omitempty"`
+	UserAuthMessage  string                 `json:"user_auth_message,omitempty"`
+}
+
+// EntityDetailsMetadata represents the metadata for entity details
+type EntityDetailsMetadata struct {
+	EntityType    string                 `json:"entity_type"`
+	URL           string                 `json:"url,omitempty"`
+	ExternalRef   WorkObjectExternalRef  `json:"external_ref,omitempty"`
+	EntityPayload map[string]interface{} `json:"entity_payload"`
+}
+
+// EntityDetailsError represents an error response for entity details
+type EntityDetailsError struct {
+	Status        string                `json:"status"`
+	CustomTitle   string                `json:"custom_title,omitempty"`
+	CustomMessage string                `json:"custom_message,omitempty"`
+	MessageFormat string                `json:"message_format,omitempty"`
+	Actions       []EntityDetailsAction `json:"actions,omitempty"`
+}
+
+// EntityDetailsAction represents an action button in entity details error
+type EntityDetailsAction struct {
+	Text            string                        `json:"text"`
+	ActionID        string                        `json:"action_id"`
+	Value           string                        `json:"value,omitempty"`
+	Style           string                        `json:"style,omitempty"`
+	URL             string                        `json:"url,omitempty"`
+	ProcessingState *EntityDetailsProcessingState `json:"processing_state,omitempty"`
+}
+
+// EntityDetailsProcessingState represents the processing state of an action
+type EntityDetailsProcessingState struct {
+	Enabled bool `json:"enabled"`
+}
+
+// EntityPresentDetailsResponse represents the response from entity.presentDetails
+type EntityPresentDetailsResponse struct {
+	SlackResponse
+}
+
+// EntityPresentDetails presents entity details in the flexpane
+// For more details, see EntityPresentDetailsContext documentation.
+func (api *Client) EntityPresentDetails(params EntityPresentDetailsParameters) error {
+	return api.EntityPresentDetailsContext(context.Background(), params)
+}
+
+// EntityPresentDetailsContext presents entity details in the flexpane with a custom context.
+// Slack API docs: https://docs.slack.dev/reference/methods/entity.presentDetails
+func (api *Client) EntityPresentDetailsContext(ctx context.Context, params EntityPresentDetailsParameters) error {
+	values := url.Values{
+		"token":      {api.token},
+		"trigger_id": {params.TriggerID},
+	}
+
+	// Add metadata if provided
+	if params.Metadata != nil {
+		metadataJSON, err := json.Marshal(params.Metadata)
+		if err != nil {
+			return err
+		}
+		values.Set("metadata", string(metadataJSON))
+	}
+
+	// Add error if provided
+	if params.Error != nil {
+		errorJSON, err := json.Marshal(params.Error)
+		if err != nil {
+			return err
+		}
+		values.Set("error", string(errorJSON))
+	}
+
+	// Add user auth parameters if provided
+	if params.UserAuthRequired {
+		values.Set("user_auth_required", "true")
+	}
+	if params.UserAuthURL != "" {
+		values.Set("user_auth_url", params.UserAuthURL)
+	}
+	if params.UserAuthMessage != "" {
+		values.Set("user_auth_message", params.UserAuthMessage)
+	}
+
+	response := &EntityPresentDetailsResponse{}
+	err := api.postMethod(ctx, "entity.presentDetails", values, response)
+	if err != nil {
+		return err
+	}
+
+	return response.Err()
+}
+
+// EntityPresentDetailsWithMetadata is a convenience method for presenting entity details with metadata
+func (api *Client) EntityPresentDetailsWithMetadata(triggerID string, metadata EntityDetailsMetadata) error {
+	return api.EntityPresentDetailsContext(context.Background(), EntityPresentDetailsParameters{
+		TriggerID: triggerID,
+		Metadata:  &metadata,
+	})
+}
+
+// EntityPresentDetailsWithError is a convenience method for presenting entity details with an error
+func (api *Client) EntityPresentDetailsWithError(triggerID string, errPayload EntityDetailsError) error {
+	return api.EntityPresentDetailsContext(context.Background(), EntityPresentDetailsParameters{
+		TriggerID: triggerID,
+		Error:     &errPayload,
+	})
+}
+
+// EntityPresentDetailsWithAuth is a convenience method for presenting entity details with authentication required
+func (api *Client) EntityPresentDetailsWithAuth(triggerID, authURL, authMessage string) error {
+	return api.EntityPresentDetailsContext(context.Background(), EntityPresentDetailsParameters{
+		TriggerID:        triggerID,
+		UserAuthRequired: true,
+		UserAuthURL:      authURL,
+		UserAuthMessage:  authMessage,
+	})
+}

--- a/entity_test.go
+++ b/entity_test.go
@@ -1,0 +1,322 @@
+package slack
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestEntityPresentDetailsParameters(t *testing.T) {
+	// Test basic parameter structure
+	params := EntityPresentDetailsParameters{
+		TriggerID: "1234567890123.1234567890123.abcdef01234567890abcdef012345689",
+		Metadata: &EntityDetailsMetadata{
+			EntityType: "slack#/entities/file",
+			URL:        "https://example.com/document/123",
+			ExternalRef: WorkObjectExternalRef{
+				ID:   "123",
+				Type: "document",
+			},
+			EntityPayload: map[string]interface{}{
+				"title":       "Test Document",
+				"description": "A test document for Work Objects",
+				"status":      "active",
+			},
+		},
+	}
+
+	// Test JSON marshaling
+	jsonData, err := json.Marshal(params)
+	if err != nil {
+		t.Errorf("Failed to marshal EntityPresentDetailsParameters: %v", err)
+	}
+
+	// Test JSON unmarshaling
+	var unmarshaled EntityPresentDetailsParameters
+	err = json.Unmarshal(jsonData, &unmarshaled)
+	if err != nil {
+		t.Errorf("Failed to unmarshal EntityPresentDetailsParameters: %v", err)
+	}
+
+	// Verify the data
+	if unmarshaled.TriggerID != params.TriggerID {
+		t.Errorf("Expected trigger_id '%s', got '%s'", params.TriggerID, unmarshaled.TriggerID)
+	}
+
+	if unmarshaled.Metadata.EntityType != params.Metadata.EntityType {
+		t.Errorf("Expected entity_type '%s', got '%s'", params.Metadata.EntityType, unmarshaled.Metadata.EntityType)
+	}
+
+	if unmarshaled.Metadata.ExternalRef.ID != params.Metadata.ExternalRef.ID {
+		t.Errorf("Expected external_ref.id '%s', got '%s'", params.Metadata.ExternalRef.ID, unmarshaled.Metadata.ExternalRef.ID)
+	}
+}
+
+func TestEntityDetailsError(t *testing.T) {
+	// Test error structure
+	errorObj := EntityDetailsError{
+		Status:        "restricted",
+		CustomTitle:   "Access Denied",
+		CustomMessage: "You do not have permission to view this entity.",
+		MessageFormat: "markdown",
+		Actions: []EntityDetailsAction{
+			{
+				Text:     "Request Access",
+				ActionID: "request_access",
+				Value:    "entity_123",
+				Style:    "primary",
+				URL:      "https://example.com/request-access",
+				ProcessingState: &EntityDetailsProcessingState{
+					Enabled: true,
+				},
+			},
+		},
+	}
+
+	// Test JSON marshaling
+	jsonData, err := json.Marshal(errorObj)
+	if err != nil {
+		t.Errorf("Failed to marshal EntityDetailsError: %v", err)
+	}
+
+	// Test JSON unmarshaling
+	var unmarshaled EntityDetailsError
+	err = json.Unmarshal(jsonData, &unmarshaled)
+	if err != nil {
+		t.Errorf("Failed to unmarshal EntityDetailsError: %v", err)
+	}
+
+	// Verify the data
+	if unmarshaled.Status != errorObj.Status {
+		t.Errorf("Expected status '%s', got '%s'", errorObj.Status, unmarshaled.Status)
+	}
+
+	if unmarshaled.CustomTitle != errorObj.CustomTitle {
+		t.Errorf("Expected custom_title '%s', got '%s'", errorObj.CustomTitle, unmarshaled.CustomTitle)
+	}
+
+	if len(unmarshaled.Actions) != 1 {
+		t.Errorf("Expected 1 action, got %d", len(unmarshaled.Actions))
+	}
+
+	if len(unmarshaled.Actions) > 0 {
+		action := unmarshaled.Actions[0]
+		if action.Text != "Request Access" {
+			t.Errorf("Expected action text 'Request Access', got '%s'", action.Text)
+		}
+		if action.ProcessingState == nil || !action.ProcessingState.Enabled {
+			t.Error("Expected processing state to be enabled")
+		}
+	}
+}
+
+func TestEntityPresentDetailsWithMetadata(t *testing.T) {
+	http.DefaultServeMux = new(http.ServeMux)
+	http.HandleFunc("/entity.presentDetails", func(rw http.ResponseWriter, r *http.Request) {
+		rw.Header().Set("Content-Type", "application/json")
+
+		// Verify the request
+		if r.Method != "POST" {
+			t.Errorf("Expected POST request, got %s", r.Method)
+		}
+
+		// Parse form data
+		err := r.ParseForm()
+		if err != nil {
+			t.Errorf("Failed to parse form: %v", err)
+			return
+		}
+
+		// Check required fields
+		triggerID := r.FormValue("trigger_id")
+		if triggerID != "1234567890123.1234567890123.abcdef01234567890abcdef012345689" {
+			t.Errorf("Expected trigger_id '1234567890123.1234567890123.abcdef01234567890abcdef012345689', got '%s'", triggerID)
+		}
+
+		// Check metadata
+		metadataStr := r.FormValue("metadata")
+		if metadataStr == "" {
+			t.Error("Expected metadata to be present")
+		} else {
+			var metadata EntityDetailsMetadata
+			err := json.Unmarshal([]byte(metadataStr), &metadata)
+			if err != nil {
+				t.Errorf("Failed to unmarshal metadata: %v", err)
+			}
+			if metadata.EntityType != "slack#/entities/file" {
+				t.Errorf("Expected entity_type 'slack#/entities/file', got '%s'", metadata.EntityType)
+			}
+		}
+
+		// Return success response
+		response := EntityPresentDetailsResponse{
+			SlackResponse: SlackResponse{Ok: true},
+		}
+		jsonResponse, _ := json.Marshal(response)
+		rw.Write(jsonResponse)
+	})
+
+	once.Do(startServer)
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
+
+	metadata := EntityDetailsMetadata{
+		EntityType: "slack#/entities/file",
+		URL:        "https://example.com/document/123",
+		ExternalRef: WorkObjectExternalRef{
+			ID:   "123",
+			Type: "document",
+		},
+		EntityPayload: map[string]interface{}{
+			"title":       "Test Document",
+			"description": "A test document for Work Objects",
+		},
+	}
+
+	err := api.EntityPresentDetailsWithMetadata("1234567890123.1234567890123.abcdef01234567890abcdef012345689", metadata)
+	if err != nil {
+		t.Errorf("EntityPresentDetailsWithMetadata returned error: %v", err)
+	}
+}
+
+func TestEntityPresentDetailsWithError(t *testing.T) {
+	http.DefaultServeMux = new(http.ServeMux)
+	http.HandleFunc("/entity.presentDetails", func(rw http.ResponseWriter, r *http.Request) {
+		rw.Header().Set("Content-Type", "application/json")
+
+		// Parse form data
+		err := r.ParseForm()
+		if err != nil {
+			t.Errorf("Failed to parse form: %v", err)
+			return
+		}
+
+		// Check error field
+		errorStr := r.FormValue("error")
+		if errorStr == "" {
+			t.Error("Expected error to be present")
+		} else {
+			var errorObj EntityDetailsError
+			err := json.Unmarshal([]byte(errorStr), &errorObj)
+			if err != nil {
+				t.Errorf("Failed to unmarshal error: %v", err)
+			}
+			if errorObj.Status != "restricted" {
+				t.Errorf("Expected error status 'restricted', got '%s'", errorObj.Status)
+			}
+		}
+
+		// Return success response
+		response := EntityPresentDetailsResponse{
+			SlackResponse: SlackResponse{Ok: true},
+		}
+		jsonResponse, _ := json.Marshal(response)
+		rw.Write(jsonResponse)
+	})
+
+	once.Do(startServer)
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
+
+	errorObj := EntityDetailsError{
+		Status:        "restricted",
+		CustomTitle:   "Access Denied",
+		CustomMessage: "You do not have permission to view this entity.",
+		Actions: []EntityDetailsAction{
+			{
+				Text:     "Request Access",
+				ActionID: "request_access",
+				Style:    "primary",
+			},
+		},
+	}
+
+	err := api.EntityPresentDetailsWithError("1234567890123.1234567890123.abcdef01234567890abcdef012345689", errorObj)
+	if err != nil {
+		t.Errorf("EntityPresentDetailsWithError returned error: %v", err)
+	}
+}
+
+func TestEntityPresentDetailsWithAuth(t *testing.T) {
+	http.DefaultServeMux = new(http.ServeMux)
+	http.HandleFunc("/entity.presentDetails", func(rw http.ResponseWriter, r *http.Request) {
+		rw.Header().Set("Content-Type", "application/json")
+
+		// Parse form data
+		err := r.ParseForm()
+		if err != nil {
+			t.Errorf("Failed to parse form: %v", err)
+			return
+		}
+
+		// Check auth fields
+		userAuthRequired := r.FormValue("user_auth_required")
+		if userAuthRequired != "true" {
+			t.Errorf("Expected user_auth_required 'true', got '%s'", userAuthRequired)
+		}
+
+		userAuthURL := r.FormValue("user_auth_url")
+		if userAuthURL != "https://example.com/auth" {
+			t.Errorf("Expected user_auth_url 'https://example.com/auth', got '%s'", userAuthURL)
+		}
+
+		userAuthMessage := r.FormValue("user_auth_message")
+		if userAuthMessage != "Please authenticate to view this entity." {
+			t.Errorf("Expected user_auth_message 'Please authenticate to view this entity.', got '%s'", userAuthMessage)
+		}
+
+		// Return success response
+		response := EntityPresentDetailsResponse{
+			SlackResponse: SlackResponse{Ok: true},
+		}
+		jsonResponse, _ := json.Marshal(response)
+		rw.Write(jsonResponse)
+	})
+
+	once.Do(startServer)
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
+
+	err := api.EntityPresentDetailsWithAuth(
+		"1234567890123.1234567890123.abcdef01234567890abcdef012345689",
+		"https://example.com/auth",
+		"Please authenticate to view this entity.",
+	)
+	if err != nil {
+		t.Errorf("EntityPresentDetailsWithAuth returned error: %v", err)
+	}
+}
+
+func TestEntityPresentDetailsContext(t *testing.T) {
+	http.DefaultServeMux = new(http.ServeMux)
+	http.HandleFunc("/entity.presentDetails", func(rw http.ResponseWriter, r *http.Request) {
+		rw.Header().Set("Content-Type", "application/json")
+
+		// Return success response
+		response := EntityPresentDetailsResponse{
+			SlackResponse: SlackResponse{Ok: true},
+		}
+		jsonResponse, _ := json.Marshal(response)
+		rw.Write(jsonResponse)
+	})
+
+	once.Do(startServer)
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
+
+	params := EntityPresentDetailsParameters{
+		TriggerID: "1234567890123.1234567890123.abcdef01234567890abcdef012345689",
+		Metadata: &EntityDetailsMetadata{
+			EntityType: "slack#/entities/task",
+			URL:        "https://example.com/task/456",
+			ExternalRef: WorkObjectExternalRef{
+				ID: "456",
+			},
+			EntityPayload: map[string]interface{}{
+				"title":  "Test Task",
+				"status": "in_progress",
+			},
+		},
+	}
+
+	err := api.EntityPresentDetails(params)
+	if err != nil {
+		t.Errorf("EntityPresentDetails returned error: %v", err)
+	}
+}

--- a/metadata.go
+++ b/metadata.go
@@ -5,3 +5,34 @@ type SlackMetadata struct {
 	EventType    string         `json:"event_type"`
 	EventPayload map[string]any `json:"event_payload"`
 }
+
+// Work Object entity type constants.
+// See https://docs.slack.dev/messaging/work-objects/
+const (
+	EntityTypeTask        = "slack#/entities/task"
+	EntityTypeFile        = "slack#/entities/file"
+	EntityTypeItem        = "slack#/entities/item"
+	EntityTypeIncident    = "slack#/entities/incident"
+	EntityTypeContentItem = "slack#/entities/content_item"
+)
+
+// WorkObjectExternalRef represents an external reference for a Work Object
+type WorkObjectExternalRef struct {
+	ID   string `json:"id"`
+	Type string `json:"type,omitempty"`
+}
+
+// WorkObjectEntity represents a single Work Object entity
+type WorkObjectEntity struct {
+	AppUnfurlURL  string                 `json:"app_unfurl_url,omitempty"`
+	URL           string                 `json:"url"`
+	ExternalRef   WorkObjectExternalRef  `json:"external_ref"`
+	EntityType    string                 `json:"entity_type"`
+	EntityPayload map[string]interface{} `json:"entity_payload"`
+}
+
+// WorkObjectMetadata represents the metadata for Work Objects
+// Used in chat.unfurl and chat.postMessage for Work Objects support
+type WorkObjectMetadata struct {
+	Entities []WorkObjectEntity `json:"entities"`
+}

--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -1130,6 +1130,36 @@ type UserStatusChangedEvent struct {
 	EventTS string `json:"event_ts"`
 }
 
+// EntityDetailsRequestedEvent is sent when entity details are requested
+// This event is fired when a user clicks on a Work Object link and Slack requests
+// details about the entity from your app.
+type EntityDetailsRequestedEvent struct {
+	Type         string                            `json:"type"`
+	User         string                            `json:"user"`
+	ExternalRef  EntityDetailsRequestedExternalRef `json:"external_ref"`
+	EntityURL    string                            `json:"entity_url"`
+	Link         EntityDetailsRequestedLink        `json:"link"`
+	AppUnfurlURL string                            `json:"app_unfurl_url"`
+	EventTS      string                            `json:"event_ts"`
+	TriggerID    string                            `json:"trigger_id"`
+	UserLocale   string                            `json:"user_locale"`
+	Channel      string                            `json:"channel,omitempty"`
+	MessageTs    string                            `json:"message_ts,omitempty"`
+	ThreadTs     string                            `json:"thread_ts,omitempty"`
+}
+
+// EntityDetailsRequestedExternalRef represents the external reference in entity_details_requested event
+type EntityDetailsRequestedExternalRef struct {
+	ID   string `json:"id"`
+	Type string `json:"type,omitempty"`
+}
+
+// EntityDetailsRequestedLink represents the link information in entity_details_requested event
+type EntityDetailsRequestedLink struct {
+	URL    string `json:"url"`
+	Domain string `json:"domain"`
+}
+
 type Actor struct {
 	ID          string `json:"id"`
 	Name        string `json:"name"`
@@ -1339,6 +1369,8 @@ const (
 	UserStatusChanged = EventsAPIType("user_status_changed")
 	// WorkflowStepExecute Happens, if a workflow step of your app is invoked
 	WorkflowStepExecute = EventsAPIType("workflow_step_execute")
+	// EntityDetailsRequested is sent when entity details are requested
+	EntityDetailsRequested = EventsAPIType("entity_details_requested")
 )
 
 // EventsAPIInnerEventMapping maps INNER Event API events to their corresponding struct
@@ -1425,4 +1457,5 @@ var EventsAPIInnerEventMapping = map[EventsAPIType]interface{}{
 	UserHuddleChanged:             UserHuddleChangedEvent{},
 	UserProfileChanged:            UserProfileChangedEvent{},
 	UserStatusChanged:             UserStatusChangedEvent{},
+	EntityDetailsRequested:        EntityDetailsRequestedEvent{},
 }

--- a/slackevents/inner_events_test.go
+++ b/slackevents/inner_events_test.go
@@ -3055,3 +3055,142 @@ func TestAppHomeOpenedEvent_FullEventParsing_WithoutView(t *testing.T) {
 	assert.Equal(t, "1747319568.267214", appHomeEvent.EventTimeStamp)
 	assert.Nil(t, appHomeEvent.View)
 }
+
+func TestEntityDetailsRequestedEvent(t *testing.T) {
+	jsonStr := `{
+		"type": "entity_details_requested",
+		"user": "U123456789",
+		"trigger_id": "1234567890123.1234567890123.abcdef01234567890abcdef012345689",
+		"user_locale": "en-US",
+		"entity_url": "https://example.com/incidents/123",
+		"external_ref": {
+			"id": "123"
+		},
+		"link": {
+			"url": "https://example.com/incidents/123",
+			"domain": "example.com"
+		},
+		"app_unfurl_url": "https://example.com/incidents/123",
+		"channel": "C123456789",
+		"message_ts": "1234567890.123456",
+		"event_ts": "1234567890.123456"
+	}`
+
+	var event EntityDetailsRequestedEvent
+	if err := json.Unmarshal([]byte(jsonStr), &event); err != nil {
+		t.Errorf("Failed to unmarshal EntityDetailsRequestedEvent: %v", err)
+	}
+
+	if event.Type != "entity_details_requested" {
+		t.Errorf("Expected type to be 'entity_details_requested', got %s", event.Type)
+	}
+
+	if event.User != "U123456789" {
+		t.Errorf("Expected user to be 'U123456789', got %s", event.User)
+	}
+
+	if event.ExternalRef.ID != "123" {
+		t.Errorf("Expected external_ref.id to be '123', got %s", event.ExternalRef.ID)
+	}
+
+	if event.EntityURL != "https://example.com/incidents/123" {
+		t.Errorf("Expected entity_url to be 'https://example.com/incidents/123', got %s", event.EntityURL)
+	}
+
+	if event.Link.URL != "https://example.com/incidents/123" {
+		t.Errorf("Expected link.url to be 'https://example.com/incidents/123', got %s", event.Link.URL)
+	}
+
+	if event.Link.Domain != "example.com" {
+		t.Errorf("Expected link.domain to be 'example.com', got %s", event.Link.Domain)
+	}
+
+	if event.TriggerID != "1234567890123.1234567890123.abcdef01234567890abcdef012345689" {
+		t.Errorf("Expected trigger_id to be '1234567890123.1234567890123.abcdef01234567890abcdef012345689', got %s", event.TriggerID)
+	}
+
+	if event.EventTS != "1234567890.123456" {
+		t.Errorf("Expected event_ts to be '1234567890.123456', got %s", event.EventTS)
+	}
+
+	if event.Channel != "C123456789" {
+		t.Errorf("Expected channel to be 'C123456789', got %s", event.Channel)
+	}
+
+	if event.MessageTs != "1234567890.123456" {
+		t.Errorf("Expected message_ts to be '1234567890.123456', got %s", event.MessageTs)
+	}
+}
+
+func TestParseEventAPIEntityDetailsRequested(t *testing.T) {
+	rawE := []byte(`
+		{
+			"token": "test-token",
+			"team_id": "T123456789",
+			"api_app_id": "A123456789",
+			"event": {
+				"type": "entity_details_requested",
+				"user": "U123456789",
+				"trigger_id": "1234567890123.1234567890123.abcdef01234567890abcdef012345689",
+				"user_locale": "en-US",
+				"entity_url": "https://example.com/incidents/123",
+				"external_ref": {
+					"id": "123"
+				},
+				"link": {
+					"url": "https://example.com/incidents/123",
+					"domain": "example.com"
+				},
+				"app_unfurl_url": "https://example.com/incidents/123",
+				"channel": "C123456789",
+				"message_ts": "1234567890.123456",
+				"event_ts": "1234567890.123456"
+			},
+			"type": "event_callback",
+			"event_id": "Ev123456789",
+			"event_time": 1234567890
+		}
+	`)
+
+	parsedEvent, err := ParseEvent(rawE, OptionNoVerifyToken())
+	if err != nil {
+		t.Errorf("Failed to parse EntityDetailsRequestedEvent: %v", err)
+	}
+
+	if parsedEvent.Type != "event_callback" {
+		t.Errorf("Expected outer event type to be 'event_callback', got %s", parsedEvent.Type)
+	}
+
+	if parsedEvent.InnerEvent.Type != "entity_details_requested" {
+		t.Errorf("Expected inner event type to be 'entity_details_requested', got %s", parsedEvent.InnerEvent.Type)
+	}
+
+	innerEvent, ok := parsedEvent.InnerEvent.Data.(*EntityDetailsRequestedEvent)
+	if !ok {
+		t.Errorf("Expected inner event data to be *EntityDetailsRequestedEvent, got %T", parsedEvent.InnerEvent.Data)
+	}
+
+	if innerEvent.Type != "entity_details_requested" {
+		t.Errorf("Expected inner event type to be 'entity_details_requested', got %s", innerEvent.Type)
+	}
+
+	if innerEvent.User != "U123456789" {
+		t.Errorf("Expected user to be 'U123456789', got %s", innerEvent.User)
+	}
+
+	if innerEvent.ExternalRef.ID != "123" {
+		t.Errorf("Expected external_ref.id to be '123', got %s", innerEvent.ExternalRef.ID)
+	}
+
+	if innerEvent.TriggerID != "1234567890123.1234567890123.abcdef01234567890abcdef012345689" {
+		t.Errorf("Expected trigger_id to be '1234567890123.1234567890123.abcdef01234567890abcdef012345689', got %s", innerEvent.TriggerID)
+	}
+
+	if innerEvent.EventTS != "1234567890.123456" {
+		t.Errorf("Expected event_ts to be '1234567890.123456', got %s", innerEvent.EventTS)
+	}
+
+	if innerEvent.Link.Domain != "example.com" {
+		t.Errorf("Expected link.domain to be 'example.com', got %s", innerEvent.Link.Domain)
+	}
+}


### PR DESCRIPTION
## What?

Add support for Slack Work Objects so apps can show rich previews and flexpane details for links.

- Chat: Unfurl with Work Object metadata (UnfurlMessageWorkObject), optional metadata-only unfurl, unfurl by unfurl_id/source (composer), and user_auth_blocks for the auth prompt.
- Entity: entity.presentDetails for flexpane (EntityPresentDetailsContext, WithMetadata, WithError, WithAuth).
- Events: EntityDetailsRequestedEvent and mapping for entity_details_requested.
- Types: WorkObjectMetadata, WorkObjectEntity, WorkObjectExternalRef, and entity type constants in metadata.go.

See https://docs.slack.dev/messaging/work-objects/

## Why?

The Slack API offers the work objects, so to be able to use them, we need to expose types and methods in the library.

Closes https://github.com/slack-go/slack/issues/1510