### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - gocritic
     - govet
     - misspell
+    - modernize
     - unconvert
     - unused
   exclusions:

--- a/attachments_test.go
+++ b/attachments_test.go
@@ -58,8 +58,8 @@ func TestAttachment_UnmarshalMarshalJSON_WithBlocks(t *testing.T) {
 	}
 
 	var (
-		actual   interface{}
-		expected interface{}
+		actual   any
+		expected any
 	)
 	if err = json.Unmarshal([]byte(originalAttachmentJson), &expected); err != nil {
 		t.Fatal(err)

--- a/audit.go
+++ b/audit.go
@@ -40,14 +40,14 @@ type AuditEntry struct {
 		IPAddress string `json:"ip_address"`
 	} `json:"context"`
 	Details struct {
-		NewValue      any `json:"new_value"`
-		PreviousValue any `json:"previous_value"`
-		MobileOnly    bool        `json:"mobile_only"`
-		WebOnly       bool        `json:"web_only"`
-		NonSSOOnly    bool        `json:"non_sso_only"`
-		ExportType    string      `json:"export_type"`
-		ExportStart   string      `json:"export_start_ts"`
-		ExportEnd     string      `json:"export_end_ts"`
+		NewValue      any    `json:"new_value"`
+		PreviousValue any    `json:"previous_value"`
+		MobileOnly    bool   `json:"mobile_only"`
+		WebOnly       bool   `json:"web_only"`
+		NonSSOOnly    bool   `json:"non_sso_only"`
+		ExportType    string `json:"export_type"`
+		ExportStart   string `json:"export_start_ts"`
+		ExportEnd     string `json:"export_end_ts"`
 	} `json:"details"`
 }
 

