### PR TITLE
feat(block): add alert block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `AddCard` helpers. Both blocks wire into `Blocks.UnmarshalJSON` for
   round-trip fidelity, and reuse existing `ImageBlockElement` /
   `ButtonBlockElement` / `BlockElements` types rather than introducing new
-  composition objects. The Alert block is deliberately not included in this
-  release pending sandbox-verified rendering.
+  composition objects.
+- **Block Kit: `AlertBlock`** — Support for the third of the new agent-UI
+  blocks from the
+  [April 16 Slack changelog](https://docs.slack.dev/changelog/2026/04/16/block-kit-new-blocks).
+  `AlertBlock` is constructed via `NewAlertBlock` with a `*TextBlockObject`
+  body and a functional-options pattern. Severity is set via
+  `AlertBlockOptionLevel` (`AlertLevelDefault`, `AlertLevelInfo`,
+  `AlertLevelWarning`, `AlertLevelError`, `AlertLevelSuccess`) and the block
+  ID via `AlertBlockOptionBlockID`. Wires into `Blocks.UnmarshalJSON` for
+  round-trip fidelity. Must be delivered via the streaming chunks API —
+  `chat.postMessage` rejects it as an unsupported block type.
 - **Streaming-message chunks API** — `chat.startStream` / `chat.appendStream` /
   `chat.stopStream` now accept a `chunks` parameter. Added `MsgOptionChunks`
   along with a `StreamChunk` interface and four chunk types:

--- a/block.go
+++ b/block.go
@@ -21,6 +21,7 @@ const (
 	MBTTable          MessageBlockType = "table"
 	MBTTaskCard       MessageBlockType = "task_card"
 	MBTPlan           MessageBlockType = "plan"
+	MBTAlert          MessageBlockType = "alert"
 	MBTCard           MessageBlockType = "card"
 	MBTCarousel       MessageBlockType = "carousel"
 )

--- a/block_alert.go
+++ b/block_alert.go
@@ -1,0 +1,70 @@
+package slack
+
+// AlertLevel defines the severity for an AlertBlock.
+type AlertLevel string
+
+const (
+	AlertLevelDefault AlertLevel = "default"
+	AlertLevelInfo    AlertLevel = "info"
+	AlertLevelWarning AlertLevel = "warning"
+	AlertLevelError   AlertLevel = "error"
+	AlertLevelSuccess AlertLevel = "success"
+)
+
+// AlertBlock defines a block of type alert used to surface a notification
+// message with an optional severity level.
+//
+// Surface: modal only. Slack rejects alert blocks sent via chat.postMessage
+// or the streaming APIs — use OpenView / UpdateView / PushView with a
+// ModalViewRequest whose Blocks include the alert.
+//
+// More Information: https://docs.slack.dev/reference/block-kit/blocks/alert-block/
+type AlertBlock struct {
+	Type    MessageBlockType `json:"type"`
+	Text    *TextBlockObject `json:"text"`
+	Level   AlertLevel       `json:"level,omitempty"`
+	BlockID string           `json:"block_id,omitempty"`
+}
+
+// BlockType returns the type of the block
+func (s AlertBlock) BlockType() MessageBlockType {
+	return s.Type
+}
+
+// ID returns the ID of the block
+func (s AlertBlock) ID() string {
+	return s.BlockID
+}
+
+// AlertBlockOption allows configuration of options for a new alert block
+type AlertBlockOption func(*AlertBlock)
+
+// AlertBlockOptionLevel sets the severity level for the alert block
+func AlertBlockOptionLevel(level AlertLevel) AlertBlockOption {
+	return func(block *AlertBlock) {
+		block.Level = level
+	}
+}
+
+// AlertBlockOptionBlockID sets the block ID for the alert block
+func AlertBlockOptionBlockID(blockID string) AlertBlockOption {
+	return func(block *AlertBlock) {
+		block.BlockID = blockID
+	}
+}
+
+// NewAlertBlock returns a new instance of an alert block
+func NewAlertBlock(text *TextBlockObject, options ...AlertBlockOption) *AlertBlock {
+	block := AlertBlock{
+		Type: MBTAlert,
+		Text: text,
+	}
+
+	for _, option := range options {
+		if option != nil {
+			option(&block)
+		}
+	}
+
+	return &block
+}

--- a/block_alert_test.go
+++ b/block_alert_test.go
@@ -1,0 +1,80 @@
+package slack
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAlertBlock(t *testing.T) {
+	text := NewTextBlockObject("mrkdwn", "The work is mysterious and important.", false, false)
+	block := NewAlertBlock(text,
+		AlertBlockOptionLevel(AlertLevelInfo),
+		AlertBlockOptionBlockID("alert-1"),
+	)
+
+	assert.Equal(t, MBTAlert, block.BlockType())
+	assert.Equal(t, "alert", string(block.Type))
+	assert.Equal(t, "alert-1", block.ID())
+	assert.Equal(t, AlertLevelInfo, block.Level)
+	assert.Equal(t, text, block.Text)
+}
+
+func TestNewAlertBlockWithNilOption(t *testing.T) {
+	text := NewTextBlockObject("plain_text", "hi", false, false)
+	assert.NotPanics(t, func() {
+		NewAlertBlock(text, nil)
+	}, "should not panic when nil option passed")
+}
+
+func TestAlertBlockJSONRoundTrip(t *testing.T) {
+	payload := `{
+		"type": "alert",
+		"text": {
+			"type": "mrkdwn",
+			"text": "The work is mysterious and important."
+		},
+		"level": "info",
+		"block_id": "alert-1"
+	}`
+
+	var block AlertBlock
+	err := json.Unmarshal([]byte(payload), &block)
+	require.NoError(t, err)
+
+	assert.Equal(t, MBTAlert, block.BlockType())
+	assert.Equal(t, "alert-1", block.ID())
+	assert.Equal(t, AlertLevelInfo, block.Level)
+	require.NotNil(t, block.Text)
+	assert.Equal(t, "mrkdwn", block.Text.Type)
+
+	marshalled, err := json.Marshal(block)
+	require.NoError(t, err)
+
+	var expected, actual map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(payload), &expected))
+	require.NoError(t, json.Unmarshal(marshalled, &actual))
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestAlertBlockUnmarshalViaBlocks(t *testing.T) {
+	payload := `[
+		{
+			"type": "alert",
+			"text": {"type": "plain_text", "text": "Heads up"},
+			"level": "warning"
+		}
+	]`
+
+	var blocks Blocks
+	require.NoError(t, json.Unmarshal([]byte(payload), &blocks))
+	require.Len(t, blocks.BlockSet, 1)
+
+	alert, ok := blocks.BlockSet[0].(*AlertBlock)
+	require.True(t, ok, "expected *AlertBlock, got %T", blocks.BlockSet[0])
+	assert.Equal(t, MBTAlert, alert.BlockType())
+	assert.Equal(t, AlertLevelWarning, alert.Level)
+}

--- a/block_conv.go
+++ b/block_conv.go
@@ -81,6 +81,8 @@ func (b *Blocks) UnmarshalJSON(data []byte) error {
 			block = &TableBlock{}
 		case "task_card":
 			block = &TaskCardBlock{}
+		case "alert":
+			block = &AlertBlock{}
 		case "plan":
 			block = &PlanBlock{}
 		case "card":


### PR DESCRIPTION
Adds `AlertBlock`, the third agent-UI block from the April 16 Slack changelog. Uses the functional-options pattern (`NewAlertBlock`) with severity via `AlertBlockOptionLevel` (default/info/warning/error/success) and block ID via `AlertBlockOptionBlockID`. Wires into `Blocks.UnmarshalJSON` for round-trip fidelity and adds coverage in `block_alert_test.go`.