### PR TITLE
fix: correct typos in comments and debug strings

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -115,7 +115,7 @@ func (api *Client) auditLogsRequest(ctx context.Context, path string, values url
 	return response, response.Err()
 }
 
-// GetAuditLogs retrieves a page of audit entires according to the parameters given
+// GetAuditLogs retrieves a page of audit entries according to the parameters given
 func (api *Client) GetAuditLogs(params AuditLogParameters) (entries []AuditEntry, nextCursor string, err error) {
 	return api.GetAuditLogsContext(context.Background(), params)
 }

--- a/socketmode/socketmode_handler.go
+++ b/socketmode/socketmode_handler.go
@@ -172,7 +172,7 @@ func (r *SocketmodeHandler) RunEventLoopContext(ctx context.Context) error {
 	return r.Client.RunContext(ctx)
 }
 
-// Call the dispatcher for each incomming event
+// Call the dispatcher for each incoming event
 func (r *SocketmodeHandler) runEventLoop(ctx context.Context) {
 	for {
 		select {

--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -412,7 +412,7 @@ func (rtm *RTM) receiveIncomingEvent(events chan json.RawMessage) error {
 		select {
 		case events <- event:
 		case <-rtm.disconnected:
-			rtm.Debugln("disonnected while attempting to send raw event")
+			rtm.Debugln("disconnected while attempting to send raw event")
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixed three typos in code comments and a debug log string:

- `audit.go`: `entires` → `entries` in the `GetAuditLogs` godoc comment
- `websocket_managed_conn.go`: `disonnected` → `disconnected` in an RTM debug log message
- `socketmode/socketmode_handler.go`: `incomming` → `incoming` in a function comment

No logic changes — comments and strings only.