### PR TITLE
GetFile: error on HTML download responses

### DIFF
--- a/files_test.go
+++ b/files_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -80,6 +81,33 @@ func TestSlack_GetFile(t *testing.T) {
 		} else if test.expectError == true && err == nil {
 			log.Fatalf("Expected error but got none")
 		}
+	}
+}
+
+type htmlFileHTTPClient struct{}
+
+func (m *htmlFileHTTPClient) Do(*http.Request) (*http.Response, error) {
+	body := `<html><body>Browser not supported</body></html>`
+	return &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"text/html"}},
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+	}, nil
+}
+
+func TestSlack_GetFileRejectsHTML(t *testing.T) {
+	api := &Client{
+		endpoint:   "http://" + serverAddr + "/",
+		token:      "testing-token",
+		httpclient: &htmlFileHTTPClient{},
+	}
+
+	err := api.GetFile("https://files.slack.com/files-pri/T99999999-FGGGGGGGG/download/test.csv", &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected error for HTML download response")
+	}
+	if !strings.Contains(err.Error(), "HTML instead of file content") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/misc.go
+++ b/misc.go
@@ -306,8 +306,17 @@ func downloadFile(ctx context.Context, client httpClient, token string, download
 		return err
 	}
 
-	_, err = io.Copy(writer, resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
 
+	contentType := strings.ToLower(resp.Header.Get("Content-Type"))
+	if strings.Contains(contentType, "text/html") || bytes.Contains(bytes.ToLower(body), []byte("browser not supported")) {
+		return fmt.Errorf("file download returned HTML instead of file content (check token type and files:read scope); content-type=%q", resp.Header.Get("Content-Type"))
+	}
+
+	_, err = writer.Write(body)
 	return err
 }
 


### PR DESCRIPTION
Detect HTML/Browser-not-supported responses instead of writing them as file bytes. Related to #1284.