### PR TITLE
feat(assistant): add username and icon to status update

### DIFF
--- a/assistant.go
+++ b/assistant.go
@@ -14,6 +14,9 @@ type AssistantThreadsSetStatusParameters struct {
 	Status          string   `json:"status"`
 	ThreadTS        string   `json:"thread_ts"`
 	LoadingMessages []string `json:"loading_messages,omitempty"`
+	Username        string   `json:"username,omitempty"`
+	IconURL         string   `json:"icon_url,omitempty"`
+	IconEmoji       string   `json:"icon_emoji,omitempty"`
 }
 
 // AssistantThreadSetTitleParameters are the parameters for AssistantThreadSetTitle
@@ -207,6 +210,18 @@ func (api *Client) SetAssistantThreadsStatusContext(ctx context.Context, params 
 
 	if len(params.LoadingMessages) > 0 {
 		values.Add("loading_messages", strings.Join(params.LoadingMessages, ","))
+	}
+
+	if params.Username != "" {
+		values.Add("username", params.Username)
+	}
+
+	if params.IconURL != "" {
+		values.Add("icon_url", params.IconURL)
+	}
+
+	if params.IconEmoji != "" {
+		values.Add("icon_emoji", params.IconEmoji)
 	}
 
 	response := struct {

--- a/assistant_test.go
+++ b/assistant_test.go
@@ -38,6 +38,9 @@ func TestSetAssistantThreadsStatus(t *testing.T) {
 		ThreadTS:        "1234567890.123456",
 		Status:          "updated status",
 		LoadingMessages: []string{"updating status..."},
+		Username:        "custom name",
+		IconURL:         "https://example.com/icon.png",
+		IconEmoji:       ":thinking_face:",
 	}
 
 	err := api.SetAssistantThreadsStatus(params)


### PR DESCRIPTION
Slack's [assistant.threads.setStatus](https://docs.slack.dev/reference/methods/assistant.threads.setStatus) added a couple of additional optional parameters: `username`, `icon_url`, and `icon_emoji` for customization. This PR adds these new parameters to `SetAssistantThreadsStatusContext`.

Changes:
- updates `AssistantThreadsSetStatusParameters` to include these new parameters
- updates `SetAssistantThreadsStatusContext` to forward these new parameters when set
- updates existing test to include these fields

| icon_url | icon_emoji |
| --- | --- |
|<img width="147" height="217" alt="Screenshot 2026-04-20 at 12 36 03 PM" src="https://github.com/user-attachments/assets/a4a096f6-276e-4eb7-bef7-ddbb0879ba65" />|<img width="185" height="213" alt="Screenshot 2026-04-20 at 1 00 10 PM" src="https://github.com/user-attachments/assets/fe37a440-6b45-4fa7-84b8-defa459c704c" />|
