### PR TITLE
Add WorkflowID to message

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -87,6 +87,7 @@ type Msg struct {
 	Username   string      `json:"username,omitempty"`
 	Icons      *Icon       `json:"icons,omitempty"`
 	BotProfile *BotProfile `json:"bot_profile,omitempty"`
+	WorkflowID string      `json:"workflow_id,omitempty"`
 
 	// channel_join, group_join
 	Inviter string `json:"inviter,omitempty"`

--- a/messages_test.go
+++ b/messages_test.go
@@ -285,6 +285,31 @@ var botMessage = `{
     "ts": "1358877455.000010"
 }`
 
+var workflowBotMessage = `{
+    "type": "message",
+    "subtype": "bot_message",
+    "text": "Can you create a TODO.md file",
+    "bot_id": "BB12033",
+    "username": "Test Workflow",
+    "workflow_id": "Wf0123456789",
+    "blocks": [],
+    "channel": "C2147483705",
+    "ts": "1358877455.000010"
+}`
+
+func TestWorkflowBotMessage(t *testing.T) {
+	message, err := unmarshalMessage(workflowBotMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, message)
+	assert.Equal(t, "message", message.Type)
+	assert.Equal(t, MsgSubTypeBotMessage, message.SubType)
+	assert.Equal(t, "BB12033", message.BotID)
+	assert.Equal(t, "Test Workflow", message.Username)
+	assert.Equal(t, "Wf0123456789", message.WorkflowID)
+	assert.Equal(t, "C2147483705", message.Channel)
+	assert.Equal(t, "1358877455.000010", message.Timestamp)
+}
+
 func TestBotMessage(t *testing.T) {
 	message, err := unmarshalMessage(botMessage)
 	assert.Nil(t, err)

--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -320,9 +320,10 @@ type MessageEvent struct {
 	SubType string `json:"subtype,omitempty"`
 
 	// bot_message (https://api.slack.com/events/message/bot_message)
-	BotID    string `json:"bot_id,omitempty"`
-	Username string `json:"username,omitempty"`
-	Icons    *Icon  `json:"icons,omitempty"`
+	BotID      string `json:"bot_id,omitempty"`
+	Username   string `json:"username,omitempty"`
+	Icons      *Icon  `json:"icons,omitempty"`
+	WorkflowID string `json:"workflow_id,omitempty"`
 
 	// AssistantThread contains action token for Data Access API queries in message events
 	AssistantThread *AssistantThreadActionToken `json:"assistant_thread,omitempty"`


### PR DESCRIPTION
Hey team, this adds the `workflow_id` to the message struct.

I can't find this field documented anywhere, but it is on the messages we see that originate from Workflows - let me know if there's something different/else you'd need!