### PR TITLE
feat(block): add card and carousel blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Block Kit: `CardBlock` and `CarouselBlock`** — Support for two of the new
+  agent-UI blocks announced in the
+  [April 16 Slack changelog](https://docs.slack.dev/changelog/2026/04/16/block-kit-new-blocks).
+  `CardBlock` is constructed via `NewCardBlock` with a functional-options
+  pattern and fluent `With*` builders (`WithTitle`, `WithSubtitle`, `WithBody`,
+  `WithIcon`, `WithHeroImage`, `WithActions`). `CarouselBlock` is constructed
+  via `NewCarouselBlock` with a variadic `*CardBlock` list plus `WithBlockID`
+  and `AddCard` helpers. Both blocks wire into `Blocks.UnmarshalJSON` for
+  round-trip fidelity, and reuse existing `ImageBlockElement` /
+  `ButtonBlockElement` / `BlockElements` types rather than introducing new
+  composition objects. The Alert block is deliberately not included in this
+  release pending sandbox-verified rendering.
+- **Streaming-message chunks API** — `chat.startStream` / `chat.appendStream` /
+  `chat.stopStream` now accept a `chunks` parameter. Added `MsgOptionChunks`
+  along with a `StreamChunk` interface and four chunk types:
+  `MarkdownTextChunk`, `TaskUpdateChunk`, `PlanUpdateChunk`, and `BlocksChunk`
+  (each with a `New*Chunk` constructor). This is the supported transport for
+  streaming Block Kit content and the new agent-UI blocks in particular
+  (which `chat.postMessage` rejects as `Unsupported block type`).
+- **`MsgOptionTaskDisplayMode`** — New option for `chat.startStream` controlling
+  whether task chunks render as a sequential timeline or a grouped plan.
+  Accepts `TaskDisplayModeTimeline` or `TaskDisplayModePlan`.
+
 ## [0.22.0] - 2026-04-12
 
 ### Added

--- a/block.go
+++ b/block.go
@@ -21,6 +21,8 @@ const (
 	MBTTable          MessageBlockType = "table"
 	MBTTaskCard       MessageBlockType = "task_card"
 	MBTPlan           MessageBlockType = "plan"
+	MBTCard           MessageBlockType = "card"
+	MBTCarousel       MessageBlockType = "carousel"
 )
 
 // Block defines an interface all block types should implement

--- a/block_card.go
+++ b/block_card.go
@@ -1,0 +1,90 @@
+package slack
+
+// CardBlock defines a block of type card used to display a rich, self-contained
+// piece of content with an optional hero image, icon, title, subtitle, body,
+// and action buttons. Cards can stand alone or be grouped inside a
+// CarouselBlock.
+//
+// More Information: https://docs.slack.dev/reference/block-kit/blocks/card-block/
+type CardBlock struct {
+	Type      MessageBlockType   `json:"type"`
+	BlockID   string             `json:"block_id,omitempty"`
+	HeroImage *ImageBlockElement `json:"hero_image,omitempty"`
+	Icon      *ImageBlockElement `json:"icon,omitempty"`
+	Title     *TextBlockObject   `json:"title,omitempty"`
+	Subtitle  *TextBlockObject   `json:"subtitle,omitempty"`
+	Body      *TextBlockObject   `json:"body,omitempty"`
+	Actions   *BlockElements     `json:"actions,omitempty"`
+}
+
+// BlockType returns the type of the block
+func (s CardBlock) BlockType() MessageBlockType {
+	return s.Type
+}
+
+// ID returns the ID of the block
+func (s CardBlock) ID() string {
+	return s.BlockID
+}
+
+// CardBlockOption allows configuration of options for a new card block
+type CardBlockOption func(*CardBlock)
+
+// CardBlockOptionBlockID sets the block ID for the card block
+func CardBlockOptionBlockID(blockID string) CardBlockOption {
+	return func(block *CardBlock) {
+		block.BlockID = blockID
+	}
+}
+
+// NewCardBlock returns a new instance of a card block. Use the chainable
+// With* methods or provide options to populate its fields.
+func NewCardBlock(options ...CardBlockOption) *CardBlock {
+	block := CardBlock{
+		Type: MBTCard,
+	}
+
+	for _, option := range options {
+		if option != nil {
+			option(&block)
+		}
+	}
+
+	return &block
+}
+
+// WithTitle sets the title text for the CardBlock
+func (s *CardBlock) WithTitle(title *TextBlockObject) *CardBlock {
+	s.Title = title
+	return s
+}
+
+// WithSubtitle sets the subtitle text for the CardBlock
+func (s *CardBlock) WithSubtitle(subtitle *TextBlockObject) *CardBlock {
+	s.Subtitle = subtitle
+	return s
+}
+
+// WithBody sets the body text for the CardBlock
+func (s *CardBlock) WithBody(body *TextBlockObject) *CardBlock {
+	s.Body = body
+	return s
+}
+
+// WithIcon sets the icon image for the CardBlock
+func (s *CardBlock) WithIcon(icon *ImageBlockElement) *CardBlock {
+	s.Icon = icon
+	return s
+}
+
+// WithHeroImage sets the hero image for the CardBlock
+func (s *CardBlock) WithHeroImage(heroImage *ImageBlockElement) *CardBlock {
+	s.HeroImage = heroImage
+	return s
+}
+
+// WithActions sets the action buttons displayed at the bottom of the card
+func (s *CardBlock) WithActions(elements ...BlockElement) *CardBlock {
+	s.Actions = &BlockElements{ElementSet: elements}
+	return s
+}

--- a/block_card_test.go
+++ b/block_card_test.go
@@ -1,0 +1,116 @@
+package slack
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCardBlock(t *testing.T) {
+	title := NewTextBlockObject("mrkdwn", "Card title", false, false)
+	subtitle := NewTextBlockObject("mrkdwn", "Card subtitle", false, false)
+	body := NewTextBlockObject("mrkdwn", "Card body text.", false, false)
+
+	iconURL := "https://example.com/icon.png"
+	icon := &ImageBlockElement{Type: METImage, ImageURL: &iconURL, AltText: "icon"}
+	heroURL := "https://example.com/hero.png"
+	hero := &ImageBlockElement{Type: METImage, ImageURL: &heroURL, AltText: "hero"}
+
+	btnText := NewTextBlockObject("plain_text", "Open", false, false)
+	btn := NewButtonBlockElement("open_action", "go", btnText)
+
+	block := NewCardBlock(CardBlockOptionBlockID("card-1")).
+		WithTitle(title).
+		WithSubtitle(subtitle).
+		WithBody(body).
+		WithIcon(icon).
+		WithHeroImage(hero).
+		WithActions(btn)
+
+	assert.Equal(t, MBTCard, block.BlockType())
+	assert.Equal(t, "card", string(block.Type))
+	assert.Equal(t, "card-1", block.ID())
+	assert.Equal(t, title, block.Title)
+	assert.Equal(t, subtitle, block.Subtitle)
+	assert.Equal(t, body, block.Body)
+	assert.Equal(t, icon, block.Icon)
+	assert.Equal(t, hero, block.HeroImage)
+	require.NotNil(t, block.Actions)
+	require.Len(t, block.Actions.ElementSet, 1)
+}
+
+func TestCardBlockJSONRoundTrip(t *testing.T) {
+	payload := `{
+		"type": "card",
+		"block_id": "card-1",
+		"hero_image": {
+			"type": "image",
+			"image_url": "https://example.com/hero.png",
+			"alt_text": "hero"
+		},
+		"icon": {
+			"type": "image",
+			"image_url": "https://example.com/icon.png",
+			"alt_text": "icon"
+		},
+		"title": {"type": "mrkdwn", "text": "Lumon Industries"},
+		"subtitle": {"type": "mrkdwn", "text": "Macrodata Refinement"},
+		"body": {"type": "mrkdwn", "text": "The work is mysterious and important."},
+		"actions": [
+			{
+				"type": "button",
+				"text": {"type": "plain_text", "text": "Enter"},
+				"action_id": "enter",
+				"value": "mdr"
+			}
+		]
+	}`
+
+	var block CardBlock
+	err := json.Unmarshal([]byte(payload), &block)
+	require.NoError(t, err)
+
+	assert.Equal(t, MBTCard, block.BlockType())
+	assert.Equal(t, "card-1", block.ID())
+	require.NotNil(t, block.HeroImage)
+	require.NotNil(t, block.Icon)
+	require.NotNil(t, block.Title)
+	require.NotNil(t, block.Subtitle)
+	require.NotNil(t, block.Body)
+	require.NotNil(t, block.Actions)
+	require.Len(t, block.Actions.ElementSet, 1)
+
+	btn, ok := block.Actions.ElementSet[0].(*ButtonBlockElement)
+	require.True(t, ok, "expected *ButtonBlockElement, got %T", block.Actions.ElementSet[0])
+	assert.Equal(t, "enter", btn.ActionID)
+
+	marshalled, err := json.Marshal(block)
+	require.NoError(t, err)
+
+	var expected, actual map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(payload), &expected))
+	require.NoError(t, json.Unmarshal(marshalled, &actual))
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestCardBlockUnmarshalViaBlocks(t *testing.T) {
+	payload := `[
+		{
+			"type": "card",
+			"title": {"type": "mrkdwn", "text": "Hello"}
+		}
+	]`
+
+	var blocks Blocks
+	require.NoError(t, json.Unmarshal([]byte(payload), &blocks))
+	require.Len(t, blocks.BlockSet, 1)
+
+	card, ok := blocks.BlockSet[0].(*CardBlock)
+	require.True(t, ok, "expected *CardBlock, got %T", blocks.BlockSet[0])
+	assert.Equal(t, MBTCard, card.BlockType())
+	require.NotNil(t, card.Title)
+	assert.Equal(t, "Hello", card.Title.Text)
+}

