### PR TITLE
feat: add support for the container block

### DIFF
--- a/block.go
+++ b/block.go
@@ -26,6 +26,7 @@ const (
 	MBTAlert             MessageBlockType = "alert"
 	MBTCard              MessageBlockType = "card"
 	MBTCarousel          MessageBlockType = "carousel"
+	MBTContainer         MessageBlockType = "container"
 )
 
 // Block defines an interface all block types should implement

--- a/block_container.go
+++ b/block_container.go
@@ -1,0 +1,182 @@
+package slack
+
+import "fmt"
+
+// ContainerWidth controls the rendered width of a ContainerBlock. When unset,
+// Slack defaults to ContainerWidthStandard.
+type ContainerWidth string
+
+const (
+	ContainerWidthNarrow   ContainerWidth = "narrow"
+	ContainerWidthStandard ContainerWidth = "standard"
+	ContainerWidthWide     ContainerWidth = "wide"
+	ContainerWidthFull     ContainerWidth = "full"
+)
+
+// containerMaxChildBlocks is the maximum number of child blocks Slack permits
+// inside a container block.
+const containerMaxChildBlocks = 10
+
+// ContainerBlock groups a set of child blocks so they render together as a
+// single, optionally collapsible, unit with a title, subtitle, and icon.
+//
+// More Information: https://docs.slack.dev/reference/block-kit/blocks/container-block/
+type ContainerBlock struct {
+	Type    MessageBlockType `json:"type"`
+	BlockID string           `json:"block_id,omitempty"`
+	// Title is the container heading rendered as a plain_text object. One of
+	// Title or RichTextTitle is required; RichTextTitle takes precedence when
+	// both are set. Slack requires a maximum of 150 characters.
+	Title *TextBlockObject `json:"title,omitempty"`
+	// RichTextTitle is the container heading rendered as a rich_text block. It
+	// takes precedence over Title when both are set.
+	RichTextTitle *RichTextBlock `json:"rich_text_title,omitempty"`
+	// Subtitle is descriptive text below the title, rendered as a plain_text or
+	// mrkdwn object. Slack requires a maximum of 150 characters.
+	Subtitle *TextBlockObject `json:"subtitle,omitempty"`
+	// Icon is a small image displayed beside the title and subtitle.
+	Icon *ImageBlockElement `json:"icon,omitempty"`
+	// Width controls the container width. Slack defaults to standard when unset.
+	Width ContainerWidth `json:"width,omitempty"`
+	// IsCollapsible enables the container's collapse control.
+	IsCollapsible bool `json:"is_collapsible,omitempty"`
+	// DefaultCollapsed starts the container collapsed. It only applies when
+	// IsCollapsible is true.
+	DefaultCollapsed bool `json:"default_collapsed,omitempty"`
+	// HasHeaderDivider draws a border below the header. Slack only supports it on
+	// non-collapsible containers.
+	HasHeaderDivider bool `json:"has_header_divider,omitempty"`
+	// ChildBlocks are the blocks rendered inside the container. Slack requires 1
+	// to 10 blocks: actions, context, divider, file, header, image, input,
+	// rich_text, section, table, and video blocks are supported.
+	ChildBlocks Blocks `json:"child_blocks"`
+}
+
+// BlockType returns the type of the block.
+func (s ContainerBlock) BlockType() MessageBlockType {
+	return s.Type
+}
+
+// ID returns the ID of the block.
+func (s ContainerBlock) ID() string {
+	return s.BlockID
+}
+
+// Validate checks whether the block satisfies Slack's documented container
+// constraints.
+func (s ContainerBlock) Validate() error {
+	if s.Type != MBTContainer {
+		return fmt.Errorf("type must be %q", MBTContainer)
+	}
+	if s.Title == nil && s.RichTextTitle == nil {
+		return fmt.Errorf("one of title or rich_text_title is required")
+	}
+	if s.Title != nil {
+		if s.Title.Type != PlainTextType {
+			return fmt.Errorf("title must be a plain_text object")
+		}
+		if runeLen(s.Title.Text) > 150 {
+			return fmt.Errorf("title cannot be longer than 150 characters")
+		}
+	}
+	if s.Subtitle != nil {
+		if s.Subtitle.Type != PlainTextType && s.Subtitle.Type != MarkdownType {
+			return fmt.Errorf("subtitle must be a plain_text or mrkdwn object")
+		}
+		if runeLen(s.Subtitle.Text) > 150 {
+			return fmt.Errorf("subtitle cannot be longer than 150 characters")
+		}
+	}
+	switch s.Width {
+	case "", ContainerWidthNarrow, ContainerWidthStandard, ContainerWidthWide, ContainerWidthFull:
+	default:
+		return fmt.Errorf("width must be one of narrow, standard, wide, or full")
+	}
+	if s.Icon != nil {
+		if runeLen(s.Icon.AltText) > 2000 {
+			return fmt.Errorf("icon alt_text cannot be longer than 2000 characters")
+		}
+		if s.Icon.ImageURL != nil && runeLen(*s.Icon.ImageURL) > 3000 {
+			return fmt.Errorf("icon image_url cannot be longer than 3000 characters")
+		}
+	}
+	if s.HasHeaderDivider && s.IsCollapsible {
+		return fmt.Errorf("has_header_divider is only supported on non-collapsible containers")
+	}
+	if s.DefaultCollapsed && !s.IsCollapsible {
+		return fmt.Errorf("default_collapsed requires is_collapsible to be true")
+	}
+	if n := len(s.ChildBlocks.BlockSet); n < 1 {
+		return fmt.Errorf("child_blocks must have at least 1 block")
+	} else if n > containerMaxChildBlocks {
+		return fmt.Errorf("child_blocks cannot have more than %d blocks", containerMaxChildBlocks)
+	}
+	return nil
+}
+
+// NewContainerBlock returns a new container block wrapping the given child
+// blocks. Use the With* methods to set the title, subtitle, and other optional
+// fields.
+func NewContainerBlock(childBlocks ...Block) *ContainerBlock {
+	return &ContainerBlock{
+		Type:        MBTContainer,
+		ChildBlocks: Blocks{BlockSet: childBlocks},
+	}
+}
+
+// WithBlockID sets the block ID for the ContainerBlock.
+func (s *ContainerBlock) WithBlockID(blockID string) *ContainerBlock {
+	s.BlockID = blockID
+	return s
+}
+
+// WithTitle sets the plain_text title for the ContainerBlock.
+func (s *ContainerBlock) WithTitle(title *TextBlockObject) *ContainerBlock {
+	s.Title = title
+	return s
+}
+
+// WithRichTextTitle sets the rich_text title for the ContainerBlock. It takes
+// precedence over a plain_text title set with WithTitle.
+func (s *ContainerBlock) WithRichTextTitle(title *RichTextBlock) *ContainerBlock {
+	s.RichTextTitle = title
+	return s
+}
+
+// WithSubtitle sets the subtitle for the ContainerBlock.
+func (s *ContainerBlock) WithSubtitle(subtitle *TextBlockObject) *ContainerBlock {
+	s.Subtitle = subtitle
+	return s
+}
+
+// WithIcon sets the icon displayed beside the title for the ContainerBlock.
+func (s *ContainerBlock) WithIcon(icon *ImageBlockElement) *ContainerBlock {
+	s.Icon = icon
+	return s
+}
+
+// WithWidth sets the rendered width of the ContainerBlock.
+func (s *ContainerBlock) WithWidth(width ContainerWidth) *ContainerBlock {
+	s.Width = width
+	return s
+}
+
+// WithCollapsible marks the ContainerBlock collapsible and controls whether it
+// starts collapsed.
+func (s *ContainerBlock) WithCollapsible(collapsible, defaultCollapsed bool) *ContainerBlock {
+	s.IsCollapsible = collapsible
+	s.DefaultCollapsed = defaultCollapsed
+	return s
+}
+
+// WithHeaderDivider draws a border below the container header.
+func (s *ContainerBlock) WithHeaderDivider(hasHeaderDivider bool) *ContainerBlock {
+	s.HasHeaderDivider = hasHeaderDivider
+	return s
+}
+
+// AddChildBlock appends a block to the container's child blocks.
+func (s *ContainerBlock) AddChildBlock(block Block) *ContainerBlock {
+	s.ChildBlocks.BlockSet = append(s.ChildBlocks.BlockSet, block)
+	return s
+}

