### PR TITLE
fix!: preserve all cell types in `TableBlock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+> [!WARNING]
+> **Breaking change.**
+
+- `TableBlock.Rows` is now `[][]TableCell` (was `[][]*RichTextBlock`), so `table`
+  blocks no longer drop `raw_text`, `raw_number`, and `null` cells (#1558).
+
 ## [0.24.0]
 
 ### Added

--- a/block_roundtrip_test.go
+++ b/block_roundtrip_test.go
@@ -1,0 +1,113 @@
+package slack
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBlockRealPayloadRoundTrip is a guardrail against silent data loss when decoding the
+// JSON that Slack actually sends.
+//
+// Each case is a single block payload written as raw JSON in the shape Slack delivers
+// (i.e. authored from the JSON in, not built via the SDK constructors — that distinction
+// matters, see below). Every case is decoded through the same path inbound events take —
+// Blocks.UnmarshalJSON, which dispatches to the concrete block type — and the test asserts:
+//
+//  1. it decodes into a recognised concrete block (never UnknownBlock), and
+//  2. re-marshalling the decoded block reproduces the input exactly (semantic JSON equality).
+//
+// (2) is the important part: a field the concrete type fails to model — like the per-cell
+// text that went missing in issue #1558 — disappears on the way back out and fails the
+// comparison. Constructor-based tests can't catch this, because they only ever serialise
+// what the SDK already knows how to represent.
+//
+// Note this deliberately does NOT use BlockFromJSON: that helper preserves the raw bytes and
+// echoes them back unchanged, so it would round-trip any payload perfectly while exercising
+// none of the concrete UnmarshalJSON logic this guardrail exists to protect.
+//
+// To cover a new block, add a case below with a payload in the shape Slack sends. If it
+// doesn't round-trip, the SDK is dropping something Slack sent — fix the type, don't trim
+// the payload.
+func TestBlockRealPayloadRoundTrip(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{
+			// A table pasted from a spreadsheet (issue #1558): a bold rich_text header
+			// row, raw_text/raw_number data cells, and a null cell for an empty space.
+			name: "table with mixed cell types and an empty cell",
+			payload: `{
+				"type": "table",
+				"block_id": "tbl_pasted",
+				"rows": [
+					[
+						{"type": "rich_text", "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": "Name", "style": {"bold": true}}]}]},
+						{"type": "rich_text", "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": "Score", "style": {"bold": true}}]}]}
+					],
+					[
+						{"type": "raw_text", "text": "Alice"},
+						{"type": "raw_number", "value": 42}
+					],
+					[
+						{"type": "raw_text", "text": "Bob"},
+						null
+					]
+				]
+			}`,
+		},
+		{
+			name: "data_table with raw_text, raw_number and rich_text cells",
+			payload: `{
+				"type": "data_table",
+				"block_id": "dt-1",
+				"caption": "A Fabulous Table",
+				"page_size": 5,
+				"rows": [
+					[
+						{"type": "raw_text", "text": "Name"},
+						{"type": "raw_text", "text": "Department"},
+						{"type": "raw_text", "text": "Badge"}
+					],
+					[
+						{"type": "raw_text", "text": "Helly"},
+						{"type": "raw_text", "text": "MDR"},
+						{"type": "rich_text", "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": "Blue", "style": {"bold": true}}]}]}
+					],
+					[
+						{"type": "raw_text", "text": "Score"},
+						{"type": "raw_text", "text": "Wellness"},
+						{"type": "raw_number", "value": 97}
+					]
+				]
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Slack delivers blocks as a JSON array; Blocks.UnmarshalJSON is what
+			// dispatches each element to its concrete type.
+			var blocks Blocks
+			require.NoError(t, json.Unmarshal([]byte("["+tt.payload+"]"), &blocks), "payload failed to decode")
+			require.Len(t, blocks.BlockSet, 1)
+
+			block := blocks.BlockSet[0]
+			_, isUnknown := block.(*UnknownBlock)
+			assert.False(t, isUnknown,
+				"payload decoded to an UnknownBlock; the block type is not modelled")
+
+			marshalled, err := json.Marshal(block)
+			require.NoError(t, err)
+
+			var want, got interface{}
+			require.NoError(t, json.Unmarshal([]byte(tt.payload), &want))
+			require.NoError(t, json.Unmarshal(marshalled, &got))
+			assert.Equal(t, want, got,
+				"round-trip lost or altered data: the concrete block type is not preserving everything Slack sent")
+		})
+	}
+}

