### PR TITLE
feat: Expose full message object from chat.postMessage responses

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -29,11 +29,12 @@ const (
 )
 
 type chatResponseFull struct {
-	Channel            string `json:"channel"`
-	Timestamp          string `json:"ts"`                             // Regular message timestamp
-	MessageTimeStamp   string `json:"message_ts"`                     // Ephemeral message timestamp
-	ScheduledMessageID string `json:"scheduled_message_id,omitempty"` // Scheduled message id
-	Text               string `json:"text"`
+	Channel            string  `json:"channel"`
+	Timestamp          string  `json:"ts"`                             // Regular message timestamp
+	MessageTimeStamp   string  `json:"message_ts"`                     // Ephemeral message timestamp
+	ScheduledMessageID string  `json:"scheduled_message_id,omitempty"` // Scheduled message id
+	Text               string  `json:"text"`
+	Message            Message `json:"message"` // Full message object, as returned by chat.postMessage and chat.update
 	SlackResponse
 }
 
@@ -148,6 +149,33 @@ func (api *Client) PostMessageContext(ctx context.Context, channelID string, opt
 	return respChannel, respTimestamp, err
 }
 
+// PostMessageWithResponse sends a message to a channel and returns the full
+// message object from the Slack API response.
+// For more details, see PostMessageWithResponseContext documentation.
+func (api *Client) PostMessageWithResponse(channelID string, options ...MsgOption) (string, string, Message, error) {
+	return api.PostMessageWithResponseContext(context.Background(), channelID, options...)
+}
+
+// PostMessageWithResponseContext sends a message to a channel with a custom
+// context and returns the full message object from the Slack API response.
+// Unlike PostMessageContext, it exposes fields that are only available in the
+// response's message object, such as Message.ThreadTimestamp, which can be
+// used to detect that a threaded reply was posted un-threaded because its
+// parent message was deleted.
+// Slack API docs: https://api.slack.com/methods/chat.postMessage
+func (api *Client) PostMessageWithResponseContext(ctx context.Context, channelID string, options ...MsgOption) (string, string, Message, error) {
+	response, err := api.sendResponseFull(
+		ctx,
+		channelID,
+		MsgOptionPost(),
+		MsgOptionCompose(options...),
+	)
+	if response == nil {
+		return "", "", Message{}, err
+	}
+	return response.Channel, response.getMessageTimestamp(), response.Message, err
+}
+
 // PostEphemeral sends an ephemeral message to a user in a channel.
 // Message is escaped by default according to https://api.slack.com/docs/formatting
 // Use http://davestevens.github.io/slack-message-builder/ to help crafting your message.