--- a/block_container_test.go
+++ b/block_container_test.go
@@ -1,0 +1,143 @@
+package slack
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewContainerBlock(t *testing.T) {
+	section := NewSectionBlock(NewTextBlockObject("mrkdwn", "Content", false, false), nil, nil)
+	divider := NewDividerBlock()
+
+	block := NewContainerBlock(section).
+		WithBlockID("container-1").
+		WithTitle(NewTextBlockObject(PlainTextType, "Title", false, false)).
+		WithSubtitle(NewTextBlockObject(MarkdownType, "Subtitle", false, false)).
+		WithIcon(NewImageBlockElement("https://example.com/icon.png", "icon")).
+		WithWidth(ContainerWidthWide).
+		WithCollapsible(true, true)
+
+	assert.Equal(t, MBTContainer, block.BlockType())
+	assert.Equal(t, "container", string(block.Type))
+	assert.Equal(t, "container-1", block.ID())
+	assert.Equal(t, ContainerWidthWide, block.Width)
+	assert.True(t, block.IsCollapsible)
+	assert.True(t, block.DefaultCollapsed)
+	require.Len(t, block.ChildBlocks.BlockSet, 1)
+	assert.Equal(t, section, block.ChildBlocks.BlockSet[0])
+
+	block.AddChildBlock(divider)
+	require.Len(t, block.ChildBlocks.BlockSet, 2)
+	assert.Equal(t, divider, block.ChildBlocks.BlockSet[1])
+
+	assert.NoError(t, block.Validate())
+}
+
+func TestContainerBlockValidate(t *testing.T) {
+	child := NewSectionBlock(NewTextBlockObject("mrkdwn", "Content", false, false), nil, nil)
+	plainTitle := NewTextBlockObject(PlainTextType, "Title", false, false)
+
+	tests := []struct {
+		name    string
+		block   *ContainerBlock
+		wantErr bool
+	}{
+		{
+			name:  "valid",
+			block: NewContainerBlock(child).WithTitle(plainTitle),
+		},
+		{
+			name:  "valid with rich_text_title",
+			block: NewContainerBlock(child).WithRichTextTitle(NewRichTextBlock("rtt")),
+		},
+		{
+			name:    "missing title",
+			block:   NewContainerBlock(child),
+			wantErr: true,
+		},
+		{
+			name:    "non plain_text title",
+			block:   NewContainerBlock(child).WithTitle(NewTextBlockObject(MarkdownType, "Title", false, false)),
+			wantErr: true,
+		},
+		{
+			name:    "no child blocks",
+			block:   NewContainerBlock().WithTitle(plainTitle),
+			wantErr: true,
+		},
+		{
+			name: "too many child blocks",
+			block: NewContainerBlock(
+				child, child, child, child, child, child, child, child, child, child, child,
+			).WithTitle(plainTitle),
+			wantErr: true,
+		},
+		{
+			name:    "invalid width",
+			block:   NewContainerBlock(child).WithTitle(plainTitle).WithWidth("gigantic"),
+			wantErr: true,
+		},
+		{
+			name:    "header divider on collapsible",
+			block:   NewContainerBlock(child).WithTitle(plainTitle).WithCollapsible(true, false).WithHeaderDivider(true),
+			wantErr: true,
+		},
+		{
+			name:    "default collapsed without collapsible",
+			block:   &ContainerBlock{Type: MBTContainer, Title: plainTitle, DefaultCollapsed: true, ChildBlocks: Blocks{BlockSet: []Block{child}}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.block.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestContainerBlockJSONRoundTrip(t *testing.T) {
+	payload := `{
+		"type": "container",
+		"block_id": "container-1",
+		"title": {"type": "plain_text", "text": "Deploy status"},
+		"subtitle": {"type": "mrkdwn", "text": "*production*"},
+		"icon": {"type": "image", "image_url": "https://example.com/icon.png", "alt_text": "icon"},
+		"width": "wide",
+		"is_collapsible": true,
+		"default_collapsed": true,
+		"child_blocks": [
+			{"type": "section", "text": {"type": "mrkdwn", "text": "All systems go"}},
+			{"type": "divider"}
+		]
+	}`
+
+	var block ContainerBlock
+	require.NoError(t, json.Unmarshal([]byte(payload), &block))
+
+	assert.Equal(t, MBTContainer, block.BlockType())
+	assert.Equal(t, "container-1", block.ID())
+	assert.Equal(t, ContainerWidthWide, block.Width)
+	assert.True(t, block.IsCollapsible)
+	require.NotNil(t, block.Title)
+	assert.Equal(t, "Deploy status", block.Title.Text)
+	require.Len(t, block.ChildBlocks.BlockSet, 2)
+	assert.Equal(t, MBTSection, block.ChildBlocks.BlockSet[0].BlockType())
+	assert.Equal(t, MBTDivider, block.ChildBlocks.BlockSet[1].BlockType())
+
+	marshalled, err := json.Marshal(block)
+	require.NoError(t, err)
+
+	var want, got any
+	require.NoError(t, json.Unmarshal([]byte(payload), &want))
+	require.NoError(t, json.Unmarshal(marshalled, &got))
+	assert.Equal(t, want, got)
+}

--- a/block_conv.go
+++ b/block_conv.go
@@ -93,6 +93,8 @@ func (b *Blocks) UnmarshalJSON(data []byte) error {
 			block = &CardBlock{}
 		case "carousel":
 			block = &CarouselBlock{}
+		case "container":
+			block = &ContainerBlock{}
 		default:
 			b := &UnknownBlock{raw: r}
 			if err = json.Unmarshal(r, b); err != nil {

--- a/block_roundtrip_test.go
+++ b/block_roundtrip_test.go
@@ -60,6 +60,25 @@ func TestBlockRealPayloadRoundTrip(t *testing.T) {
 			}`,
 		},
 		{
+			// A collapsible container wrapping a section and a divider, with a
+			// plain_text title, mrkdwn subtitle, and an icon.
+			name: "container with title, subtitle, icon and child blocks",
+			payload: `{
+				"type": "container",
+				"block_id": "container-1",
+				"title": {"type": "plain_text", "text": "Deploy status"},
+				"subtitle": {"type": "mrkdwn", "text": "*production*"},
+				"icon": {"type": "image", "image_url": "https://example.com/icon.png", "alt_text": "icon"},
+				"width": "wide",
+				"is_collapsible": true,
+				"default_collapsed": true,
+				"child_blocks": [
+					{"type": "section", "text": {"type": "mrkdwn", "text": "All systems go"}},
+					{"type": "divider"}
+				]
+			}`,
+		},
+		{
 			name: "data_table with raw_text, raw_number and rich_text cells",
 			payload: `{
 				"type": "data_table",


### PR DESCRIPTION
Add ContainerBlock, modelling Slack's container block type introduced on 2026-06-29, which groups child blocks into a single, optionally collapsible unit with a title, subtitle, icon, and width.

- Register MBTContainer and dispatch "container" in Blocks.UnmarshalJSON so inbound payloads decode to the concrete type.
- Reuse the existing Blocks type for child_blocks, so nested blocks marshal and round-trip through the same polymorphic path as top-level blocks.
- Add a NewContainerBlock constructor with fluent With* builders and a Validate method covering Slack's documented constraints.
- Add constructor, validation, and JSON round-trip tests, plus a container case in the real-payload round-trip guardrail.

Slack API docs: https://docs.slack.dev/reference/block-kit/blocks/container-block/

##### Pull Request Guidelines

These are recommendations for pull requests.
They are strictly guidelines to help manage expectations.

##### PR preparation
Run `make pr-prep` from the root of the repository to run formatting, linting and tests.

##### Should this be an issue instead
- [ ] is it a convenience method? (no new functionality, streamlines some use case)
- [ ] exposes a previously private type, const, method, etc.
- [ ] is it application specific (caching, retry logic, rate limiting, etc)
- [ ] is it performance related.

##### API changes

Since API changes have to be maintained they undergo a more detailed review and are more likely to require changes.

- no tests, if you're adding to the API include at least a single test of the happy case.
- If you can accomplish your goal without changing the API, then do so.
- dependency changes. updates are okay. adding/removing need justification.

###### Examples of API changes that do not meet guidelines:
- in library cache for users. caches are use case specific.
- Convenience methods for Sending Messages, update, post, ephemeral, etc. consider opening an issue instead.
