### PR TITLE
fix: parse top-level action tokens

### DIFF
--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -76,6 +76,8 @@ type AppMentionEvent struct {
 
 	// AssistantThread contains action token for Data Access API queries when app is mentioned
 	AssistantThread *AssistantThreadActionToken `json:"assistant_thread,omitempty"`
+	// ActionToken contains the top-level action token for Data Access API queries.
+	ActionToken string `json:"action_token,omitempty"`
 }
 
 // AppHomeOpenedEvent Your Slack app home was opened.
@@ -340,6 +342,8 @@ type MessageEvent struct {
 
 	// AssistantThread contains action token for Data Access API queries in message events
 	AssistantThread *AssistantThreadActionToken `json:"assistant_thread,omitempty"`
+	// ActionToken contains the top-level action token for Data Access API queries.
+	ActionToken string `json:"action_token,omitempty"`
 
 	// Huddle-related fields (subtype "huddle_thread")
 	Room            *slack.HuddleRoom `json:"room,omitempty"`

--- a/slackevents/inner_events_test.go
+++ b/slackevents/inner_events_test.go
@@ -115,6 +115,28 @@ func TestAppMentionWithAssistantThread(t *testing.T) {
 	}
 }
 
+func TestAppMentionWithActionToken(t *testing.T) {
+	rawE := []byte(`
+			{
+				"type": "app_mention",
+				"user": "U061F7AUR",
+				"text": "<@U0LAN0Z89> search slack",
+				"ts": "1515449522.000016",
+				"channel": "C0LAN2Q65",
+				"event_ts": "1515449522000016",
+				"action_token": "1234567.top-level"
+			}
+	`)
+	var event AppMentionEvent
+	if err := json.Unmarshal(rawE, &event); err != nil {
+		t.Fatal(err)
+	}
+
+	if event.ActionToken != "1234567.top-level" {
+		t.Errorf("Expected ActionToken to be '1234567.top-level', got %s", event.ActionToken)
+	}
+}
+
 func TestAppMentionWithBlocksFilesAttachments(t *testing.T) {
 	rawE := []byte(`{
 		"type": "app_mention",
@@ -512,6 +534,29 @@ func TestMessageEventWithAssistantThread(t *testing.T) {
 	}
 	if !e.IsIM() {
 		t.Error(fmt.Errorf("expected IsIM true, got false"))
+	}
+}
+
+func TestMessageEventWithActionToken(t *testing.T) {
+	rawE := []byte(`
+		{
+			"type": "message",
+			"channel": "D024BE91L",
+			"user": "U2147483697",
+			"text": "Search slack",
+			"ts": "1355517523.000005",
+			"event_ts": "1355517523.000005",
+			"channel_type": "im",
+			"action_token": "9876543.top-level"
+		}
+	`)
+	var event MessageEvent
+	if err := json.Unmarshal(rawE, &event); err != nil {
+		t.Fatal(err)
+	}
+
+	if event.ActionToken != "9876543.top-level" {
+		t.Errorf("Expected ActionToken to be '9876543.top-level', got %s", event.ActionToken)
 	}
 }
 

--- a/slackevents/parsers_test.go
+++ b/slackevents/parsers_test.go
@@ -255,6 +255,41 @@ func TestParseEventAPIAppMentionWithAssistantThread(t *testing.T) {
 	}
 }
 
+func TestParseEventAPIAppMentionWithActionToken(t *testing.T) {
+	eventsAPIRawCallbackEvent := `
+		{
+			"token": "XXYYZZ",
+			"team_id": "TXXXXXXXX",
+			"api_app_id": "AXXXXXXXXX",
+			"event": {
+				"type": "app_mention",
+				"event_ts": "1234567890.123456",
+				"user": "UXXXXXXX1",
+				"text": "<@U0LAN0Z89> search slack",
+				"ts": "1515449522.000016",
+				"channel": "C0LAN2Q65",
+				"action_token": "1234567.top-level"
+			},
+			"type": "event_callback",
+			"authed_users": [ "UXXXXXXX1" ],
+			"event_id": "Ev08MFMKH6",
+			"event_time": 1234567890
+		}
+	`
+	msg, err := ParseEvent(json.RawMessage(eventsAPIRawCallbackEvent), OptionVerifyToken(&TokenComparator{"XXYYZZ"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	innerEvent, ok := msg.InnerEvent.Data.(*AppMentionEvent)
+	if !ok {
+		t.Fatalf("Expected *AppMentionEvent, got %T", msg.InnerEvent.Data)
+	}
+	if innerEvent.ActionToken != "1234567.top-level" {
+		t.Errorf("Expected ActionToken to be '1234567.top-level', got %s", innerEvent.ActionToken)
+	}
+}
+
 func TestParseEventAPIMessageIMWithAssistantThread(t *testing.T) {
 	eventsAPIRawCallbackEvent := `
 		{
@@ -311,6 +346,42 @@ func TestParseEventAPIMessageIMWithAssistantThread(t *testing.T) {
 			fmt.Println(outerEvent)
 			t.Fail()
 		}
+	}
+}
+
+func TestParseEventAPIMessageIMWithActionToken(t *testing.T) {
+	eventsAPIRawCallbackEvent := `
+		{
+			"token": "XXYYZZ",
+			"team_id": "TXXXXXXXX",
+			"api_app_id": "AXXXXXXXXX",
+			"event": {
+				"type": "message",
+				"channel": "D024BE91L",
+				"user": "U2147483697",
+				"text": "Search slack",
+				"ts": "1355517523.000005",
+				"event_ts": "1355517523.000005",
+				"channel_type": "im",
+				"action_token": "9876543.top-level"
+			},
+			"type": "event_callback",
+			"authed_users": [ "U2147483697" ],
+			"event_id": "Ev08MFMKH7",
+			"event_time": 1234567890
+		}
+	`
+	msg, err := ParseEvent(json.RawMessage(eventsAPIRawCallbackEvent), OptionVerifyToken(&TokenComparator{"XXYYZZ"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	innerEvent, ok := msg.InnerEvent.Data.(*MessageEvent)
+	if !ok {
+		t.Fatalf("Expected *MessageEvent, got %T", msg.InnerEvent.Data)
+	}
+	if innerEvent.ActionToken != "9876543.top-level" {
+		t.Errorf("Expected ActionToken to be '9876543.top-level', got %s", innerEvent.ActionToken)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Parse top-level `action_token` values on `AppMentionEvent` and `MessageEvent`.
- Preserve the existing nested `assistant_thread` representation for backwards compatibility.
- Add direct JSON and full Events API parser regression coverage.

## Root cause

Slack sends the Data Access API action token directly on real `app_mention` and `message` event objects. The typed events only modeled the token inside `assistant_thread`, so standard JSON unmarshalling silently discarded the top-level field and callers received no usable token.

Fixes #1577.