### PR TITLE
docs: format go get command in code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ Release Policy](https://go.dev/doc/devel/release#policy)).
 
 ### *go get*
 
-    $ go get -u github.com/slack-go/slack
+```bash
+go get -u github.com/slack-go/slack
+```
 
 ## Example
 


### PR DESCRIPTION
# Summary

Format the `go get` installation command in the README using a fenced Markdown code block.

The previous installation example included the shell prompt (`$`), which may lead users to copy it directly into the terminal and encounter errors such as `command not found: $`.

This change updates the installation section to display only the executable command inside a fenced `bash` code block for better readability and easier copy-paste.

## Changes
- Replace indented command formatting with a fenced Markdown code block
- Remove the `$` shell prompt from the installation example
- Improve installation instructions readability

### Before

```md
## Installing

### *go get*

    $ go get -u github.com/slack-go/slack
```

### After

```md
## Installing

### *go get*

```bash
go get -u github.com/slack-go/slack
```
```

## Validation
- [x] Documentation change only
- [x] No API changes
- [ ] Run `make pr-prep`