@@ -245,34 +273,47 @@ func (api *Client) SendMessage(channel string, options ...MsgOption) (string, st
 // SendMessageContext more flexible method for configuring messages with a custom context.
 // Slack API docs: https://api.slack.com/methods/chat.postMessage
 func (api *Client) SendMessageContext(ctx context.Context, channelID string, options ...MsgOption) (_channel string, _timestampOrScheduledMessageID string, _text string, err error) {
+	response, err := api.sendResponseFull(ctx, channelID, options...)
+	if response == nil {
+		return "", "", "", err
+	}
+
+	if response.ScheduledMessageID != "" {
+		return response.Channel, response.ScheduledMessageID, response.Text, err
+	} else {
+		return response.Channel, response.getMessageTimestamp(), response.Text, err
+	}
+}
+
+// sendResponseFull sends a message and returns the full response.
+// It returns a nil response if the request could not be built or sent;
+// otherwise the returned error is the response's error, if any.
+func (api *Client) sendResponseFull(ctx context.Context, channelID string, options ...MsgOption) (*chatResponseFull, error) {
 	var (
 		req      *http.Request
 		parser   func(*chatResponseFull) responseParser
 		response chatResponseFull
+		err      error
 	)
 
 	if req, parser, err = buildSender(api.endpoint, options...).BuildRequestContext(ctx, api.token, channelID); err != nil {
-		return "", "", "", err
+		return nil, err
 	}
 
 	if api.Debug() {
 		reqBody, err := io.ReadAll(req.Body)
 		if err != nil {
-			return "", "", "", err
+			return nil, err
 		}
 		req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
 		api.Debugf("Sending request: %s", redactToken(reqBody))
 	}
 
 	if _, err = doPost(api.httpclient, req, parser(&response), api); err != nil {
-		return "", "", "", err
+		return nil, err
 	}
 
-	if response.ScheduledMessageID != "" {
-		return response.Channel, response.ScheduledMessageID, response.Text, response.Err()
-	} else {
-		return response.Channel, response.getMessageTimestamp(), response.Text, response.Err()
-	}
+	return &response, response.Err()
 }
 
 func redactToken(b []byte) []byte {

--- a/chat_test.go
+++ b/chat_test.go
@@ -37,6 +37,46 @@ func TestPostMessageInvalidChannel(t *testing.T) {
 	}
 }
 
+func TestPostMessageWithResponse(t *testing.T) {
+	http.DefaultServeMux = new(http.ServeMux)
+	http.HandleFunc("/chat.postMessage", func(rw http.ResponseWriter, r *http.Request) {
+		rw.Header().Set("Content-Type", "application/json")
+		rw.Write([]byte(`{
+			"ok": true,
+			"channel": "CXXX",
+			"ts": "1503435956.000247",
+			"message": {
+				"text": "hello",
+				"ts": "1503435956.000247",
+				"thread_ts": "1503435950.000000"
+			}
+		}`))
+	})
+	once.Do(startServer)
+	api := New("testing-token", OptionAPIURL("http://"+serverAddr+"/"))
+
+	channel, timestamp, message, err := api.PostMessageWithResponse("CXXX", MsgOptionText("hello", false))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+		return
+	}
+	if got, want := channel, "CXXX"; got != want {
+		t.Errorf("unexpected channel: got %s, want %s", got, want)
+	}
+	if got, want := timestamp, "1503435956.000247"; got != want {
+		t.Errorf("unexpected timestamp: got %s, want %s", got, want)
+	}
+	if got, want := message.Text, "hello"; got != want {
+		t.Errorf("unexpected message text: got %s, want %s", got, want)
+	}
+	if got, want := message.Timestamp, "1503435956.000247"; got != want {
+		t.Errorf("unexpected message timestamp: got %s, want %s", got, want)
+	}
+	if got, want := message.ThreadTimestamp, "1503435950.000000"; got != want {
+		t.Errorf("unexpected message thread timestamp: got %s, want %s", got, want)
+	}
+}
+
 func TestGetPermalink(t *testing.T) {
 	channel := "C1H9RESGA"
 	timeStamp := "p135854651500008"


### PR DESCRIPTION
Fixes #1571

##### Summary

`chat.postMessage` responses include a full `message` object, but the library dropped it during deserialization: `chatResponseFull` only captured `channel`, `ts`, `message_ts`, `scheduled_message_id`, and `text`. This made `message.thread_ts` inaccessible — which is the only way to detect that a threaded reply was silently posted as a top-level message because its parent was deleted between receipt and posting. The current workaround requires `UnsafeApplyMsgOptions` and a hand-rolled HTTP post.

##### Changes

- Add a `Message Message `json:"message"`` field to `chatResponseFull` so the response's message object is no longer discarded.
- Add `PostMessageWithResponse` / `PostMessageWithResponseContext`, which return the full `Message` alongside the existing channel/timestamp return values (API shape as proposed in #1571).
- Refactor `SendMessageContext` into a thin wrapper over a new private `sendResponseFull` helper; existing behavior and signatures are unchanged.
- Add `TestPostMessageWithResponse` covering the happy path, asserting `Message.Text`, `Message.Timestamp`, and `Message.ThreadTimestamp` are populated from the response.

The change is purely additive — no existing exported signatures were modified.

##### PR preparation

Ran `make pr-prep`: gofmt clean, `go vet` clean, full test suite (including `-race`) passes.