--- a/audit.go
+++ b/audit.go
@@ -40,8 +40,8 @@ type AuditEntry struct {
 		IPAddress string `json:"ip_address"`
 	} `json:"context"`
 	Details struct {
-		NewValue      interface{} `json:"new_value"`
-		PreviousValue interface{} `json:"previous_value"`
+		NewValue      any `json:"new_value"`
+		PreviousValue any `json:"previous_value"`
 		MobileOnly    bool        `json:"mobile_only"`
 		WebOnly       bool        `json:"web_only"`
 		NonSSOOnly    bool        `json:"non_sso_only"`

--- a/block_alert_test.go
+++ b/block_alert_test.go
@@ -53,7 +53,7 @@ func TestAlertBlockJSONRoundTrip(t *testing.T) {
 	marshalled, err := json.Marshal(block)
 	require.NoError(t, err)
 
-	var expected, actual map[string]interface{}
+	var expected, actual map[string]any
 	require.NoError(t, json.Unmarshal([]byte(payload), &expected))
 	require.NoError(t, json.Unmarshal(marshalled, &actual))
 

--- a/block_card_test.go
+++ b/block_card_test.go
@@ -89,7 +89,7 @@ func TestCardBlockJSONRoundTrip(t *testing.T) {
 	marshalled, err := json.Marshal(block)
 	require.NoError(t, err)
 
-	var expected, actual map[string]interface{}
+	var expected, actual map[string]any
 	require.NoError(t, json.Unmarshal([]byte(payload), &expected))
 	require.NoError(t, json.Unmarshal(marshalled, &actual))
 

--- a/block_carousel_test.go
+++ b/block_carousel_test.go
@@ -58,7 +58,7 @@ func TestCarouselBlockJSONRoundTrip(t *testing.T) {
 	marshalled, err := json.Marshal(block)
 	require.NoError(t, err)
 
-	var expected, actual map[string]interface{}
+	var expected, actual map[string]any
 	require.NoError(t, json.Unmarshal([]byte(payload), &expected))
 	require.NoError(t, json.Unmarshal(marshalled, &actual))
 

--- a/block_data_table_test.go
+++ b/block_data_table_test.go
@@ -130,7 +130,7 @@ func TestDataTableBlockJSONRoundTrip(t *testing.T) {
 	marshalled, err := json.Marshal(block)
 	require.NoError(t, err)
 
-	var expected, actual map[string]interface{}
+	var expected, actual map[string]any
 	require.NoError(t, json.Unmarshal([]byte(payload), &expected))
 	require.NoError(t, json.Unmarshal(marshalled, &actual))
 	assert.Equal(t, expected, actual)

--- a/block_json_test.go
+++ b/block_json_test.go
@@ -108,7 +108,7 @@ func TestRawJSONBlockRoundTrip(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Unmarshal both to compare (ignoring whitespace differences)
-		var original, result map[string]interface{}
+		var original, result map[string]any
 		assert.NoError(t, json.Unmarshal([]byte(originalJSON), &original))
 		assert.NoError(t, json.Unmarshal(marshalled, &result))
 
@@ -153,14 +153,14 @@ func TestRawJSONBlockRoundTrip(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Unmarshal both to compare
-		var original, result map[string]interface{}
+		var original, result map[string]any
 		assert.NoError(t, json.Unmarshal([]byte(originalJSON), &original))
 		assert.NoError(t, json.Unmarshal(marshalled, &result))
 
 		assert.Equal(t, original, result, "Complex block should preserve all nested fields")
 
 		// Specifically verify elements array is preserved
-		resultElements, ok := result["elements"].([]interface{})
+		resultElements, ok := result["elements"].([]any)
 		assert.True(t, ok, "elements should be an array")
 		assert.Equal(t, 2, len(resultElements), "should have 2 elements")
 	})
@@ -211,19 +211,19 @@ func TestRawJSONBlockInDeepStructure(t *testing.T) {
 		assert.Equal(t, 3, len(result.Blocks), "should have 3 blocks")
 
 		// Verify the middle block (our RawJSONBlock) has all fields preserved
-		var contextActionsBlock map[string]interface{}
+		var contextActionsBlock map[string]any
 		assert.NoError(t, json.Unmarshal(result.Blocks[1], &contextActionsBlock))
 
 		assert.Equal(t, "context_actions", contextActionsBlock["type"])
 		assert.Equal(t, "feedback_block", contextActionsBlock["block_id"])
 
 		// Verify elements array is present and intact
-		elements, ok := contextActionsBlock["elements"].([]interface{})
+		elements, ok := contextActionsBlock["elements"].([]any)
 		assert.True(t, ok, "elements should be an array")
 		assert.Equal(t, 1, len(elements), "should have 1 element")
 
 		// Verify the nested feedback_buttons element
-		firstElement, ok := elements[0].(map[string]interface{})
+		firstElement, ok := elements[0].(map[string]any)
 		assert.True(t, ok, "first element should be an object")
 		assert.Equal(t, "feedback_buttons", firstElement["type"])
 		assert.Equal(t, "ai_feedback", firstElement["action_id"])

--- a/block_object.go
+++ b/block_object.go
@@ -46,7 +46,7 @@ func (b *BlockObjects) UnmarshalJSON(data []byte) error {
 	}
 
 	for _, r := range raw {
-		var obj map[string]interface{}
+		var obj map[string]any
 		err := json.Unmarshal(r, &obj)
 		if err != nil {
 			return err
@@ -89,7 +89,7 @@ func (b *BlockObjects) UnmarshalJSON(data []byte) error {
 // Ideally would have a better way to identify the block objects for
 // type casting at time of unmarshalling, should be adapted if possible
 // to accomplish in a more reliable manner.
-func getBlockObjectType(obj map[string]interface{}) string {
+func getBlockObjectType(obj map[string]any) string {
 	if t, ok := obj["type"].(string); ok {
 		return t
 	}

--- a/block_plan_test.go
+++ b/block_plan_test.go
@@ -90,7 +90,7 @@ func TestPlanBlockJSONRoundTrip(t *testing.T) {
 	marshalled, err := json.Marshal(block)
 	require.NoError(t, err)
 
-	var expected, actual map[string]interface{}
+	var expected, actual map[string]any
 	err = json.Unmarshal([]byte(payload), &expected)
 	require.NoError(t, err)
 	err = json.Unmarshal(marshalled, &actual)

--- a/block_roundtrip_test.go
+++ b/block_roundtrip_test.go
@@ -103,7 +103,7 @@ func TestBlockRealPayloadRoundTrip(t *testing.T) {
 			marshalled, err := json.Marshal(block)
 			require.NoError(t, err)
 
-			var want, got interface{}
+			var want, got any
 			require.NoError(t, json.Unmarshal([]byte(tt.payload), &want))
 			require.NoError(t, json.Unmarshal(marshalled, &got))
 			assert.Equal(t, want, got,

--- a/block_table_test.go
+++ b/block_table_test.go
@@ -177,7 +177,7 @@ func TestTableBlockHeterogeneousCells(t *testing.T) {
 	marshalled, err := json.Marshal(&tb)
 	assert.NoError(t, err)
 
-	var expected, actual map[string]interface{}
+	var expected, actual map[string]any
 	assert.NoError(t, json.Unmarshal([]byte(payload), &expected))
 	assert.NoError(t, json.Unmarshal(marshalled, &actual))
 	assert.Equal(t, expected, actual)

--- a/block_table_test.go
+++ b/block_table_test.go
@@ -116,7 +116,7 @@ func TestNewTableBlock(t *testing.T) {
 	marshalled, err := json.Marshal(tableBlock)
 	assert.NoError(t, err)
 
-	var expected, actual map[string]interface{}
+	var expected, actual map[string]any
 	err = json.Unmarshal([]byte(testPayload), &expected)
 	assert.NoError(t, err)
 	err = json.Unmarshal(marshalled, &actual)

--- a/block_task_card_test.go
+++ b/block_task_card_test.go
@@ -122,7 +122,7 @@ func TestTaskCardBlockJSONRoundTrip(t *testing.T) {
 	marshalled, err := json.Marshal(block)
 	require.NoError(t, err)
 
-	var expected, actual map[string]interface{}
+	var expected, actual map[string]any
 	err = json.Unmarshal([]byte(payload), &expected)
 	require.NoError(t, err)
 	err = json.Unmarshal(marshalled, &actual)

--- a/chat_test.go
+++ b/chat_test.go
@@ -151,7 +151,7 @@ func TestPostMessage(t *testing.T) {
 				MsgOptionMetadata(
 					SlackMetadata{
 						EventType: "testing-event",
-						EventPayload: map[string]interface{}{
+						EventPayload: map[string]any{
 							"id":   13,
 							"name": "testing-name",
 						},
@@ -255,7 +255,7 @@ func TestPostMessage(t *testing.T) {
 						URL:           "https://example.com/doc/1",
 						ExternalRef:   WorkObjectExternalRef{ID: "1"},
 						EntityType:    EntityTypeFile,
-						EntityPayload: map[string]interface{}{"title": "Doc"},
+						EntityPayload: map[string]any{"title": "Doc"},
 					}},
 				}),
 			},
@@ -294,7 +294,7 @@ func TestPostMessage(t *testing.T) {
 				MsgOptionPostMessageParameters(PostMessageParameters{
 					MetaData: SlackMetadata{
 						EventType: "testing-event",
-						EventPayload: map[string]interface{}{
+						EventPayload: map[string]any{
 							"id":   13,
 							"name": "testing-name",
 						},
@@ -612,7 +612,7 @@ func TestWorkObjectMetadata(t *testing.T) {
 					Type: "document",
 				},
 				EntityType: "slack#/entities/file",
-				EntityPayload: map[string]interface{}{
+				EntityPayload: map[string]any{
 					"title":       "Test Document",
 					"description": "A test document for Work Objects",
 				},
@@ -661,7 +661,7 @@ func TestMsgOptionWorkObjectMetadata(t *testing.T) {
 					ID: "456",
 				},
 				EntityType: "slack#/entities/task",
-				EntityPayload: map[string]interface{}{
+				EntityPayload: map[string]any{
 					"title":  "Test Task",
 					"status": "in_progress",
 				},
@@ -724,7 +724,7 @@ func TestMsgOptionWorkObjectEntity(t *testing.T) {
 			Type: "incident",
 		},
 		EntityType: "slack#/entities/incident",
-		EntityPayload: map[string]interface{}{
+		EntityPayload: map[string]any{
 			"title":    "Production Outage",
 			"severity": "high",
 		},

--- a/dialog.go
+++ b/dialog.go
@@ -47,7 +47,7 @@ type Dialog struct {
 }
 
 // DialogElement abstract type for dialogs.
-type DialogElement interface{}
+type DialogElement any
 
 // DialogCallback DEPRECATED use InteractionCallback
 type DialogCallback InteractionCallback

--- a/entity.go
+++ b/entity.go
@@ -20,7 +20,7 @@ type EntityPresentDetailsParameters struct {
 type EntityDetailsMetadata struct {
 	EntityType    string                `json:"entity_type"`
 	URL           string                `json:"url,omitempty"`
-	ExternalRef   WorkObjectExternalRef `json:"external_ref,omitempty"`
+	ExternalRef   WorkObjectExternalRef `json:"external_ref,omitzero"`
 	EntityPayload map[string]any        `json:"entity_payload"`
 }
 

--- a/entity.go
+++ b/entity.go
@@ -21,7 +21,7 @@ type EntityDetailsMetadata struct {
 	EntityType    string                 `json:"entity_type"`
 	URL           string                 `json:"url,omitempty"`
 	ExternalRef   WorkObjectExternalRef  `json:"external_ref,omitempty"`
-	EntityPayload map[string]interface{} `json:"entity_payload"`
+	EntityPayload map[string]any `json:"entity_payload"`
 }
 
 // EntityDetailsError represents an error response for entity details

--- a/entity.go
+++ b/entity.go
@@ -18,10 +18,10 @@ type EntityPresentDetailsParameters struct {
 
 // EntityDetailsMetadata represents the metadata for entity details
 type EntityDetailsMetadata struct {
-	EntityType    string                 `json:"entity_type"`
-	URL           string                 `json:"url,omitempty"`
-	ExternalRef   WorkObjectExternalRef  `json:"external_ref,omitempty"`
-	EntityPayload map[string]any `json:"entity_payload"`
+	EntityType    string                `json:"entity_type"`
+	URL           string                `json:"url,omitempty"`
+	ExternalRef   WorkObjectExternalRef `json:"external_ref,omitempty"`
+	EntityPayload map[string]any        `json:"entity_payload"`
 }
 
 // EntityDetailsError represents an error response for entity details

--- a/entity_test.go
+++ b/entity_test.go
@@ -17,7 +17,7 @@ func TestEntityPresentDetailsParameters(t *testing.T) {
 				ID:   "123",
 				Type: "document",
 			},
-			EntityPayload: map[string]interface{}{
+			EntityPayload: map[string]any{
 				"title":       "Test Document",
 				"description": "A test document for Work Objects",
 				"status":      "active",
@@ -166,7 +166,7 @@ func TestEntityPresentDetailsWithMetadata(t *testing.T) {
 			ID:   "123",
 			Type: "document",
 		},
-		EntityPayload: map[string]interface{}{
+		EntityPayload: map[string]any{
 			"title":       "Test Document",
 			"description": "A test document for Work Objects",
 		},
@@ -308,7 +308,7 @@ func TestEntityPresentDetailsContext(t *testing.T) {
 			ExternalRef: WorkObjectExternalRef{
 				ID: "456",
 			},
-			EntityPayload: map[string]interface{}{
+			EntityPayload: map[string]any{
 				"title":  "Test Task",
 				"status": "in_progress",
 			},

--- a/examples/socketmode/socketmode.go
+++ b/examples/socketmode/socketmode.go
@@ -122,7 +122,7 @@ func main() {
 
 				fmt.Printf("Interaction received: %+v\n", callback)
 
-				var payload interface{}
+				var payload any
 
 				switch callback.Type {
 				case slack.InteractionTypeBlockActions:
@@ -148,7 +148,7 @@ func main() {
 
 				client.Debugf("Slash command received: %+v", cmd)
 
-				payload := map[string]interface{}{
+				payload := map[string]any{
 					"blocks": []slack.Block{
 						slack.NewSectionBlock(
 							&slack.TextBlockObject{

--- a/examples/socketmode_handler/socketmode_handler.go
+++ b/examples/socketmode_handler/socketmode_handler.go
@@ -174,7 +174,7 @@ func middlewareInteractive(evt *socketmode.Event, client *socketmode.Client) {
 
 	fmt.Printf("Interaction received: %+v\n", callback)
 
-	var payload interface{}
+	var payload any
 
 	switch callback.Type {
 	case slack.InteractionTypeBlockActions:
@@ -204,7 +204,7 @@ func middlewareSlashCommand(evt *socketmode.Event, client *socketmode.Client) {
 
 	client.Debugf("Slash command received: %+v", cmd)
 
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"blocks": []slack.Block{
 			slack.NewSectionBlock(
 				&slack.TextBlockObject{

--- a/files_test.go
+++ b/files_test.go
@@ -461,9 +461,9 @@ func TestCompleteUploadExternalContext(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.title, func(t *testing.T) {
-			var resBody map[string]interface{}
+			var resBody map[string]any
 			if !tc.wantErr {
-				resBody = map[string]interface{}{
+				resBody = map[string]any{
 					"ok": true,
 				}
 				files := make([]map[string]string, 0)
@@ -478,7 +478,7 @@ func TestCompleteUploadExternalContext(t *testing.T) {
 				}
 				resBody["files"] = files
 			} else {
-				resBody = map[string]interface{}{
+				resBody = map[string]any{
 					"ok":    false,
 					"error": "errored",
 				}

--- a/interactions.go
+++ b/interactions.go
@@ -171,7 +171,7 @@ func (a ActionCallbacks) MarshalJSON() ([]byte, error) {
 	length := len(a.AttachmentActions) + len(a.BlockActions)
 	buffer := bytes.NewBufferString("[")
 
-	f := func(obj interface{}) error {
+	f := func(obj any) error {
 		js, err := json.Marshal(obj)
 		if err != nil {
 			return err
@@ -215,7 +215,7 @@ func (a *ActionCallbacks) UnmarshalJSON(data []byte) error {
 	}
 
 	for _, r := range raw {
-		var obj map[string]interface{}
+		var obj map[string]any
 		err := json.Unmarshal(r, &obj)
 		if err != nil {
 			return err

--- a/logger.go
+++ b/logger.go
@@ -13,18 +13,18 @@ type logger interface {
 // ilogger represents the internal logging api we use.
 type ilogger interface {
 	logger
-	Print(...interface{})
-	Printf(string, ...interface{})
-	Println(...interface{})
+	Print(...any)
+	Printf(string, ...any)
+	Println(...any)
 }
 
 type Debug interface {
 	Debug() bool
 
 	// Debugf print a formatted debug line.
-	Debugf(format string, v ...interface{})
+	Debugf(format string, v ...any)
 	// Debugln print a debug line.
-	Debugln(v ...interface{})
+	Debugln(v ...any)
 }
 
 // internalLog implements the additional methods used by our internal logging.
@@ -33,17 +33,17 @@ type internalLog struct {
 }
 
 // Println replicates the behaviour of the standard logger.
-func (t internalLog) Println(v ...interface{}) {
+func (t internalLog) Println(v ...any) {
 	t.Output(2, fmt.Sprintln(v...))
 }
 
 // Printf replicates the behaviour of the standard logger.
-func (t internalLog) Printf(format string, v ...interface{}) {
+func (t internalLog) Printf(format string, v ...any) {
 	t.Output(2, fmt.Sprintf(format, v...))
 }
 
 // Print replicates the behaviour of the standard logger.
-func (t internalLog) Print(v ...interface{}) {
+func (t internalLog) Print(v ...any) {
 	t.Output(2, fmt.Sprint(v...))
 }
 
@@ -54,7 +54,7 @@ func (t discard) Debug() bool {
 }
 
 // Debugf print a formatted debug line.
-func (t discard) Debugf(format string, v ...interface{}) {}
+func (t discard) Debugf(format string, v ...any) {}
 
 // Debugln print a debug line.
-func (t discard) Debugln(v ...interface{}) {}
+func (t discard) Debugln(v ...any) {}

--- a/metadata.go
+++ b/metadata.go
@@ -24,11 +24,11 @@ type WorkObjectExternalRef struct {
 
 // WorkObjectEntity represents a single Work Object entity
 type WorkObjectEntity struct {
-	AppUnfurlURL  string                 `json:"app_unfurl_url,omitempty"`
-	URL           string                 `json:"url"`
-	ExternalRef   WorkObjectExternalRef  `json:"external_ref"`
-	EntityType    string                 `json:"entity_type"`
-	EntityPayload map[string]any `json:"entity_payload"`
+	AppUnfurlURL  string                `json:"app_unfurl_url,omitempty"`
+	URL           string                `json:"url"`
+	ExternalRef   WorkObjectExternalRef `json:"external_ref"`
+	EntityType    string                `json:"entity_type"`
+	EntityPayload map[string]any        `json:"entity_payload"`
 }
 
 // WorkObjectMetadata represents the metadata for Work Objects

--- a/metadata.go
+++ b/metadata.go
@@ -28,7 +28,7 @@ type WorkObjectEntity struct {
 	URL           string                 `json:"url"`
 	ExternalRef   WorkObjectExternalRef  `json:"external_ref"`
 	EntityType    string                 `json:"entity_type"`
-	EntityPayload map[string]interface{} `json:"entity_payload"`
+	EntityPayload map[string]any `json:"entity_payload"`
 }
 
 // WorkObjectMetadata represents the metadata for Work Objects

--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -1043,10 +1043,10 @@ type FunctionExecutedEvent struct {
 		DateDeleted int64  `json:"date_deleted"`
 	} `json:"function"`
 	Inputs              map[string]any `json:"inputs"`
-	FunctionExecutionID string                 `json:"function_execution_id"`
-	WorkflowExecutionID string                 `json:"workflow_execution_id"`
-	EventTs             string                 `json:"event_ts"`
-	BotAccessToken      string                 `json:"bot_access_token"`
+	FunctionExecutionID string         `json:"function_execution_id"`
+	WorkflowExecutionID string         `json:"workflow_execution_id"`
+	EventTs             string         `json:"event_ts"`
+	BotAccessToken      string         `json:"bot_access_token"`
 }
 
 type InviteRequestedEvent struct {
@@ -1117,29 +1117,29 @@ type User struct {
 }
 
 type Profile struct {
-	Title                  string                 `json:"title"`
-	Phone                  string                 `json:"phone"`
-	Skype                  string                 `json:"skype"`
-	RealName               string                 `json:"real_name"`
-	RealNameNormalized     string                 `json:"real_name_normalized"`
-	DisplayName            string                 `json:"display_name"`
-	DisplayNameNormalized  string                 `json:"display_name_normalized"`
+	Title                  string         `json:"title"`
+	Phone                  string         `json:"phone"`
+	Skype                  string         `json:"skype"`
+	RealName               string         `json:"real_name"`
+	RealNameNormalized     string         `json:"real_name_normalized"`
+	DisplayName            string         `json:"display_name"`
+	DisplayNameNormalized  string         `json:"display_name_normalized"`
 	Fields                 map[string]any `json:"fields"`
-	StatusText             string                 `json:"status_text"`
-	StatusEmoji            string                 `json:"status_emoji"`
+	StatusText             string         `json:"status_text"`
+	StatusEmoji            string         `json:"status_emoji"`
 	StatusEmojiDisplayInfo []any          `json:"status_emoji_display_info"`
-	StatusExpiration       int                    `json:"status_expiration"`
-	AvatarHash             string                 `json:"avatar_hash"`
-	FirstName              string                 `json:"first_name"`
-	LastName               string                 `json:"last_name"`
-	Image24                string                 `json:"image_24"`
-	Image32                string                 `json:"image_32"`
-	Image48                string                 `json:"image_48"`
-	Image72                string                 `json:"image_72"`
-	Image192               string                 `json:"image_192"`
-	Image512               string                 `json:"image_512"`
-	StatusTextCanonical    string                 `json:"status_text_canonical"`
-	Team                   string                 `json:"team"`
+	StatusExpiration       int            `json:"status_expiration"`
+	AvatarHash             string         `json:"avatar_hash"`
+	FirstName              string         `json:"first_name"`
+	LastName               string         `json:"last_name"`
+	Image24                string         `json:"image_24"`
+	Image32                string         `json:"image_32"`
+	Image48                string         `json:"image_48"`
+	Image72                string         `json:"image_72"`
+	Image192               string         `json:"image_192"`
+	Image512               string         `json:"image_512"`
+	StatusTextCanonical    string         `json:"status_text_canonical"`
+	Team                   string         `json:"team"`
 }
 
 type UserStatusChangedEvent struct {

--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -11,7 +11,7 @@ import (
 // EventsAPIInnerEvent the inner event of a EventsAPI event_callback Event.
 type EventsAPIInnerEvent struct {
 	Type string `json:"type"`
-	Data interface{}
+	Data any
 }
 
 // AssistantThreadMessageEvent is an (inner) EventsAPI subscribable event.
@@ -954,7 +954,7 @@ type AppRequestedEvent struct {
 			Name   string `json:"name"`
 			Domain string `json:"domain"`
 		} `json:"team"`
-		Enterprise interface{} `json:"enterprise"`
+		Enterprise any `json:"enterprise"`
 		Scopes     []struct {
 			Name        string `json:"name"`
 			Description string `json:"description"`
@@ -1042,7 +1042,7 @@ type FunctionExecutedEvent struct {
 		DateUpdated int64  `json:"date_updated"`
 		DateDeleted int64  `json:"date_deleted"`
 	} `json:"function"`
-	Inputs              map[string]interface{} `json:"inputs"`
+	Inputs              map[string]any `json:"inputs"`
 	FunctionExecutionID string                 `json:"function_execution_id"`
 	WorkflowExecutionID string                 `json:"workflow_execution_id"`
 	EventTs             string                 `json:"event_ts"`
@@ -1124,10 +1124,10 @@ type Profile struct {
 	RealNameNormalized     string                 `json:"real_name_normalized"`
 	DisplayName            string                 `json:"display_name"`
 	DisplayNameNormalized  string                 `json:"display_name_normalized"`
-	Fields                 map[string]interface{} `json:"fields"`
+	Fields                 map[string]any `json:"fields"`
 	StatusText             string                 `json:"status_text"`
 	StatusEmoji            string                 `json:"status_emoji"`
-	StatusEmojiDisplayInfo []interface{}          `json:"status_emoji_display_info"`
+	StatusEmojiDisplayInfo []any          `json:"status_emoji_display_info"`
 	StatusExpiration       int                    `json:"status_expiration"`
 	AvatarHash             string                 `json:"avatar_hash"`
 	FirstName              string                 `json:"first_name"`
@@ -1395,7 +1395,7 @@ const (
 // EventsAPIInnerEventMapping maps INNER Event API events to their corresponding struct
 // implementations. The structs should be instances of the unmarshalling
 // target for the matching event type.
-var EventsAPIInnerEventMapping = map[EventsAPIType]interface{}{
+var EventsAPIInnerEventMapping = map[EventsAPIType]any{
 	AppDeleted:                    AppDeletedEvent{},
 	AppHomeOpened:                 AppHomeOpenedEvent{},
 	AppInstalled:                  AppInstalledEvent{},

--- a/slackevents/outer_events.go
+++ b/slackevents/outer_events.go
@@ -13,7 +13,7 @@ type EventsAPIEvent struct {
 	Type         string `json:"type"`
 	APIAppID     string `json:"api_app_id"`
 	EnterpriseID string `json:"enterprise_id"`
-	Data         interface{}
+	Data         any
 	InnerEvent   EventsAPIInnerEvent
 }
 
@@ -65,7 +65,7 @@ const (
 // EventsAPIEventMap maps OUTER Event API events to their corresponding struct
 // implementations. The structs should be instances of the unmarshalling
 // target for the matching event type.
-var EventsAPIEventMap = map[string]interface{}{
+var EventsAPIEventMap = map[string]any{
 	CallbackEvent:   EventsAPICallbackEvent{},
 	URLVerification: EventsAPIURLVerificationEvent{},
 	AppRateLimited:  EventsAPIAppRateLimited{},

--- a/slackevents/parsers.go
+++ b/slackevents/parsers.go
@@ -13,7 +13,7 @@ import (
 // eventsMap checks both slackevents.EventsAPIInnerEventMapping and slack.EventMapping
 // (RTM). EventsAPI mapping is checked first because both define a "message" type, and
 // EventsAPI's MessageEvent is the correct choice for Events API payloads.
-func eventsMap(t string) (interface{}, bool) {
+func eventsMap(t string) (any, bool) {
 	// EventsAPI mapping takes precedence over RTM mapping.
 	v, exists := EventsAPIInnerEventMapping[EventsAPIType(t)]
 	if exists {

--- a/slash.go
+++ b/slash.go
@@ -65,7 +65,7 @@ func (s *SlashCommand) UnmarshalJSON(data []byte) error {
 	type SlashCommandCopy SlashCommand
 	scopy := &struct {
 		*SlashCommandCopy
-		IsEnterpriseInstall interface{} `json:"is_enterprise_install"`
+		IsEnterpriseInstall any `json:"is_enterprise_install"`
 	}{
 		SlashCommandCopy: (*SlashCommandCopy)(s),
 	}

--- a/socket_mode.go
+++ b/socket_mode.go
@@ -9,7 +9,7 @@ import (
 // It is returned by an "apps.connections.open" API call.
 type SocketModeConnection struct {
 	URL  string                 `json:"url,omitempty"`
-	Data map[string]interface{} `json:"-"`
+	Data map[string]any `json:"-"`
 }
 
 type openResponseFull struct {

--- a/socket_mode.go
+++ b/socket_mode.go
@@ -8,7 +8,7 @@ import (
 // SocketModeConnection contains various details about the SocketMode connection.
 // It is returned by an "apps.connections.open" API call.
 type SocketModeConnection struct {
-	URL  string                 `json:"url,omitempty"`
+	URL  string         `json:"url,omitempty"`
 	Data map[string]any `json:"-"`
 }
 

--- a/socketmode/event.go
+++ b/socketmode/event.go
@@ -5,7 +5,7 @@ import "encoding/json"
 // Event is the event sent to the consumer of Client
 type Event struct {
 	Type EventType
-	Data interface{}
+	Data any
 
 	// Request is the json-decoded raw WebSocket message that is received via the Slack Socket Mode
 	// WebSocket connection.

--- a/socketmode/log.go
+++ b/socketmode/log.go
@@ -13,9 +13,9 @@ type logger interface {
 // ilogger represents the internal logging api we use.
 type ilogger interface {
 	logger
-	Print(...interface{})
-	Printf(string, ...interface{})
-	Println(...interface{})
+	Print(...any)
+	Printf(string, ...any)
+	Println(...any)
 }
 
 // internalLog implements the additional methods used by our internal logging.
@@ -24,27 +24,27 @@ type internalLog struct {
 }
 
 // Println replicates the behaviour of the standard logger.
-func (t internalLog) Println(v ...interface{}) {
+func (t internalLog) Println(v ...any) {
 	t.Output(2, fmt.Sprintln(v...))
 }
 
 // Printf replicates the behaviour of the standard logger.
-func (t internalLog) Printf(format string, v ...interface{}) {
+func (t internalLog) Printf(format string, v ...any) {
 	t.Output(2, fmt.Sprintf(format, v...))
 }
 
 // Print replicates the behaviour of the standard logger.
-func (t internalLog) Print(v ...interface{}) {
+func (t internalLog) Print(v ...any) {
 	t.Output(2, fmt.Sprint(v...))
 }
 
-func (smc *Client) Debugf(format string, v ...interface{}) {
+func (smc *Client) Debugf(format string, v ...any) {
 	if smc.debug {
 		smc.log.Output(2, fmt.Sprintf(format, v...))
 	}
 }
 
-func (smc *Client) Debugln(v ...interface{}) {
+func (smc *Client) Debugln(v ...any) {
 	if smc.debug {
 		smc.log.Output(2, fmt.Sprintln(v...))
 	}

--- a/socketmode/response.go
+++ b/socketmode/response.go
@@ -2,7 +2,7 @@ package socketmode
 
 type Response struct {
 	EnvelopeID string      `json:"envelope_id"`
-	Payload    interface{} `json:"payload,omitempty"`
+	Payload    any `json:"payload,omitempty"`
 
 	// rawJSON holds the pre-marshaled JSON bytes when set by SendCtx.
 	// This avoids double-marshaling: once for the size check and once for

--- a/socketmode/response.go
+++ b/socketmode/response.go
@@ -1,8 +1,8 @@
 package socketmode
 
 type Response struct {
-	EnvelopeID string      `json:"envelope_id"`
-	Payload    any `json:"payload,omitempty"`
+	EnvelopeID string `json:"envelope_id"`
+	Payload    any    `json:"payload,omitempty"`
 
 	// rawJSON holds the pre-marshaled JSON bytes when set by SendCtx.
 	// This avoids double-marshaling: once for the size check and once for

--- a/socketmode/socket_mode_managed_conn.go
+++ b/socketmode/socket_mode_managed_conn.go
@@ -448,7 +448,7 @@ func unsafeWriteSocketModeResponse(conn *websocket.Conn, res *Response) error {
 	return conn.WriteJSON(res)
 }
 
-func newEvent(tpe EventType, data interface{}, req ...*Request) Event {
+func newEvent(tpe EventType, data any, req ...*Request) Event {
 	evt := Event{Type: tpe, Data: data}
 
 	if len(req) > 0 {
@@ -466,8 +466,8 @@ func newEvent(tpe EventType, data interface{}, req ...*Request) Event {
 // Returns an error if the serialized response is 20KB or larger, as Slack
 // silently drops oversized Socket Mode responses. Use Web API methods (e.g.
 // chat.PostMessage, views.Push) for large payloads.
-func (smc *Client) Ack(req Request, payload ...interface{}) error {
-	var pld interface{}
+func (smc *Client) Ack(req Request, payload ...any) error {
+	var pld any
 	if len(payload) > 0 {
 		pld = payload[0]
 	}
@@ -482,7 +482,7 @@ func (smc *Client) Ack(req Request, payload ...interface{}) error {
 //
 // Returns an error if the serialized response is 20KB or larger, as Slack
 // silently drops oversized Socket Mode responses.
-func (smc *Client) AckCtx(ctx context.Context, reqID string, payload interface{}) error {
+func (smc *Client) AckCtx(ctx context.Context, reqID string, payload any) error {
 	return smc.SendCtx(ctx, Response{
 		EnvelopeID: reqID,
 		Payload:    payload,

--- a/socketmode/socketmode_test.go
+++ b/socketmode/socketmode_test.go
@@ -275,7 +275,7 @@ func TestEventParsing(t *testing.T) {
 		})
 }
 
-func testParsing(t *testing.T, raw string, want interface{}) {
+func testParsing(t *testing.T, raw string, want any) {
 	t.Helper()
 
 	got, err := parse(raw)
@@ -288,7 +288,7 @@ func testParsing(t *testing.T, raw string, want interface{}) {
 	}
 }
 
-func dump(t *testing.T, data interface{}) string {
+func dump(t *testing.T, data any) string {
 	t.Helper()
 
 	var buf bytes.Buffer

--- a/team.go
+++ b/team.go
@@ -12,10 +12,10 @@ type TeamResponse struct {
 }
 
 type TeamInfo struct {
-	ID          string                 `json:"id"`
-	Name        string                 `json:"name"`
-	Domain      string                 `json:"domain"`
-	EmailDomain string                 `json:"email_domain"`
+	ID          string         `json:"id"`
+	Name        string         `json:"name"`
+	Domain      string         `json:"domain"`
+	EmailDomain string         `json:"email_domain"`
 	Icon        map[string]any `json:"icon"`
 }
 

--- a/team.go
+++ b/team.go
@@ -16,7 +16,7 @@ type TeamInfo struct {
 	Name        string                 `json:"name"`
 	Domain      string                 `json:"domain"`
 	EmailDomain string                 `json:"email_domain"`
-	Icon        map[string]interface{} `json:"icon"`
+	Icon        map[string]any `json:"icon"`
 }
 
 type TeamProfileResponse struct {

--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -321,7 +321,7 @@ func (rtm *RTM) handleIncomingEvents(events chan json.RawMessage) {
 	}
 }
 
-func (rtm *RTM) sendWithDeadline(msg interface{}) error {
+func (rtm *RTM) sendWithDeadline(msg any) error {
 	// set a write deadline on the connection
 	if err := rtm.conn.SetWriteDeadline(time.Now().Add(10 * time.Second)); err != nil {
 		return err
@@ -518,7 +518,7 @@ func (rtm *RTM) handleEvent(typeStr string, event json.RawMessage) {
 // EventMapping holds a mapping of event names to their corresponding struct
 // implementations. The structs should be instances of the unmarshalling
 // target for the matching event type.
-var EventMapping = map[string]interface{}{
+var EventMapping = map[string]any{
 	"message":         MessageEvent{},
 	"presence_change": PresenceChangeEvent{},
 	"user_typing":     UserTypingEvent{},

--- a/websocket_misc.go
+++ b/websocket_misc.go
@@ -35,7 +35,7 @@ type MessageEvent Message
 // RTMEvent is the main wrapper. You will find all the other messages attached
 type RTMEvent struct {
 	Type string
-	Data interface{}
+	Data any
 }
 
 // HelloEvent represents the hello event


### PR DESCRIPTION
Replace all occurrences of  with  (available since Go 1.18) for modern Go idiom.

Fixes 34 files found via code search.