--- a/block_carousel.go
+++ b/block_carousel.go
@@ -1,0 +1,42 @@
+package slack
+
+// CarouselBlock defines a block of type carousel that displays a scrollable
+// list of cards. A carousel must contain between 1 and 10 cards.
+//
+// More Information: https://docs.slack.dev/reference/block-kit/blocks/carousel-block/
+type CarouselBlock struct {
+	Type     MessageBlockType `json:"type"`
+	BlockID  string           `json:"block_id,omitempty"`
+	Elements []*CardBlock     `json:"elements"`
+}
+
+// BlockType returns the type of the block
+func (s CarouselBlock) BlockType() MessageBlockType {
+	return s.Type
+}
+
+// ID returns the ID of the block
+func (s CarouselBlock) ID() string {
+	return s.BlockID
+}
+
+// NewCarouselBlock returns a new instance of a carousel block containing the
+// given cards.
+func NewCarouselBlock(cards ...*CardBlock) *CarouselBlock {
+	return &CarouselBlock{
+		Type:     MBTCarousel,
+		Elements: cards,
+	}
+}
+
+// WithBlockID sets the block ID for the CarouselBlock
+func (s *CarouselBlock) WithBlockID(blockID string) *CarouselBlock {
+	s.BlockID = blockID
+	return s
+}
+
+// AddCard appends a card to the carousel
+func (s *CarouselBlock) AddCard(card *CardBlock) *CarouselBlock {
+	s.Elements = append(s.Elements, card)
+	return s
+}