--- a/block_table.go
+++ b/block_table.go
@@ -1,13 +1,118 @@
 package slack
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// TableCellType identifies the variant of a cell inside a TableBlock row.
+type TableCellType string
+
+const (
+	TableCellRawText   TableCellType = "raw_text"
+	TableCellRawNumber TableCellType = "raw_number"
+	TableCellRichText  TableCellType = "rich_text"
+)
+
+// TableCell is implemented by every cell type valid inside a TableBlock row:
+// TableRichTextCell, TableRawTextCell, and TableRawNumberCell. A nil TableCell
+// represents an empty cell, which Slack sends as null (common in user-pasted tables).
+type TableCell interface {
+	TableCellType() TableCellType
+}
+
+// TableRichTextCell is a cell holding rich text formatting. Slack uses rich_text cells
+// for styled content such as the bold header row of a pasted table.
+type TableRichTextCell struct {
+	Type     TableCellType     `json:"type"`
+	Elements []RichTextElement `json:"elements"`
+}
+
+// TableCellType returns the cell variant.
+func (c TableRichTextCell) TableCellType() TableCellType {
+	return c.Type
+}
+
+// NewTableRichTextCell returns a rich_text cell with the given rich text elements.
+func NewTableRichTextCell(elements ...RichTextElement) *TableRichTextCell {
+	return &TableRichTextCell{Type: TableCellRichText, Elements: elements}
+}
+
+// UnmarshalJSON delegates rich text element parsing to RichTextBlock so the cell handles
+// the same set of inner elements (sections, lists, quotes, preformatted, unknown).
+func (c *TableRichTextCell) UnmarshalJSON(data []byte) error {
+	var rt RichTextBlock
+	if err := json.Unmarshal(data, &rt); err != nil {
+		return err
+	}
+	c.Type = TableCellRichText
+	c.Elements = rt.Elements
+	return nil
+}
+
+// TableRawTextCell is a plain-text cell in a TableBlock. Slack sends raw_text cells for
+// non-numeric data, including text pasted from a spreadsheet.
+type TableRawTextCell struct {
+	Type TableCellType `json:"type"`
+	Text string        `json:"text"`
+}
+
+// TableCellType returns the cell variant.
+func (c TableRawTextCell) TableCellType() TableCellType {
+	return c.Type
+}
+
+// NewTableRawTextCell returns a raw_text cell with the given text.
+func NewTableRawTextCell(text string) *TableRawTextCell {
+	return &TableRawTextCell{Type: TableCellRawText, Text: text}
+}
+
+// TableRawNumberCell is a numeric cell in a TableBlock. Text, when set, overrides the
+// displayed value.
+//
+// raw_number cells are receive-only: Slack emits them for numeric columns in user-pasted
+// tables, but chat.postMessage rejects them. To post a number, use a TableRawTextCell. See
+// TableBlock for the full list of postable vs receive-only cell types.
+type TableRawNumberCell struct {
+	Type  TableCellType `json:"type"`
+	Value float64       `json:"value"`
+	Text  string        `json:"text,omitempty"`
+}
+
+// TableCellType returns the cell variant.
+func (c TableRawNumberCell) TableCellType() TableCellType {
+	return c.Type
+}
+
+// NewTableRawNumberCell returns a raw_number cell with the given value.
+func NewTableRawNumberCell(value float64) *TableRawNumberCell {
+	return &TableRawNumberCell{Type: TableCellRawNumber, Value: value}
+}
+
+// WithText sets the display text shown in place of the numeric value.
+func (c *TableRawNumberCell) WithText(text string) *TableRawNumberCell {
+	c.Text = text
+	return c
+}
+
 // TableBlock defines a block that lets you use a table to display your data.
+//
+// Rows is an array of cell arrays. Each cell is a TableRichTextCell, TableRawTextCell,
+// or TableRawNumberCell; a nil cell represents an empty cell (Slack sends null).
+//
+// Not every cell type can be posted. chat.postMessage validates a table cell against two
+// schemas only: raw_text (TableRawTextCell, requires "text") and rich_text
+// (TableRichTextCell, requires "elements"). TableRawNumberCell and nil cells are produced
+// by Slack on output — numeric columns and empty cells in user-pasted tables — but the API
+// rejects them on input with invalid_blocks. So you may receive all cell types, but post
+// only raw_text and rich_text; render a number you want to send as a raw_text cell.
 //
 // More Information: https://docs.slack.dev/reference/block-kit/blocks/table-block/
 type TableBlock struct {
-	Type           MessageBlockType   `json:"type"`
-	BlockID        string             `json:"block_id,omitempty"`
-	Rows           [][]*RichTextBlock `json:"rows"`
-	ColumnSettings []ColumnSetting    `json:"column_settings,omitempty"`
+	Type           MessageBlockType `json:"type"`
+	BlockID        string           `json:"block_id,omitempty"`
+	Rows           [][]TableCell    `json:"rows"`
+	ColumnSettings []ColumnSetting  `json:"column_settings,omitempty"`
 }
 
 type ColumnAlignment string
