### PR TITLE
feat: unmarshal is_ext_shared_channel field in EventsAPIEvent

### DIFF
--- a/slackevents/outer_events.go
+++ b/slackevents/outer_events.go
@@ -8,13 +8,14 @@ import (
 
 // EventsAPIEvent is the base EventsAPIEvent
 type EventsAPIEvent struct {
-	Token        string `json:"token"`
-	TeamID       string `json:"team_id"`
-	Type         string `json:"type"`
-	APIAppID     string `json:"api_app_id"`
-	EnterpriseID string `json:"enterprise_id"`
-	Data         any
-	InnerEvent   EventsAPIInnerEvent
+	Token              string `json:"token"`
+	TeamID             string `json:"team_id"`
+	Type               string `json:"type"`
+	APIAppID           string `json:"api_app_id"`
+	EnterpriseID       string `json:"enterprise_id"`
+	IsExtSharedChannel bool   `json:"is_ext_shared_channel"`
+	Data               any
+	InnerEvent         EventsAPIInnerEvent
 }
 
 // EventsAPIURLVerificationEvent received when configuring a EventsAPI driven app

--- a/slackevents/outer_events_test.go
+++ b/slackevents/outer_events_test.go
@@ -33,7 +33,8 @@ func TestCallBackEvent(t *testing.T) {
 				"type": "event_callback",
 				"authed_users": [ "UXXXXXXX1" ],
 				"event_id": "Ev08MFMKH6",
-				"event_time": 1234567890
+				"event_time": 1234567890,
+				"is_ext_shared_channel": true
 		}
 	`)
 	err := json.Unmarshal(rawE, &EventsAPICallbackEvent{})

--- a/slackevents/parsers.go
+++ b/slackevents/parsers.go
@@ -33,6 +33,7 @@ func parseOuterEvent(rawE json.RawMessage) (EventsAPIEvent, error) {
 			"unmarshalling_error",
 			"",
 			"",
+			false,
 			&slack.UnmarshallingErrorEvent{ErrorObj: err},
 			EventsAPIInnerEvent{},
 		}, err
@@ -47,6 +48,7 @@ func parseOuterEvent(rawE json.RawMessage) (EventsAPIEvent, error) {
 				"unmarshalling_error",
 				"",
 				"",
+				false,
 				&slack.UnmarshallingErrorEvent{ErrorObj: err},
 				EventsAPIInnerEvent{},
 			}, err
@@ -57,6 +59,7 @@ func parseOuterEvent(rawE json.RawMessage) (EventsAPIEvent, error) {
 			e.Type,
 			e.APIAppID,
 			e.EnterpriseID,
+			e.IsExtSharedChannel,
 			cbEvent,
 			EventsAPIInnerEvent{},
 		}, nil
@@ -70,6 +73,7 @@ func parseOuterEvent(rawE json.RawMessage) (EventsAPIEvent, error) {
 			"unmarshalling_error",
 			"",
 			"",
+			false,
 			&slack.UnmarshallingErrorEvent{ErrorObj: err},
 			EventsAPIInnerEvent{},
 		}, err
@@ -80,6 +84,7 @@ func parseOuterEvent(rawE json.RawMessage) (EventsAPIEvent, error) {
 		e.Type,
 		e.APIAppID,
 		e.EnterpriseID,
+		e.IsExtSharedChannel,
 		urlVE,
 		EventsAPIInnerEvent{},
 	}, nil
@@ -96,6 +101,7 @@ func parseInnerEvent(e *EventsAPICallbackEvent) (EventsAPIEvent, error) {
 			"unmarshalling_error",
 			e.APIAppID,
 			e.EnterpriseID,
+			false,
 			&slack.UnmarshallingErrorEvent{ErrorObj: err},
 			EventsAPIInnerEvent{},
 		}, err
@@ -108,6 +114,7 @@ func parseInnerEvent(e *EventsAPICallbackEvent) (EventsAPIEvent, error) {
 			iE.Type,
 			e.APIAppID,
 			e.EnterpriseID,
+			false,
 			nil,
 			EventsAPIInnerEvent{},
 		}, fmt.Errorf("inner Event does not exist! %s", iE.Type)
@@ -122,6 +129,7 @@ func parseInnerEvent(e *EventsAPICallbackEvent) (EventsAPIEvent, error) {
 			"unmarshalling_error",
 			e.APIAppID,
 			e.EnterpriseID,
+			false,
 			&slack.UnmarshallingErrorEvent{ErrorObj: err},
 			EventsAPIInnerEvent{},
 		}, err
@@ -132,6 +140,7 @@ func parseInnerEvent(e *EventsAPICallbackEvent) (EventsAPIEvent, error) {
 		e.Type,
 		e.APIAppID,
 		e.EnterpriseID,
+		false,
 		e,
 		EventsAPIInnerEvent{iE.Type, recvEvent},
 	}, nil
@@ -199,6 +208,7 @@ func ParseEvent(rawEvent json.RawMessage, opts ...Option) (EventsAPIEvent, error
 				"unmarshalling_error",
 				"",
 				"",
+				false,
 				&slack.UnmarshallingErrorEvent{ErrorObj: err},
 				EventsAPIInnerEvent{},
 			}, err
@@ -216,6 +226,7 @@ func ParseEvent(rawEvent json.RawMessage, opts ...Option) (EventsAPIEvent, error
 				"unmarshalling_error",
 				"",
 				"",
+				false,
 				&slack.UnmarshallingErrorEvent{ErrorObj: err},
 				EventsAPIInnerEvent{},
 			}, err
@@ -226,6 +237,7 @@ func ParseEvent(rawEvent json.RawMessage, opts ...Option) (EventsAPIEvent, error
 			e.Type,
 			e.APIAppID,
 			e.EnterpriseID,
+			e.IsExtSharedChannel,
 			appRateLimitedEvent,
 			EventsAPIInnerEvent{},
 		}, nil
@@ -240,6 +252,7 @@ func ParseEvent(rawEvent json.RawMessage, opts ...Option) (EventsAPIEvent, error
 			"unmarshalling_error",
 			"",
 			"",
+			false,
 			&slack.UnmarshallingErrorEvent{ErrorObj: err},
 			EventsAPIInnerEvent{},
 		}, err
@@ -250,6 +263,7 @@ func ParseEvent(rawEvent json.RawMessage, opts ...Option) (EventsAPIEvent, error
 		e.Type,
 		e.APIAppID,
 		e.EnterpriseID,
+		e.IsExtSharedChannel,
 		urlVerificationEvent,
 		EventsAPIInnerEvent{},
 	}, nil


### PR DESCRIPTION
Fixes https://github.com/slack-go/slack/issues/1564

Adds `IsExtSharedChannel` to the `EventsAPIEvent` struct so it gets unmarshalled from JSON. This is a field on the outer event as described by https://docs.slack.dev/apis/events-api/#callback-field and I would like to be able to write some logic around this field after calling `slackevents.ParseEvent`.