--- a/block_carousel_test.go
+++ b/block_carousel_test.go
@@ -1,0 +1,87 @@
+package slack
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCarouselBlock(t *testing.T) {
+	cardA := NewCardBlock().WithTitle(NewTextBlockObject("mrkdwn", "A", false, false))
+	cardB := NewCardBlock().WithTitle(NewTextBlockObject("mrkdwn", "B", false, false))
+
+	block := NewCarouselBlock(cardA, cardB).WithBlockID("carousel-1")
+
+	assert.Equal(t, MBTCarousel, block.BlockType())
+	assert.Equal(t, "carousel", string(block.Type))
+	assert.Equal(t, "carousel-1", block.ID())
+	require.Len(t, block.Elements, 2)
+	assert.Equal(t, cardA, block.Elements[0])
+	assert.Equal(t, cardB, block.Elements[1])
+
+	cardC := NewCardBlock().WithTitle(NewTextBlockObject("mrkdwn", "C", false, false))
+	block.AddCard(cardC)
+	require.Len(t, block.Elements, 3)
+	assert.Equal(t, cardC, block.Elements[2])
+}
+
+func TestCarouselBlockJSONRoundTrip(t *testing.T) {
+	payload := `{
+		"type": "carousel",
+		"block_id": "carousel-1",
+		"elements": [
+			{
+				"type": "card",
+				"title": {"type": "mrkdwn", "text": "MDR"},
+				"body": {"type": "mrkdwn", "text": "Macrodata Refinement"}
+			},
+			{
+				"type": "card",
+				"title": {"type": "mrkdwn", "text": "O&D"},
+				"body": {"type": "mrkdwn", "text": "Optics and Design"}
+			}
+		]
+	}`
+
+	var block CarouselBlock
+	err := json.Unmarshal([]byte(payload), &block)
+	require.NoError(t, err)
+
+	assert.Equal(t, MBTCarousel, block.BlockType())
+	assert.Equal(t, "carousel-1", block.ID())
+	require.Len(t, block.Elements, 2)
+	assert.Equal(t, "MDR", block.Elements[0].Title.Text)
+	assert.Equal(t, "O&D", block.Elements[1].Title.Text)
+
+	marshalled, err := json.Marshal(block)
+	require.NoError(t, err)
+
+	var expected, actual map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(payload), &expected))
+	require.NoError(t, json.Unmarshal(marshalled, &actual))
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestCarouselBlockUnmarshalViaBlocks(t *testing.T) {
+	payload := `[
+		{
+			"type": "carousel",
+			"elements": [
+				{"type": "card", "title": {"type": "mrkdwn", "text": "Only"}}
+			]
+		}
+	]`
+
+	var blocks Blocks
+	require.NoError(t, json.Unmarshal([]byte(payload), &blocks))
+	require.Len(t, blocks.BlockSet, 1)
+
+	carousel, ok := blocks.BlockSet[0].(*CarouselBlock)
+	require.True(t, ok, "expected *CarouselBlock, got %T", blocks.BlockSet[0])
+	assert.Equal(t, MBTCarousel, carousel.BlockType())
+	require.Len(t, carousel.Elements, 1)
+	assert.Equal(t, "Only", carousel.Elements[0].Title.Text)
+}