@@ -33,6 +138,59 @@ func (s TableBlock) ID() string {
 	return s.BlockID
 }
 
+// UnmarshalJSON parses the heterogeneous cell types in each row. A null cell is decoded
+// as a nil TableCell.
+func (s *TableBlock) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Type           MessageBlockType    `json:"type"`
+		BlockID        string              `json:"block_id"`
+		ColumnSettings []ColumnSetting     `json:"column_settings"`
+		Rows           [][]json.RawMessage `json:"rows"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	rows := make([][]TableCell, 0, len(raw.Rows))
+	for _, rawRow := range raw.Rows {
+		row := make([]TableCell, 0, len(rawRow))
+		for _, rawCell := range rawRow {
+			if len(rawCell) == 0 || string(rawCell) == "null" {
+				row = append(row, nil)
+				continue
+			}
+			var probe struct {
+				Type TableCellType `json:"type"`
+			}
+			if err := json.Unmarshal(rawCell, &probe); err != nil {
+				return err
+			}
+			var cell TableCell
+			switch probe.Type {
+			case TableCellRawText:
+				cell = &TableRawTextCell{}
+			case TableCellRawNumber:
+				cell = &TableRawNumberCell{}
+			case TableCellRichText:
+				cell = &TableRichTextCell{}
+			default:
+				return fmt.Errorf("unsupported table cell type %q", probe.Type)
+			}
+			if err := json.Unmarshal(rawCell, cell); err != nil {
+				return err
+			}
+			row = append(row, cell)
+		}
+		rows = append(rows, row)
+	}
+
+	s.Type = raw.Type
+	s.BlockID = raw.BlockID
+	s.ColumnSettings = raw.ColumnSettings
+	s.Rows = rows
+	return nil
+}
+
 // WithColumnSettings sets the column settings for the Table Block
 func (s *TableBlock) WithColumnSettings(columnSettings ...ColumnSetting) *TableBlock {
 	s.ColumnSettings = columnSettings
@@ -40,8 +198,8 @@ func (s *TableBlock) WithColumnSettings(columnSettings ...ColumnSetting) *TableB
 }
 
 // AddRow adds a new row of cells to the Table Block
-func (s *TableBlock) AddRow(cells ...*RichTextBlock) *TableBlock {
-	s.Rows = append(s.Rows, append([]*RichTextBlock{}, cells...))
+func (s *TableBlock) AddRow(cells ...TableCell) *TableBlock {
+	s.Rows = append(s.Rows, append([]TableCell{}, cells...))
 	return s
 }
 
@@ -50,6 +208,6 @@ func NewTableBlock(blockID string) *TableBlock {
 	return &TableBlock{
 		Type:    MBTTable,
 		BlockID: blockID,
-		Rows:    make([][]*RichTextBlock, 0),
+		Rows:    make([][]TableCell, 0),
 	}
 }

--- a/block_table_test.go
+++ b/block_table_test.go
@@ -73,49 +73,37 @@ func TestNewTableBlock(t *testing.T) {
 
 	tableBlock := NewTableBlock("test1")
 
-	tableBlock.AddRow(&RichTextBlock{
-		Type: MBTRichText,
-		Elements: []RichTextElement{
-			&RichTextSection{
-				Type: RTESection,
-				Elements: []RichTextSectionElement{
-					&RichTextSectionTextElement{Type: RTSEText, Text: "Col1"},
-				},
+	tableBlock.AddRow(NewTableRichTextCell(
+		&RichTextSection{
+			Type: RTESection,
+			Elements: []RichTextSectionElement{
+				&RichTextSectionTextElement{Type: RTSEText, Text: "Col1"},
 			},
 		},
-	}, &RichTextBlock{
-		Type: MBTRichText,
-		Elements: []RichTextElement{
-			&RichTextSection{
-				Type: RTESection,
-				Elements: []RichTextSectionElement{
-					&RichTextSectionTextElement{Type: RTSEText, Text: "Col2"},
-				},
+	), NewTableRichTextCell(
+		&RichTextSection{
+			Type: RTESection,
+			Elements: []RichTextSectionElement{
+				&RichTextSectionTextElement{Type: RTSEText, Text: "Col2"},
 			},
 		},
-	})
+	))
 
-	tableBlock.AddRow(&RichTextBlock{
-		Type: MBTRichText,
-		Elements: []RichTextElement{
-			&RichTextSection{
-				Type: RTESection,
-				Elements: []RichTextSectionElement{
-					&RichTextSectionTextElement{Type: RTSEText, Text: "Val1"},
-				},
+	tableBlock.AddRow(NewTableRichTextCell(
+		&RichTextSection{
+			Type: RTESection,
+			Elements: []RichTextSectionElement{
+				&RichTextSectionTextElement{Type: RTSEText, Text: "Val1"},
 			},
 		},
-	}, &RichTextBlock{
-		Type: MBTRichText,
-		Elements: []RichTextElement{
-			&RichTextSection{
-				Type: RTESection,
-				Elements: []RichTextSectionElement{
-					&RichTextSectionTextElement{Type: RTSEText, Text: "Val2"},
-				},
+	), NewTableRichTextCell(
+		&RichTextSection{
+			Type: RTESection,
+			Elements: []RichTextSectionElement{
+				&RichTextSectionTextElement{Type: RTSEText, Text: "Val2"},
 			},
 		},
-	})
+	))
 
 	assert.Equal(t, tableBlock.BlockType(), MBTTable)
 	assert.Equal(t, string(tableBlock.Type), "table")
@@ -135,4 +123,69 @@ func TestNewTableBlock(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, expected, actual)
+}
+
+// TestTableBlockHeterogeneousCells covers the case reported in issue #1558: tables
+// pasted from a spreadsheet deliver header cells as rich_text and data cells as
+// raw_text/raw_number, with null for empty cells. All cell text must be preserved
+// across an unmarshal/marshal round trip.
+func TestTableBlockHeterogeneousCells(t *testing.T) {
+	payload := `{
+		"type":"table",
+		"block_id":"t1",
+		"rows":[
+			[
+				{"type":"rich_text","elements":[{"type":"rich_text_section","elements":[{"type":"text","text":"Name","style":{"bold":true}}]}]},
+				{"type":"rich_text","elements":[{"type":"rich_text_section","elements":[{"type":"text","text":"Score","style":{"bold":true}}]}]}
+			],
+			[
+				{"type":"raw_text","text":"Alice"},
+				{"type":"raw_number","value":42}
+			],
+			[
+				{"type":"raw_text","text":"Bob"},
+				null
+			]
+		]
+	}`
+
+	var tb TableBlock
+	err := json.Unmarshal([]byte(payload), &tb)
+	assert.NoError(t, err)
+	assert.Equal(t, MBTTable, tb.BlockType())
+	assert.Len(t, tb.Rows, 3)
+
+	// Header row: rich_text cells.
+	header, ok := tb.Rows[0][0].(*TableRichTextCell)
+	assert.True(t, ok)
+	assert.Equal(t, TableCellRichText, header.TableCellType())
+	assert.Len(t, header.Elements, 1)
+
+	// Data row: raw_text + raw_number must keep their values.
+	rawText, ok := tb.Rows[1][0].(*TableRawTextCell)
+	assert.True(t, ok)
+	assert.Equal(t, "Alice", rawText.Text)
+
+	rawNumber, ok := tb.Rows[1][1].(*TableRawNumberCell)
+	assert.True(t, ok)
+	assert.Equal(t, float64(42), rawNumber.Value)
+
+	// Empty cell decodes as nil.
+	assert.Nil(t, tb.Rows[2][1])
+
+	// Round trip preserves the payload.
+	marshalled, err := json.Marshal(&tb)
+	assert.NoError(t, err)
+
+	var expected, actual map[string]interface{}
+	assert.NoError(t, json.Unmarshal([]byte(payload), &expected))
+	assert.NoError(t, json.Unmarshal(marshalled, &actual))
+	assert.Equal(t, expected, actual)
+}
+
+func TestTableBlockUnsupportedCellType(t *testing.T) {
+	payload := `{"type":"table","rows":[[{"type":"bogus","text":"x"}]]}`
+	var tb TableBlock
+	err := json.Unmarshal([]byte(payload), &tb)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
TableBlock.Rows was typed [][]*RichTextBlock, so it can't represent anything but `rich_text` cells.

Slack's table block does support `raw_text` and `raw_number` and `null` for empty cells which meant that trying to decode those into *RichTextBlock would silently drop their content.

I've changed the `Rows` to instead become a union of concrete cell types according to the documentation:

- `TableRichTextCell` (rich_text, "elements")
- `TableRawTextCell` (raw_text, "text")
- `TableRawNumberCell` (raw_number, "value")
- `nil` (empty cell; I believe slack just sends null)

Funnily enough (not funny at all!) it doesn't seem possible to use `raw_number` when posting a message to slack, only `raw_text` or `rich_text`, therefore I've documented that.

BREAKING CHANGE: TableBlock.Rows is no [][]TableCell instead of [][]*RichTextBlock.