--- a/block_conv.go
+++ b/block_conv.go
@@ -83,6 +83,10 @@ func (b *Blocks) UnmarshalJSON(data []byte) error {
 			block = &TaskCardBlock{}
 		case "plan":
 			block = &PlanBlock{}
+		case "card":
+			block = &CardBlock{}
+		case "carousel":
+			block = &CarouselBlock{}
 		default:
 			b := &UnknownBlock{raw: r}
 			if err = json.Unmarshal(r, b); err != nil {

--- a/chat.go
+++ b/chat.go
@@ -912,6 +912,24 @@ func MsgOptionMarkdownText(text string) MsgOption {
 	}
 }
 
+// TaskDisplayMode controls how task_card / task_update chunks render in a
+// streamed message. Used with chat.startStream.
+type TaskDisplayMode string
+
+const (
+	TaskDisplayModeTimeline TaskDisplayMode = "timeline"
+	TaskDisplayModePlan     TaskDisplayMode = "plan"
+)
+
+// MsgOptionTaskDisplayMode sets task_display_mode on chat.startStream,
+// controlling whether tasks render as a sequential timeline or a grouped plan.
+func MsgOptionTaskDisplayMode(mode TaskDisplayMode) MsgOption {
+	return func(config *sendConfig) error {
+		config.values.Set("task_display_mode", string(mode))
+		return nil
+	}
+}
+
 // UnsafeMsgOptionEndpoint deliver the message to the specified endpoint.
 // NOTE: USE AT YOUR OWN RISK: No issues relating to the use of this Option
 // will be supported by the library, it is subject to change without notice that

--- a/chat_stream_chunks.go
+++ b/chat_stream_chunks.go
@@ -1,0 +1,95 @@
+package slack
+
+import (
+	"encoding/json"
+)
+
+// StreamChunkType identifies a chunk in the chat.startStream / chat.appendStream
+// / chat.stopStream streaming-message protocol.
+//
+// More information: https://docs.slack.dev/reference/methods/chat.appendStream/
+type StreamChunkType string
+
+const (
+	StreamChunkMarkdownText StreamChunkType = "markdown_text"
+	StreamChunkTaskUpdate   StreamChunkType = "task_update"
+	StreamChunkPlanUpdate   StreamChunkType = "plan_update"
+	StreamChunkBlocks       StreamChunkType = "blocks"
+)
+
+// StreamChunk represents a single chunk in the streaming-message chunks array.
+type StreamChunk interface {
+	ChunkType() StreamChunkType
+}
+
+// MarkdownTextChunk streams markdown-formatted text.
+type MarkdownTextChunk struct {
+	Type StreamChunkType `json:"type"`
+	Text string          `json:"text"`
+}
+
+func (c MarkdownTextChunk) ChunkType() StreamChunkType { return c.Type }
+
+// NewMarkdownTextChunk returns a markdown_text chunk.
+func NewMarkdownTextChunk(text string) MarkdownTextChunk {
+	return MarkdownTextChunk{Type: StreamChunkMarkdownText, Text: text}
+}
+
+// TaskUpdateChunk streams a task status update that renders as a task card.
+type TaskUpdateChunk struct {
+	Type    StreamChunkType  `json:"type"`
+	ID      string           `json:"id"`
+	Title   string           `json:"title"`
+	Status  TaskCardStatus   `json:"status,omitempty"`
+	Details string           `json:"details,omitempty"`
+	Output  string           `json:"output,omitempty"`
+	Sources []TaskCardSource `json:"sources,omitempty"`
+}
+
+func (c TaskUpdateChunk) ChunkType() StreamChunkType { return c.Type }
+
+// NewTaskUpdateChunk returns a task_update chunk with the given id and title.
+func NewTaskUpdateChunk(id, title string) TaskUpdateChunk {
+	return TaskUpdateChunk{Type: StreamChunkTaskUpdate, ID: id, Title: title}
+}
+
+// PlanUpdateChunk streams an update to the current plan's title.
+type PlanUpdateChunk struct {
+	Type  StreamChunkType `json:"type"`
+	Title string          `json:"title"`
+}
+
+func (c PlanUpdateChunk) ChunkType() StreamChunkType { return c.Type }
+
+// NewPlanUpdateChunk returns a plan_update chunk.
+func NewPlanUpdateChunk(title string) PlanUpdateChunk {
+	return PlanUpdateChunk{Type: StreamChunkPlanUpdate, Title: title}
+}
+
+// BlocksChunk streams a group of Block Kit blocks. Up to 50 blocks per chunk.
+type BlocksChunk struct {
+	Type   StreamChunkType `json:"type"`
+	Blocks []Block         `json:"blocks"`
+}
+
+func (c BlocksChunk) ChunkType() StreamChunkType { return c.Type }
+
+// NewBlocksChunk returns a blocks chunk containing the given blocks.
+func NewBlocksChunk(blocks ...Block) BlocksChunk {
+	return BlocksChunk{Type: StreamChunkBlocks, Blocks: blocks}
+}
+
+// MsgOptionChunks sets the `chunks` parameter for the streaming chat methods
+// (chat.startStream / chat.appendStream / chat.stopStream). It is the
+// transport for Block Kit agent-UI blocks (Alert, Card, Carousel, etc.) which
+// chat.postMessage rejects as "Unsupported block type".
+func MsgOptionChunks(chunks ...StreamChunk) MsgOption {
+	return func(config *sendConfig) error {
+		encoded, err := json.Marshal(chunks)
+		if err != nil {
+			return err
+		}
+		config.values.Set("chunks", string(encoded))
+		return nil
+	}
+}


### PR DESCRIPTION
Added the new blocks as announced in
https://docs.slack.dev/changelog/2026/04/16/block-kit-new-blocks except for `Alert` which doesn't yet seem to work (not in any of my environments at least).

`Alert` will come later in a different PR once I can test in a sandbox environment and confirm it working.